### PR TITLE
Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+  push:
+    branches: [master]
 
 env:
   CARGO_TERM_COLOR: always
@@ -42,7 +44,7 @@ jobs:
       - run: cargo clippy -p darkly-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings
 
   test:
-    name: cargo test
+    name: cargo test + coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -52,11 +54,23 @@ jobs:
           sudo apt-get install -y mesa-vulkan-drivers vulkan-tools libvulkan1
           vulkaninfo --summary || true
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
-      - name: cargo test
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: cargo llvm-cov
         env:
           WGPU_BACKEND: vulkan
-        run: cargo test --workspace --exclude darkly-wasm
+        run: cargo llvm-cov --workspace --exclude darkly-wasm --lcov --output-path lcov.info -- --test-threads=1
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          flags: rust
 
   wasm-build:
     name: wasm-pack build

--- a/README.md
+++ b/README.md
@@ -240,9 +240,9 @@ While Darkly's architecture is fundamentally different, it was really insightful
 
 Some of Darkly's veil and void shaders are ports or adaptations of work originally published on [Shadertoy](https://www.shadertoy.com/). I suck at shaders and the creators of these shaders are true artists. Please go see them in their native habitat!
 
-- **Lens Blur** (veil) - based on [ldG3W3](https://www.shadertoy.com/view/ldG3W3) by [Dave Hoskins](https://www.shadertoy.com/user/Dave_Hoskins).
-- **Painting** (veil) - a generalized Kuwahara filter, based on [mlffWf](https://www.shadertoy.com/view/mlffWf) by [p4vv37](https://www.shadertoy.com/user/p4vv37), with technique notes from [Acerola / Garrett Gunnell](https://github.com/GarrettGunnell/Post-Processing/tree/main/Assets/Kuwahara%20Filter).
-- **Rainy glass** (veil) - ported from "Heartfelt" ([ltffzl](https://www.shadertoy.com/view/ltffzl)) by [Martijn Steinrucken / BigWIngs](https://www.shadertoy.com/user/BigWIngs).
-- **VHS** (veil) - ported from [XtBXDt](https://www.shadertoy.com/view/XtBXDt) by [FMS_Cat](https://www.shadertoy.com/user/FMS_Cat).
-- **Watercolor** (veil) - based on [mdlXW2](https://www.shadertoy.com/view/mdlXW2) by [aeva](https://www.shadertoy.com/user/aeva).
-- **Noise** (void) - domain-warp algorithm from Inigo Quilez's ["Domain warping"](https://iquilezles.org/articles/warp/) article; the texture-sampled noise primitive (a 3D volume sampled by the FBM octave loop) is inspired by "Watery" ([MssSRS](https://www.shadertoy.com/view/MssSRS)) by [nimitz](https://www.shadertoy.com/user/nimitz) (twitter: @stormoid).
+- **Lens Blur** (veil) - based on ["Bokeh Venice"](https://www.shadertoy.com/view/ldG3W3) by [Dave Hoskins](https://www.shadertoy.com/user/Dave_Hoskins).
+- **Painting** (veil) - based on ["Generalized Kuwahara shader"](https://www.shadertoy.com/view/mlffWf) by [p4vv37](https://www.shadertoy.com/user/p4vv37), with technique notes from [Acerola / Garrett Gunnell](https://github.com/GarrettGunnell/Post-Processing/tree/main/Assets/Kuwahara%20Filter).
+- **Rainy glass** (veil) - ported from ["Heartfelt"](https://www.shadertoy.com/view/ltffzl) by [Martijn Steinrucken / BigWIngs](https://www.shadertoy.com/user/BigWIngs).
+- **VHS** (veil) - ported from ["20151110_VHS"](https://www.shadertoy.com/view/XtBXDt) by [FMS_Cat](https://www.shadertoy.com/user/FMS_Cat).
+- **Watercolor** (veil) - based on ["watercolor propagation"](https://www.shadertoy.com/view/mdlXW2) by [aeva](https://www.shadertoy.com/user/aeva).
+- **Noise** (void) - domain-warp algorithm from Inigo Quilez's ["Domain warping"](https://iquilezles.org/articles/warp/) article; the texture-sampled noise primitive (a 3D volume sampled by the FBM octave loop) is inspired by ["Watery"](https://www.shadertoy.com/view/MssSRS) by [nimitz](https://www.shadertoy.com/user/nimitz) (twitter: @stormoid).

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@
 ![TypeScript](https://img.shields.io/badge/TypeScript-000000?style=for-the-badge&logo=typescript&logoColor=6914ff)
 ![WebAssembly](https://img.shields.io/badge/WebAssembly-000000?style=for-the-badge&logo=WebAssembly&logoColor=4400ff)
 ![WebGPU](https://img.shields.io/badge/WebGPU-000000?style=for-the-badge&logo=webgpu&logoColor=4400ff)
+[![Coverage](https://img.shields.io/codecov/c/github/darkly-art/darkly?token=TIIFB7UHAJ&label=Coverage&logo=codecov&labelColor=black&logoColor=4400ff&style=for-the-badge&color=4400ff)](https://codecov.io/gh/darkly-art/darkly)
 
 > [!IMPORTANT]
 > **Darkly is in beta**! Features are being [added daily](#feature-roadmap). Please [report bugs](https://github.com/darkly-art/darkly/issues/new) so we can squash them.
 
-[Darkly](https://darkly.art) is a GPU-native editor written in Rust and geared towards digital painters. It has everything you expect from a paint program, plus some special **[dark arts](#unique-darkly-features)** to help you rage against the machine.
+[Darkly](https://darkly.art) is a GPU-native editor written in Rust and geared towards digital painters. It aims to have everything you expect from a paint program, plus some special **[dark arts](#unique-darkly-features)** to help you rage against the machine.
 
 ### Darkly pledges to:
 
@@ -38,13 +39,13 @@ In addition to the usual paint features, Darkly has some entropic tools to empow
 
 ### Veils
 
-Veils are where Darkly gets its name; *"For now we see through a glass, darkly"*. They're a special type of layer that sits overtop the viewport, and is visible only to the artist. By shrouding your art behind a mysterious pane of glass, they invite you to see something that wasn't there before.
+Veils are where Darkly gets its name; *"For now we see through a glass, darkly"*. They're a special type of layer that sits overtop the viewport, and is visible only to the artist. By shrouding your art behind a mysterious pane, they invite you to see something that maybe wasn't there before.
 
 Veils have practical uses too:
 
 - By hiding fine details, they can prevent **premature fixation on detail**, freeing you to focus on composition.
-- During the ideation phase, they can help with **blank page syndrome** and **destructive self-criticism** by giving you permission to be messy, and explore freely.
-- They can also help remedy **art fatigue** (losing eyes for art by staring at it for too long) by letting you view it through new eyes.
+- During the sketching / ideation phase, they can help with **blank page syndrome** and **destructive self-criticism** by giving you permission to be messy, and explore freely.
+- They can also help remedy **art fatigue** (losing eyes for art by staring at it for too long) by letting you view it through a new lense.
 
 > [!NOTE]
 > Veils live in their own dedicated group, but within that you can stack and order them however you like. Keep in mind that adding too many can drain your battery, due to the heavy load on your GPU.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - ☯️ Never [steal or license](https://x.com/SamSantala/status/1798292952219091042) your art
 - ☮️ Stay free and open source forever
 
-If you're a sane artist who likes rulers, guides, and clean vector lines, you may still like Darkly. But it's fundamentally a chaotic playground, for artists who make messes and incur happy accidents. Madness isn't a bug, it's a feature.
+Do you suffer from the **oppressive sanity** of rulers, guides, and nondestructive workflows? Channel your suppressed chaotic powers with Darkly, where messes are made and happy incidents incurred. Madness isn't a bug, it's a feature.
 
 **Try the demo [here](https://demo.darkly.art).**
 
@@ -39,6 +39,8 @@ In addition to the usual paint features, Darkly has some entropic tools to empow
 
 ### Veils
 
+https://github.com/user-attachments/assets/44d24a14-4049-4182-bcc8-bc8ef2bc9d1f
+
 Veils are where Darkly gets its name; *"For now we see through a glass, darkly"*. They're a special type of layer that sits overtop the viewport, and is visible only to the artist. By shrouding your art behind a mysterious pane, they invite you to see something that maybe wasn't there before.
 
 Veils have practical uses too:
@@ -51,6 +53,8 @@ Veils have practical uses too:
 > Veils live in their own dedicated group, but within that you can stack and order them however you like. Keep in mind that adding too many can drain your battery, due to the heavy load on your GPU.
 
 ### Voids
+
+https://github.com/user-attachments/assets/759022be-6135-42b1-b62d-42eda78856a5
 
 Voids are a special type of layer that specializes in pulling inspiration from outside sources. 
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - ☯️ Never [steal or license](https://x.com/SamSantala/status/1798292952219091042) your art
 - ☮️ Stay free and open source forever
 
-Do you suffer from the **oppressive sanity** of rulers, guides, and nondestructive workflows? Channel your suppressed chaotic powers with Darkly, where messes are made and happy incidents incurred. Madness isn't a bug, it's a feature.
+Do you suffer from the **oppressive sanity** of rulers, guides, and nondestructive workflows? Channel your suppressed chaos with Darkly, where messes are made and happy incidents incurred. Madness isn't a bug, it's a feature.
 
 **Try the demo [here](https://demo.darkly.art).**
 
@@ -39,7 +39,7 @@ In addition to the usual paint features, Darkly has some entropic tools to empow
 
 ### Veils
 
-https://github.com/user-attachments/assets/44d24a14-4049-4182-bcc8-bc8ef2bc9d1f
+https://github.com/user-attachments/assets/ee281ac2-37a8-4e52-91b3-78d564420e9d
 
 Veils are where Darkly gets its name; *"For now we see through a glass, darkly"*. They're a special type of layer that sits overtop the viewport, and is visible only to the artist. By shrouding your art behind a mysterious pane, they invite you to see something that maybe wasn't there before.
 
@@ -54,7 +54,7 @@ Veils have practical uses too:
 
 ### Voids
 
-https://github.com/user-attachments/assets/759022be-6135-42b1-b62d-42eda78856a5
+https://github.com/user-attachments/assets/43dac748-d79f-403f-8456-10dad779a6f9
 
 Voids are a special type of layer that specializes in pulling inspiration from outside sources. 
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - ☯️ Never [steal or license](https://x.com/SamSantala/status/1798292952219091042) your art
 - ☮️ Stay free and open source forever
 
-Do you suffer from the **oppressive sanity** of rulers, guides, and nondestructive workflows? Channel your suppressed chaos with Darkly, where messes are made and happy incidents incurred. Madness isn't a bug, it's a feature.
+Do you suffer from the **oppressive sanity** of rulers, guides, and nondestructive workflows? Channel your inner chaos with Darkly, where messes are made and happy incidents incurred. Madness isn't a bug, it's a feature.
 
 **Try the demo [here](https://demo.darkly.art).**
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,19 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+comment:
+  layout: "diff, files"
+  require_changes: true
+
+ignore:
+  - "crates/darkly/build.rs"
+  - "**/test_utils.rs"
+  - "frontend/**"

--- a/crates/darkly/src/brush/builtin_brushes.rs
+++ b/crates/darkly/src/brush/builtin_brushes.rs
@@ -501,7 +501,7 @@ fn smudge_brush() -> Brush {
     }
 
     let mut metadata = BrushMetadata::from_graph("Smudge", graph);
-    metadata.category = "painting".to_string();
+    metadata.category = "effects".to_string();
     Brush::without_resources(metadata)
 }
 


### PR DESCRIPTION
## Summary

- Wire Codecov coverage into the existing `test` CI job: install `cargo-llvm-cov` via `taiki-e/install-action`, replace `cargo test` with `cargo llvm-cov ... --lcov --output-path lcov.info -- --test-threads=1`, and upload the report via `codecov/codecov-action@v5` (with `fail_ci_if_error: true`, `flags: rust`).
- Adopt the mandatory `--test-threads=1` flag at the same time (CLAUDE.md requires it; the previous `cargo test` step was missing it).
- Extend the CI trigger to also run on `push: master` so Codecov has a base coverage report for PR diffs.
- Add `codecov.yml` at the repo root: `project`/`patch` status at `target: auto` with a 1% threshold, compact comment, and ignores for `build.rs`, `**/test_utils.rs`, and `frontend/**`.

Scope is intentionally limited to the Rust core (`crates/darkly`). `darkly-wasm` is excluded from native tests and not instrumented here; no frontend coverage; no README badge.

## Test plan

- [ ] Add the `CODECOV_TOKEN` secret in the GitHub repo settings before merging — `fail_ci_if_error: true` will surface a missing-token failure.
- [ ] Push the branch and confirm the `test` job runs `cargo llvm-cov` successfully under Mesa lavapipe with `WGPU_BACKEND=vulkan`.
- [ ] Confirm the "Upload coverage to Codecov" step reports a successful upload of `lcov.info`.
- [ ] Confirm Codecov posts a PR comment within ~1 minute of CI green. (First PR will show "no base report" — expected; resolved after merge once `push: master` uploads a baseline.)
- [ ] Spot-check the Codecov dashboard to confirm `crates/darkly/build.rs`, `test_utils.rs`, and `frontend/**` are excluded from the file list.
- [ ] Optional local smoke test: `cargo install cargo-llvm-cov && cargo llvm-cov --workspace --exclude darkly-wasm --lcov --output-path lcov.info -- --test-threads=1`.
