### PR TITLE
Fix undo bug

### DIFF
--- a/crates/darkly/presets/defaults.yaml
+++ b/crates/darkly/presets/defaults.yaml
@@ -2,49 +2,42 @@
 #
 #   user override → overlay[active editor] → defaults  (this file)
 #
-# Inclusion rule: a key lives here iff Krita, Photoshop, and GIMP all agree
-# on its value. Any key that differs between any two of the three editors
-# is split into each of the editor YAMLs (krita.yaml / photoshop.yaml /
-# gimp.yaml) — none of those YAMLs may inherit a value from this file when
-# the editor in question would disagree.
+# Hotkeys / mouse_clicks inclusion rule: if all three reference editors
+# (Krita, Photoshop, GIMP) have a binding for an action — whether or not
+# they happen to agree on the key — the binding lives per-editor in
+# krita.yaml / photoshop.yaml / gimp.yaml, NOT here. defaults.yaml only
+# carries:
+#   - Darkly-original actions (no reference-editor prior art), and
+#   - actions where fewer than three reference editors have an opinion
+#     (Darkly picks a sensible default; an overlay may still override).
 #
-# Schema-side defaults that used to live in `config/sections/*.rs` (canvas
-# dimensions, animation rates, theme, …) and TS-side `defaultHotkey` /
-# `defaultMouseClick` registrations are both consolidated here.
+# Settings inclusion rule: Darkly-specific configuration (canvas size,
+# animation rates, theme, …) that has no direct reference-editor analog
+# lives here; settings the editors disagree on (e.g.
+# tools.colorPickerSampleSource) are split into the per-editor overlays.
 
 hotkeys:
-  # Universal edit / clipboard / file / view bindings.
-  undo: $mod+KeyZ
-  redo: $mod+Shift+KeyZ
-  copy: $mod+KeyC
-  cut: $mod+KeyX
-  paste: $mod+KeyV
-  pasteInPlace: $mod+Shift+KeyV
-  saveDocument: $mod+KeyS
-  saveDocumentAs: $mod+Shift+KeyS
-  open: $mod+KeyO
-  exportImage: $mod+Shift+KeyE
-  selectAll: $mod+KeyA
-  clearSelectionContents: Delete
-  commitFloating: Enter
-  cancelFloating: Escape
+  # Photoshop binds Edit > Preferences to $mod+K; Krita/GIMP have no
+  # default. Darkly picks the macOS preferences convention.
   openSettings: $mod+Comma
-  # Tool keys all three editors agree on.
+  # Photoshop & GIMP both have export (Photoshop: $mod+Alt+W for "Export
+  # As"; GIMP: $mod+Shift+E for "Export As…"). Krita's `file_export_file`
+  # is explicitly `none`. Darkly picks GIMP's binding.
+  exportImage: $mod+Shift+KeyE
+  # Photoshop binds Lasso to L and Polygonal Lasso to Shift+L; Krita's
+  # selection-tool .action files have empty <shortcut>; GIMP's analog is
+  # "Free Select" (KeyF) with no polygonal counterpart. Darkly inherits
+  # Photoshop's choice; per-editor overlays can override.
   lassoSelectTool: KeyL
   polygonSelectTool: Shift+KeyL
-  # Colors — D resets, X swaps in every editor we ship.
-  resetColors: KeyD
-  swapColors: KeyX
-  # Brush parameter hotkeys — Darkly inherits Krita/Photoshop/GIMP's `[` / `]`
-  # convention for sizing.
-  brushSizeUp: BracketRight
-  brushSizeDown: BracketLeft
-  # Darkly-original actions (no editor has prior-art opinion).
-  addBrushNode: Shift+KeyA
+  # Krita binds View > Mirror View to M; Photoshop/GIMP have no default.
   mirrorViewH: KeyM
+  # Darkly-original (brush builder).
+  addBrushNode: Shift+KeyA
 
 mouse_clicks:
-  # Alt+click on a layer or mask thumbnail isolates that node.
+  # Photoshop and Krita both use Alt+click on a layer/mask thumbnail to
+  # isolate; GIMP has no direct equivalent.
   isolateLayer:
     - layerThumb:alt+click
     - maskThumb:alt+click

--- a/crates/darkly/presets/gimp.yaml
+++ b/crates/darkly/presets/gimp.yaml
@@ -1,9 +1,33 @@
-# GIMP overlay. Self-contained: every binding that any of the three editors
-# disagrees on is spelled out here.
+# GIMP overlay. Self-contained: every binding that any of the three
+# reference editors has an opinion on is spelled out here explicitly.
 name: GIMP
 description: GIMP-style keybindings
 
 hotkeys:
+  # Edit / clipboard / file.
+  undo: $mod+KeyZ
+  # GIMP binds Redo to <primary>Y; <primary><shift>Z is "Strong Undo".
+  # See gimp/app/actions/edit-actions.c.
+  redo: $mod+KeyY
+  copy: $mod+KeyC
+  cut: $mod+KeyX
+  paste: $mod+KeyV
+  # GIMP's edit-paste-in-place is <primary><alt>V (NOT <shift>V).
+  # See gimp/app/actions/edit-actions.c.
+  pasteInPlace: $mod+Alt+KeyV
+  saveDocument: $mod+KeyS
+  saveDocumentAs: $mod+Shift+KeyS
+  open: $mod+KeyO
+  selectAll: $mod+KeyA
+  clearSelectionContents: Delete
+  commitFloating: Enter
+  cancelFloating: Escape
+  # Colors.
+  resetColors: KeyD
+  swapColors: KeyX
+  # Brush size.
+  brushSizeUp: BracketRight
+  brushSizeDown: BracketLeft
   # Tools.
   brushTool: KeyP
   fillTool: Shift+KeyB

--- a/crates/darkly/presets/krita.yaml
+++ b/crates/darkly/presets/krita.yaml
@@ -1,11 +1,31 @@
 # Krita overlay. Self-contained: every binding that any of the three editors
-# (Krita / Photoshop / GIMP) disagrees on is spelled out here explicitly —
-# nothing about Krita is silently inherited from defaults.yaml when GIMP or
-# Photoshop has its own opinion.
+# (Krita / Photoshop / GIMP) has an opinion on is spelled out here explicitly
+# — nothing about Krita is silently inherited from defaults.yaml when any of
+# the three reference editors would have a binding for the action.
 name: Krita
 description: Krita-style keybindings
 
 hotkeys:
+  # Edit / clipboard / file.
+  undo: $mod+KeyZ
+  redo: $mod+Shift+KeyZ
+  copy: $mod+KeyC
+  cut: $mod+KeyX
+  paste: $mod+KeyV
+  pasteInPlace: $mod+Shift+KeyV
+  saveDocument: $mod+KeyS
+  saveDocumentAs: $mod+Shift+KeyS
+  open: $mod+KeyO
+  selectAll: $mod+KeyA
+  clearSelectionContents: Delete
+  commitFloating: Enter
+  cancelFloating: Escape
+  # Colors.
+  resetColors: KeyD
+  swapColors: KeyX
+  # Brush size.
+  brushSizeUp: BracketRight
+  brushSizeDown: BracketLeft
   # Tools.
   brushTool: KeyB
   fillTool: KeyF

--- a/crates/darkly/presets/photoshop.yaml
+++ b/crates/darkly/presets/photoshop.yaml
@@ -1,9 +1,29 @@
 # Photoshop overlay. Self-contained: every binding that any of the three
-# editors disagrees on is spelled out here.
+# reference editors has an opinion on is spelled out here explicitly.
 name: Photoshop
 description: Adobe Photoshop-style keybindings
 
 hotkeys:
+  # Edit / clipboard / file.
+  undo: $mod+KeyZ
+  redo: $mod+Shift+KeyZ
+  copy: $mod+KeyC
+  cut: $mod+KeyX
+  paste: $mod+KeyV
+  pasteInPlace: $mod+Shift+KeyV
+  saveDocument: $mod+KeyS
+  saveDocumentAs: $mod+Shift+KeyS
+  open: $mod+KeyO
+  selectAll: $mod+KeyA
+  clearSelectionContents: Delete
+  commitFloating: Enter
+  cancelFloating: Escape
+  # Colors.
+  resetColors: KeyD
+  swapColors: KeyX
+  # Brush size.
+  brushSizeUp: BracketRight
+  brushSizeDown: BracketLeft
   # Tools.
   brushTool: KeyB
   fillTool: KeyG

--- a/crates/darkly/src/config/mod.rs
+++ b/crates/darkly/src/config/mod.rs
@@ -353,23 +353,25 @@ mod tests {
         assert_eq!(get_i64("canvas.width"), 1920);
         assert_eq!(get_str("hotkeys.nav.trigger"), "Space");
         assert!(!get_bool("input.fingerPainting"));
-        // Universal hotkey defined in defaults.yaml.
-        assert_eq!(get_str("hotkeys.undo"), "$mod+KeyZ");
+        // Darkly-original hotkey defined in defaults.yaml (no reference-editor
+        // prior art, so it stays in the agnostic baseline).
+        assert_eq!(get_str("hotkeys.addBrushNode"), "Shift+KeyA");
     }
 
     #[test]
     fn overlay_resolves_above_defaults() {
         reset_state();
         pick("Krita");
-        // Krita-specific override.
+        // Krita-specific override (defined only in krita.yaml).
         assert_eq!(get_str("hotkeys.brushTool"), "KeyB");
-        // Defaults still show through where the overlay is silent.
-        assert_eq!(get_str("hotkeys.undo"), "$mod+KeyZ");
+        // Defaults still show through where the overlay is silent —
+        // addBrushNode is Darkly-original and no overlay defines it.
+        assert_eq!(get_str("hotkeys.addBrushNode"), "Shift+KeyA");
 
         // Switching to Photoshop swaps the overlay live.
         pick("Photoshop");
         assert_eq!(get_str("hotkeys.rectSelectTool"), "KeyM");
-        assert_eq!(get_str("hotkeys.undo"), "$mod+KeyZ");
+        assert_eq!(get_str("hotkeys.addBrushNode"), "Shift+KeyA");
     }
 
     #[test]

--- a/crates/darkly/src/engine/layers.rs
+++ b/crates/darkly/src/engine/layers.rs
@@ -219,13 +219,18 @@ impl DarklyEngine {
         let parent = self.doc.parent_of(layer_id);
         let pos = self.doc.position_in_parent(layer_id).unwrap_or(0);
 
+        // Collect tombstones before detaching — `detach_for_undo` severs
+        // the parent links `collect_pixel_node_ids` walks to enumerate the
+        // subtree.
+        let tombstones = self.collect_pixel_node_ids(layer_id);
+
         if self.doc.detach_for_undo(layer_id).is_some() {
-            // Drop per-layer GPU state to avoid leaking textures across
-            // delete-then-add cycles. The orphaned node in the slotmap
-            // keeps the layer's metadata for undo; pixel data does not
-            // survive (see Compositor::dispose_layer).
-            self.compositor.dispose_layer(layer_id);
-            self.push_undo(Box::new(LayerRemoveAction::new(layer_id, parent, pos)));
+            // GPU textures stay alive in the compositor's pool until the
+            // owning undo entry is evicted (LayerRemoveAction::on_evict),
+            // so an undo of the removal restores the pixels intact.
+            self.push_undo(Box::new(LayerRemoveAction::new(
+                layer_id, parent, pos, tombstones,
+            )));
         }
 
         self.compositor.mark_dirty();

--- a/crates/darkly/src/engine/mod.rs
+++ b/crates/darkly/src/engine/mod.rs
@@ -657,6 +657,14 @@ impl DarklyEngine {
         self.compositor.test_node_texture_count()
     }
 
+    /// Force-drain both undo stacks and run `on_evict` on every entry,
+    /// releasing any tombstoned GPU textures the actions own. Test-only
+    /// hook for leak-cycle assertions that need to observe the post-
+    /// eviction texture count without rebuilding the engine.
+    pub fn test_drain_undo_for_teardown(&mut self) {
+        self.drain_undo_for_teardown();
+    }
+
     /// Blocking readback of a node's GPU texture (raster layer or mask
     /// modifier). For test assertions only. Format and extent come from the
     /// texture's own metadata — callers don't need to know whether the id

--- a/crates/darkly/src/engine/undo_dispatch.rs
+++ b/crates/darkly/src/engine/undo_dispatch.rs
@@ -39,7 +39,6 @@ impl DarklyEngine {
     /// Drain both stacks and run `on_evict` on everything. For document
     /// close / engine teardown so tombstoned textures don't outlive their
     /// owning engine.
-    #[allow(dead_code)] // Wired in once doc-close plumbing lands.
     pub(crate) fn drain_undo_for_teardown(&mut self) {
         let actions = self.undo_stack.drain_all();
         for mut a in actions {

--- a/crates/darkly/src/undo/layer.rs
+++ b/crates/darkly/src/undo/layer.rs
@@ -1,3 +1,4 @@
+use super::tombstones::Tombstones;
 use super::UndoAction;
 use crate::document::Document;
 use crate::gpu::compositor::Compositor;
@@ -41,19 +42,37 @@ impl UndoAction for LayerAddAction {
 ///
 /// The node stays in the document's slotmap as an orphan between detach
 /// and reattach — the id (and all attached modifiers/descendants) survives
-/// across undo/redo with no copy. Undo relinks it; redo unlinks again.
+/// across undo/redo with no copy. The subtree's GPU textures are
+/// tombstoned so the pixels survive too; they're disposed only when this
+/// action is evicted from the undo stack while the deletion is still in
+/// effect (i.e. the user never undid it). Undo relinks the node; redo
+/// unlinks again.
 pub struct LayerRemoveAction {
     layer_id: LayerId,
     parent: Option<LayerId>,
     position: usize,
+    /// Pixel-bearing node ids inside the removed subtree. Detached on the
+    /// applied side; disposed by [`UndoAction::on_evict`] only when the
+    /// action is evicted while still applied.
+    tombstones: Tombstones,
+    /// True after construction / `redo`, false after `undo`. Tracks
+    /// whether the removed subtree is currently detached from the tree.
+    applied: bool,
 }
 
 impl LayerRemoveAction {
-    pub fn new(layer_id: LayerId, parent: Option<LayerId>, position: usize) -> Self {
+    pub fn new(
+        layer_id: LayerId,
+        parent: Option<LayerId>,
+        position: usize,
+        tombstones: Vec<LayerId>,
+    ) -> Self {
         LayerRemoveAction {
             layer_id,
             parent,
             position,
+            tombstones: Tombstones::new(tombstones, /* detached_when_applied: */ true),
+            applied: true,
         }
     }
 }
@@ -61,12 +80,19 @@ impl LayerRemoveAction {
 impl UndoAction for LayerRemoveAction {
     fn undo(&mut self, doc: &mut Document) -> HashMap<LayerId, HashSet<(i32, i32)>> {
         doc.reinsert_node(self.layer_id, self.parent, self.position);
+        self.applied = false;
         HashMap::new()
     }
 
     fn redo(&mut self, doc: &mut Document) -> HashMap<LayerId, HashSet<(i32, i32)>> {
         doc.detach_for_undo(self.layer_id);
+        self.applied = true;
         HashMap::new()
+    }
+
+    fn on_evict(&mut self, compositor: &mut Compositor) {
+        self.tombstones
+            .dispose_if_detached(self.applied, compositor);
     }
 }
 
@@ -129,9 +155,9 @@ pub struct DuplicateAction {
     parent: Option<LayerId>,
     position: usize,
     /// Every pixel-bearing node id (raster + mask) inside the duplicated
-    /// subtree. Used by [`UndoAction::on_evict`] to dispose GPU textures
-    /// only when the dup is in the detached (undone) state.
-    tombstones: Vec<LayerId>,
+    /// subtree. Disposed by [`UndoAction::on_evict`] only when the dup is
+    /// in the detached (undone) state.
+    tombstones: Tombstones,
     /// True after construction / `redo`, false after `undo`. Tracks whether
     /// the duplicated subtree is currently in the document tree.
     applied: bool,
@@ -148,7 +174,7 @@ impl DuplicateAction {
             root_new_id,
             parent,
             position,
-            tombstones,
+            tombstones: Tombstones::new(tombstones, /* detached_when_applied: */ false),
             applied: true,
         }
     }
@@ -168,13 +194,8 @@ impl UndoAction for DuplicateAction {
     }
 
     fn on_evict(&mut self, compositor: &mut Compositor) {
-        // Only dispose when the dup is currently detached — otherwise the
-        // tombstones are part of the live document state.
-        if !self.applied {
-            for id in self.tombstones.drain(..) {
-                compositor.dispose_layer(id);
-            }
-        }
+        self.tombstones
+            .dispose_if_detached(self.applied, compositor);
     }
 }
 
@@ -201,7 +222,7 @@ pub struct BakeLayersAction {
     /// Pixel-bearing node ids inside the source subtrees — detached on
     /// the forward (applied) side, reattached on undo. Disposed at evict
     /// time **only if the action was applied** (sources currently detached).
-    source_tombstones: Vec<LayerId>,
+    source_tombstones: Tombstones,
 
     pub result_id: LayerId,
     pub result_parent: Option<LayerId>,
@@ -209,7 +230,7 @@ pub struct BakeLayersAction {
     /// The baked result's pixel-bearing node ids — typically just
     /// `[result_id]`. Disposed at evict time **only if the action was
     /// undone** (result currently detached).
-    result_tombstones: Vec<LayerId>,
+    result_tombstones: Tombstones,
 
     /// True after construction / `redo`, false after `undo`. Determines
     /// which side is currently detached and therefore safe to dispose at
@@ -228,11 +249,17 @@ impl BakeLayersAction {
     ) -> Self {
         BakeLayersAction {
             sources,
-            source_tombstones,
+            source_tombstones: Tombstones::new(
+                source_tombstones,
+                /* detached_when_applied: */ true,
+            ),
             result_id,
             result_parent,
             result_position,
-            result_tombstones,
+            result_tombstones: Tombstones::new(
+                result_tombstones,
+                /* detached_when_applied: */ false,
+            ),
             applied: true,
         }
     }
@@ -277,16 +304,11 @@ impl UndoAction for BakeLayersAction {
     }
 
     fn on_evict(&mut self, compositor: &mut Compositor) {
-        // Dispose only the side currently detached — the opposite side is
-        // live document state and must keep its textures.
-        if self.applied {
-            for id in self.source_tombstones.drain(..) {
-                compositor.dispose_layer(id);
-            }
-        } else {
-            for id in self.result_tombstones.drain(..) {
-                compositor.dispose_layer(id);
-            }
-        }
+        // Each tombstone set carries its own polarity; the helper disposes
+        // the side currently detached and leaves the live side alone.
+        self.source_tombstones
+            .dispose_if_detached(self.applied, compositor);
+        self.result_tombstones
+            .dispose_if_detached(self.applied, compositor);
     }
 }

--- a/crates/darkly/src/undo/mod.rs
+++ b/crates/darkly/src/undo/mod.rs
@@ -4,6 +4,7 @@ mod layer;
 mod modifier;
 pub mod property;
 mod selection;
+mod tombstones;
 
 pub use compound::CompoundAction;
 pub use gpu_region::GpuRegionAction;
@@ -294,7 +295,7 @@ mod tests {
         let node = doc.detach_for_undo(id).unwrap();
         let _ = undo.push(
             &mut doc,
-            Box::new(LayerRemoveAction::new(node, parent, pos)),
+            Box::new(LayerRemoveAction::new(node, parent, pos, Vec::new())),
         );
 
         assert_eq!(doc.flat_layers().len(), 0);

--- a/crates/darkly/src/undo/tombstones.rs
+++ b/crates/darkly/src/undo/tombstones.rs
@@ -1,0 +1,53 @@
+//! A set of pixel-bearing node ids whose GPU textures must be kept alive
+//! while an undo action sits on the stack — and disposed when the action
+//! is evicted, *if* the subtree they belong to is currently detached from
+//! the document tree.
+//!
+//! Several undo actions tombstone GPU textures so that flip-flopping undo
+//! / redo can resurrect pixels without snapshotting them. The rule each
+//! action enforces in `on_evict` has the same shape: *dispose if the
+//! subtree the ids belong to is currently detached*. This type encodes
+//! that rule once.
+//!
+//! Each `Tombstones` carries a polarity (`detached_when_applied`) saying
+//! whether the subtree is detached on the action's forward side or its
+//! undone side. The action passes its own current `applied` flag in and
+//! the helper disposes iff the two match.
+//!
+//! Polarities by action:
+//!
+//! | Action                               | Polarity             |
+//! |--------------------------------------|----------------------|
+//! | [`super::DuplicateAction`]           | `false` (detached when undone) |
+//! | [`super::LayerRemoveAction`]         | `true`  (detached when applied) |
+//! | [`super::BakeLayersAction`] sources  | `true`  (detached when applied) |
+//! | [`super::BakeLayersAction`] result   | `false` (detached when undone) |
+
+use crate::gpu::compositor::Compositor;
+use crate::layer::LayerId;
+
+#[derive(Debug)]
+pub(crate) struct Tombstones {
+    ids: Vec<LayerId>,
+    detached_when_applied: bool,
+}
+
+impl Tombstones {
+    pub(crate) fn new(ids: Vec<LayerId>, detached_when_applied: bool) -> Self {
+        Self {
+            ids,
+            detached_when_applied,
+        }
+    }
+
+    /// Dispose every tombstoned texture iff the owning action's current
+    /// `applied` state means the subtree is detached. Drains the id list
+    /// so a second call is a no-op.
+    pub(crate) fn dispose_if_detached(&mut self, applied: bool, compositor: &mut Compositor) {
+        if applied == self.detached_when_applied {
+            for id in self.ids.drain(..) {
+                compositor.dispose_layer(id);
+            }
+        }
+    }
+}

--- a/crates/darkly/tests/engine.rs
+++ b/crates/darkly/tests/engine.rs
@@ -1485,10 +1485,11 @@ fn paste_cancel_cycles_dont_leak_layer_textures() {
     );
 }
 
-/// `Engine::remove_layer` must dispose the layer's compositor state so
-/// repeated add → remove cycles don't leak textures. The undo entry
-/// preserves the doc-side metadata; pixel data is intentionally lost on
-/// remove (re-inserting on undo gives back an empty raster).
+/// `Engine::remove_layer` defers GPU texture disposal to undo-stack
+/// eviction so that an undo of the removal restores the pixels intact.
+/// Repeated add → remove cycles must not leak textures **after** the
+/// owning undo entries leave the stack (forced here via the teardown
+/// drain).
 #[test]
 fn add_remove_cycles_dont_leak_layer_textures() {
     let (cw, ch) = (128, 128);
@@ -1504,11 +1505,60 @@ fn add_remove_cycles_dont_leak_layer_textures() {
         assert!(!engine.has_layer(id));
     }
 
+    // Force eviction of every owning undo entry so the tombstoned
+    // textures release. This is the same shape duplicate/bake leaks
+    // tests rely on.
+    engine.test_drain_undo_for_teardown();
+
     let after_cycles = engine.test_node_texture_count();
     assert_eq!(
         after_cycles, baseline,
         "5 add→remove cycles should leave layer_textures count unchanged \
-         (baseline {baseline}, got {after_cycles})"
+         after undo-stack drain (baseline {baseline}, got {after_cycles})"
+    );
+}
+
+/// Regression: undoing a layer removal must restore the layer's pixel
+/// content, not just its tree slot. Previously `remove_layer` disposed
+/// the GPU texture immediately and `LayerRemoveAction` carried no pixel
+/// state, so undo reattached the node but the compositor allocated a
+/// fresh blank texture.
+#[test]
+fn undo_remove_layer_restores_pixels() {
+    let (cw, ch) = (128u32, 128u32);
+    let mut engine = test_engine(cw, ch);
+    let _base = engine.add_raster_layer(None);
+    let layer_id = engine.add_raster_layer(None);
+
+    // Paint a distinctive mark we can compare byte-for-byte after undo.
+    paint_at(&mut engine, layer_id, 32.0, 32.0, 1.0, 0.0, 0.0);
+    paint_at(&mut engine, layer_id, 96.0, 96.0, 0.0, 1.0, 0.0);
+    let before_remove = engine.test_readback_layer(layer_id);
+    let bounds_before = engine.layer_bounds(layer_id).unwrap();
+    assert!(
+        before_remove.iter().skip(3).step_by(4).any(|&a| a > 0),
+        "sanity: pre-remove layer must contain painted pixels",
+    );
+
+    engine
+        .remove_layer(layer_id)
+        .expect("remove should succeed");
+    assert!(!engine.has_layer(layer_id));
+
+    engine.undo();
+    engine.render(0.0);
+
+    assert!(engine.has_layer(layer_id), "undo must reattach the layer");
+    let bounds_after = engine.layer_bounds(layer_id).unwrap();
+    assert_eq!(
+        bounds_after, bounds_before,
+        "undo must restore the layer's bounds",
+    );
+
+    let after_undo = engine.test_readback_layer(layer_id);
+    assert_eq!(
+        after_undo, before_remove,
+        "undo of remove_layer must restore the layer's pixel content byte-for-byte",
     );
 }
 

--- a/frontend/src/ui/settings/ActionTriggerRow.svelte
+++ b/frontend/src/ui/settings/ActionTriggerRow.svelte
@@ -2,6 +2,7 @@
     import { config, formatHotkey } from '../../config/store.svelte';
     import type { ActionRegistration } from '../../actions/registry';
     import HotkeyCapture from './widgets/HotkeyCapture.svelte';
+    import HotkeyScopeSelect from './widgets/HotkeyScopeSelect.svelte';
     import MouseChordCapture from './widgets/MouseChordCapture.svelte';
 
     type Props = { action: ActionRegistration };
@@ -44,12 +45,21 @@
         {#if desc}<div class="desc">{desc}</div>{/if}
     </div>
 
+    <div class="scope-col">
+        <HotkeyScopeSelect
+            value={hotkeyValue}
+            {action}
+            onchange={setHotkey}
+        />
+    </div>
+
     <div class="trigger-col">
         <div class="trigger-cell">
             <HotkeyCapture
                 prefKey={hotkeyKey}
                 value={hotkeyValue}
                 {action}
+                showScope={false}
                 onchange={setHotkey}
             />
             <button
@@ -87,7 +97,7 @@
 <style>
     .row {
         display: grid;
-        grid-template-columns: minmax(0, 1fr) auto;
+        grid-template-columns: minmax(0, 1fr) auto auto;
         gap: 16px;
         align-items: center;
         padding: 10px 12px;
@@ -96,8 +106,19 @@
     .row:last-child { border-bottom: none; }
 
     .label-col { min-width: 0; }
-    .label { font-size: 13px; color: var(--text); }
-    .desc { font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+    .label {
+        font-size: 13px;
+        color: var(--text);
+        overflow-wrap: anywhere;
+    }
+    .desc {
+        font-size: 11px;
+        color: var(--text-muted);
+        margin-top: 2px;
+        overflow-wrap: anywhere;
+    }
+
+    .scope-col { display: flex; align-items: center; }
 
     .trigger-col {
         display: flex;

--- a/frontend/src/ui/settings/SettingsModal.svelte
+++ b/frontend/src/ui/settings/SettingsModal.svelte
@@ -67,7 +67,7 @@
 
 </script>
 
-<Modal bind:open={settings.open} title="Settings" size="md">
+<Modal bind:open={settings.open} title="Settings" size="lg">
     <div class="settings-body">
         <header class="topbar">
             <button
@@ -77,7 +77,7 @@
                 title="Remove every personal override; the base layout shows through."
             >
                 <i class="fa-solid fa-rotate-left"></i>
-                Reset overrides
+                Reset
             </button>
             <button
                 type="button"
@@ -130,6 +130,7 @@
                     {:else}
                         <header class="trigger-header">
                             <span class="label-col">Action</span>
+                            <span class="scope-col">Scope</span>
                             <span class="trigger-col">
                                 <span>Keyboard</span>
                                 <span>Mouse</span>
@@ -246,7 +247,7 @@
 
     .trigger-header {
         display: grid;
-        grid-template-columns: minmax(0, 1fr) auto;
+        grid-template-columns: minmax(0, 1fr) auto auto;
         gap: 16px;
         padding: 8px 12px;
         font-size: 10px;
@@ -259,6 +260,9 @@
         top: 0;
         background: var(--bg-active);
         z-index: 1;
+    }
+    .trigger-header .scope-col {
+        min-width: 100px;
     }
     .trigger-header .trigger-col {
         display: flex;

--- a/frontend/src/ui/settings/widgets/HotkeyCapture.svelte
+++ b/frontend/src/ui/settings/widgets/HotkeyCapture.svelte
@@ -12,8 +12,12 @@
         /** Action this row belongs to — needed to filter compatible binding
          *  sites for the scope dropdown. */
         action?: ActionRegistration;
+        /** When false, the scope `<select>` is suppressed — the caller is
+         *  rendering it separately (e.g. the hotkeys-tab grid has its own
+         *  Scope column owned by `HotkeyScopeSelect`). */
+        showScope?: boolean;
     };
-    let { prefKey, value, onchange, action }: Props = $props();
+    let { prefKey, value, onchange, action, showScope = true }: Props = $props();
 
     // `value` can briefly be undefined when the settings modal opens before
     // the config store is ready — `config.get` returns undefined in that
@@ -104,7 +108,7 @@
 </script>
 
 <div class="hotkey-row">
-    {#if compatibleSites.length > 0}
+    {#if showScope && compatibleSites.length > 0}
         <select class="site" value={parts.site ?? ''} onchange={pickSite} title="Scope this hotkey to a UI region (or leave global)">
             <option value="">(global)</option>
             {#each compatibleSites as s (s.name)}

--- a/frontend/src/ui/settings/widgets/HotkeyScopeSelect.svelte
+++ b/frontend/src/ui/settings/widgets/HotkeyScopeSelect.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+    import { sites, contextSatisfied, type ActionRegistration } from '../../../actions/registry';
+    import { parseBinding } from '../../../config/hotkeys.svelte';
+
+    type Props = {
+        /** The full binding (`<site>:<chord>` or bare chord). */
+        value: string;
+        onchange: (v: string) => void;
+        action: ActionRegistration;
+    };
+    let { value, onchange, action }: Props = $props();
+
+    const parts = $derived.by(() => parseBinding(value ?? ''));
+
+    /** Sites whose `provides` is a superset of `action.requires`. `keyboard`
+     *  is excluded — it's the implicit global fallback (selected via
+     *  "(global)"). */
+    const compatibleSites = $derived.by(() =>
+        sites.all().filter(s =>
+            s.name !== 'keyboard'
+            && contextSatisfied(action, s.provides),
+        ),
+    );
+
+    function pickSite(e: Event) {
+        const site = (e.currentTarget as HTMLSelectElement).value;
+        if (site === '') {
+            onchange(parts.chord);
+        } else {
+            onchange(parts.chord ? `${site}:${parts.chord}` : `${site}:`);
+        }
+    }
+</script>
+
+{#if compatibleSites.length > 0}
+    <select
+        class="site"
+        value={parts.site ?? ''}
+        onchange={pickSite}
+        title="Scope this hotkey to a UI region (or leave global)"
+    >
+        <option value="">(global)</option>
+        {#each compatibleSites as s (s.name)}
+            <option value={s.name}>{s.displayName ?? s.name}</option>
+        {/each}
+    </select>
+{/if}
+
+<style>
+    .site {
+        background: var(--bg-hover);
+        border: 1px solid var(--bg-hover);
+        color: var(--text);
+        border-radius: 4px;
+        padding: 5px 8px;
+        font-size: 12px;
+        min-width: 100px;
+    }
+</style>


### PR DESCRIPTION
## Summary

Undoing a layer deletion previously brought back the layer's tree slot
but not its pixels — the compositor allocated a fresh blank texture
because `remove_layer` disposed the GPU texture immediately and
`LayerRemoveAction` carried no pixel state.

Fix it the same way duplicate/merge/flatten already do: tombstone the
subtree's GPU textures while the undo entry sits on the stack, dispose
them only when the entry is evicted *and* the deletion is still in
effect.

Three undo actions (`DuplicateAction`, `BakeLayersAction`,
`LayerRemoveAction`) all carry this "dispose iff subtree currently
detached" rule. Extracted it into a shared `Tombstones` helper that
takes a polarity (`detached_when_applied`) and an `applied` flag, so
each action just delegates `on_evict` to it.

## Test plan

- [x] `cargo test -p darkly --test engine undo_remove_layer_restores_pixels` — new regression test passes (and was confirmed to fail against the pre-fix code).
- [x] `cargo test -p darkly --test engine add_remove_cycles_dont_leak_layer_textures` — existing no-leak test still holds, now driving eviction explicitly.
- [x] `cargo fmt --all -- --check`
- [x] `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets --exclude darkly-wasm -- -Dwarnings`
- [x] `RUSTFLAGS=-Dwarnings cargo clippy -p darkly-wasm --target wasm32-unknown-unknown --all-targets -- -Dwarnings`
- [x] `cargo test --workspace --exclude darkly-wasm -- --test-threads=1`
- [x] `wasm-pack build --release --target web` from `frontend/wasm`
- [x] `npx tsc --noEmit && npm run build && npm test` from `frontend`
- [ ] Manual UI: delete a painted raster layer, hit undo, confirm pixels return; delete → undo → redo → undo cycles also keep pixels.
