### PR TITLE
Brush subsystem slop + dead-code sweep

### DIFF
--- a/crates/darkly/src/brush/builtin_brushes.rs
+++ b/crates/darkly/src/brush/builtin_brushes.rs
@@ -73,7 +73,7 @@ fn paint_brush(
     let stamp = graph.add_node(
         "stamp",
         registry.get("stamp").unwrap().ports.clone(),
-        vec![ParamValue::Int(0)], // 0 = Alpha Mask
+        vec![],
     );
     // `paint` owns the dab dimensions; stamp's `size` port is inert.
     // Hide it so users don't see two "Size" sliders in the brush
@@ -645,7 +645,7 @@ fn rough_ink() -> Brush {
     let stamp = graph.add_node(
         "stamp",
         registry.get("stamp").unwrap().ports.clone(),
-        vec![ParamValue::Int(0)], // 0 = Alpha Mask
+        vec![],
     );
     // Stamp's `size` port is exposed by default (because per-dab
     // dispatch needs it), but `paint` ignores stamp's

--- a/crates/darkly/src/brush/bundle.rs
+++ b/crates/darkly/src/brush/bundle.rs
@@ -13,15 +13,10 @@ use crate::brush::stabilizer::StabilizerConfig;
 use crate::brush::wire::BrushWireType;
 use crate::nodegraph::Graph;
 
-/// Current format version. Loaders reject any archive whose stored
-/// version is greater than this; older versions are not supported.
-pub const FORMAT_VERSION: u32 = 1;
-
 /// Metadata for a brush — the JSON-serialized envelope inside a
 /// `.darkly-brush` archive.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BrushMetadata {
-    pub format_version: u32,
     pub name: String,
     #[serde(default = "default_engine_version")]
     pub engine_version: String,
@@ -81,7 +76,6 @@ impl BrushMetadata {
     /// Create metadata from just a graph (no resources).
     pub fn from_graph(name: impl Into<String>, graph: Graph<BrushWireType>) -> Self {
         BrushMetadata {
-            format_version: FORMAT_VERSION,
             name: name.into(),
             engine_version: default_engine_version(),
             category: String::new(),
@@ -177,13 +171,6 @@ impl Brush {
                 .map_err(|e| format!("invalid {}: {e}", Self::METADATA_JSON_PATH))?
         };
 
-        if metadata.format_version > FORMAT_VERSION {
-            return Err(format!(
-                "brush format version {} is newer than supported version {FORMAT_VERSION}",
-                metadata.format_version
-            ));
-        }
-
         // Read resource data
         let mut resource_data = Vec::new();
         for meta in &metadata.resources {
@@ -260,7 +247,6 @@ mod tests {
         let loaded = Brush::from_bytes(&bytes).unwrap();
 
         assert_eq!(loaded.metadata.name, "Test Brush");
-        assert_eq!(loaded.metadata.format_version, FORMAT_VERSION);
 
         // Verify graph round-trips: same nodes and connections.
         // Compare as serde_json::Value to avoid HashMap key ordering differences.
@@ -292,18 +278,6 @@ mod tests {
         assert_eq!(loaded.metadata.resources.len(), 1);
         assert_eq!(loaded.metadata.resources[0].kind, ResourceKind::BrushTip);
         assert_eq!(loaded.resource("tip.png").unwrap(), &tip_data);
-    }
-
-    #[test]
-    fn future_version_rejected() {
-        let graph = brush::default_graph();
-        let mut metadata = BrushMetadata::from_graph("Future", graph);
-        metadata.format_version = FORMAT_VERSION + 1;
-        let brush = Brush::without_resources(metadata);
-
-        let bytes = brush.to_bytes().unwrap();
-        let err = Brush::from_bytes(&bytes).unwrap_err();
-        assert!(err.contains("newer than supported"), "got: {err}");
     }
 
     #[test]

--- a/crates/darkly/src/brush/checkpoint_ring.rs
+++ b/crates/darkly/src/brush/checkpoint_ring.rs
@@ -635,7 +635,6 @@ mod tests {
     fn coverage_invariant_holds_with_segment_boundary_pattern() {
         let mut ring = CheckpointRing::new();
         let max_div = 65usize;
-        let _spacing = CheckpointRing::spacing(max_div);
 
         for step in 1usize..400 {
             let tip = step * 3; // grow tip steadily

--- a/crates/darkly/src/brush/eval.rs
+++ b/crates/darkly/src/brush/eval.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use crate::gpu::params::ParamValue;
 use crate::nodegraph::{
-    ExecutionPlan, Graph, InputSlot, NodeId, NodeRegistration, PortDef, PortDir, PortRef,
+    ExecStep, ExecutionPlan, Graph, InputSlot, NodeId, NodeRegistration, PortDef, PortDir, PortRef,
 };
 
 use super::curve_math::CurveLut;
@@ -24,13 +24,11 @@ use super::wire::{BrushWireType, ScalarValue};
 
 /// Context passed to each node's CPU evaluator.
 ///
-/// Connected input values arrive as two parallel slices — `input_slots`
-/// gives the port name and wire metadata, `input_values` gives the
-/// post-wire-remap value (or `None` when the upstream slot hasn't been
-/// written yet). [`Self::input`] linearly scans `input_slots` to resolve
-/// a name; the bound that makes this fast is per-node input count
-/// (typically 1–3, never more than ~8), so a `HashMap` would only
-/// trade a per-step heap allocation for no real speedup.
+/// Connected input values arrive as two parallel slices: port name +
+/// metadata in `input_slots`, post-remap value in `input_values`.
+/// [`Self::input`] linearly scans `input_slots` — per-node input count
+/// is small (typically 1–3, never more than ~8), so a `HashMap` would
+/// only trade a per-step heap allocation for no real speedup.
 pub struct EvalContext<'a> {
     /// Connected input ports for this step, in the same order as
     /// `input_values`. Disconnected ports are absent — [`Self::input`]
@@ -484,6 +482,27 @@ struct NodeData {
     lut: Option<CurveLut>,
 }
 
+fn build_eval_ctx<'a>(
+    step: &'a ExecStep,
+    input_slots: &'a [InputSlot],
+    input_values: &'a [Option<ScalarValue>],
+    node_data: &'a HashMap<NodeId, NodeData>,
+    stroke_seed: u32,
+    dab_index: u32,
+) -> EvalContext<'a> {
+    let node = node_data.get(&step.node_id);
+    EvalContext {
+        input_slots,
+        input_values,
+        params: node.map(|n| n.params.as_slice()).unwrap_or(&[]),
+        port_defs: node.map(|n| n.port_defs.as_slice()).unwrap_or(&[]),
+        lut: node.and_then(|n| n.lut.as_ref()),
+        stroke_seed,
+        dab_index,
+        node_id: step.node_id,
+    }
+}
+
 impl BrushGraphRunner {
     /// Build a runner from a graph and a registry of evaluators.
     ///
@@ -679,8 +698,6 @@ impl BrushGraphRunner {
     /// Call `seed_sensors()` first.  After this returns, output slots
     /// contain the final values for this dab.
     pub fn execute_cpu(&mut self) {
-        let empty_params: Vec<ParamValue> = Vec::new();
-        let empty_ports: Vec<PortDef<BrushWireType>> = Vec::new();
         let n = self.plan.steps.len();
         for idx in 0..n {
             // Field accesses below all go through `self.<field>` directly so
@@ -712,17 +729,14 @@ impl BrushGraphRunner {
                 &mut self.inputs_scratch,
             );
 
-            let node = self.node_data.get(&step.node_id);
-            let ctx = EvalContext {
-                input_slots: &step.input_slots,
-                input_values: &self.inputs_scratch,
-                params: node.map(|n| n.params.as_slice()).unwrap_or(&empty_params),
-                port_defs: node.map(|n| n.port_defs.as_slice()).unwrap_or(&empty_ports),
-                lut: node.and_then(|n| n.lut.as_ref()),
-                stroke_seed: self.stroke_seed,
-                dab_index: self.dab_index,
-                node_id: step.node_id,
-            };
+            let ctx = build_eval_ctx(
+                step,
+                &step.input_slots,
+                &self.inputs_scratch,
+                &self.node_data,
+                self.stroke_seed,
+                self.dab_index,
+            );
 
             let outputs = evaluator.evaluate_cpu(&ctx);
 
@@ -782,8 +796,6 @@ impl BrushGraphRunner {
             gpu.slot_outputs_owned = Some(self.build_slot_outputs());
         }
 
-        let empty_params: Vec<ParamValue> = Vec::new();
-        let empty_ports: Vec<PortDef<BrushWireType>> = Vec::new();
         let n = self.plan.steps.len();
         for idx in 0..n {
             let step = &self.plan.steps[idx];
@@ -814,17 +826,14 @@ impl BrushGraphRunner {
                 &mut self.inputs_scratch,
             );
 
-            let node = self.node_data.get(&step.node_id);
-            let ctx = EvalContext {
-                input_slots: &step.input_slots,
-                input_values: &self.inputs_scratch,
-                params: node.map(|n| n.params.as_slice()).unwrap_or(&empty_params),
-                port_defs: node.map(|n| n.port_defs.as_slice()).unwrap_or(&empty_ports),
-                lut: node.and_then(|n| n.lut.as_ref()),
-                stroke_seed: self.stroke_seed,
-                dab_index: self.dab_index,
-                node_id: step.node_id,
-            };
+            let ctx = build_eval_ctx(
+                step,
+                &step.input_slots,
+                &self.inputs_scratch,
+                &self.node_data,
+                self.stroke_seed,
+                self.dab_index,
+            );
 
             // Pure-math nodes promoted to the GPU phase (because an input
             // depends on a GPU output) only implement `evaluate_cpu`. Run
@@ -915,10 +924,6 @@ impl BrushGraphRunner {
     ) where
         F: FnMut(&str, &dyn BrushNodeEvaluator, &EvalContext, &mut BrushGpuContext),
     {
-        let empty_params: Vec<ParamValue> = Vec::new();
-        let empty_ports: Vec<PortDef<BrushWireType>> = Vec::new();
-        let empty_input_slots: Vec<InputSlot> = Vec::new();
-        let empty_input_values: Vec<Option<ScalarValue>> = Vec::new();
         let n = self.plan.steps.len();
         for idx in 0..n {
             let step = &self.plan.steps[idx];
@@ -942,19 +947,16 @@ impl BrushGraphRunner {
                     );
                     (&step.input_slots, &self.inputs_scratch)
                 } else {
-                    (&empty_input_slots, &empty_input_values)
+                    (&[], &[])
                 };
-            let node = self.node_data.get(&step.node_id);
-            let ctx = EvalContext {
-                input_slots: input_slots_view,
-                input_values: input_values_view,
-                params: node.map(|n| n.params.as_slice()).unwrap_or(&empty_params),
-                port_defs: node.map(|n| n.port_defs.as_slice()).unwrap_or(&empty_ports),
-                lut: node.and_then(|n| n.lut.as_ref()),
-                stroke_seed: self.stroke_seed,
-                dab_index: self.dab_index,
-                node_id: step.node_id,
-            };
+            let ctx = build_eval_ctx(
+                step,
+                input_slots_view,
+                input_values_view,
+                &self.node_data,
+                self.stroke_seed,
+                self.dab_index,
+            );
             f(&step.type_id, evaluator.as_ref(), &ctx, gpu);
         }
     }

--- a/crates/darkly/src/brush/gpu_context.rs
+++ b/crates/darkly/src/brush/gpu_context.rs
@@ -124,32 +124,6 @@ impl std::ops::AddAssign for BrushPerfCounters {
 /// bumped rather than silently truncating in release.
 pub const MAX_DABS_PER_PHASE: u32 = 16384;
 
-/// One queued dab waiting for the next `paint` terminal flush.
-///
-/// Layout MUST match the `Dab` struct in `shaders/brush/paint.wgsl` —
-/// the WGSL binding reads this verbatim as a storage buffer element.
-/// In std430, `vec2` is 8-byte aligned and `vec4` is 16-byte aligned,
-/// so `vec2 pos + f32 radius + f32 softness + vec4 color` packs cleanly
-/// into 32 bytes with no trailing pad.
-///
-/// Queued via `BrushGpuContext::queue_dab` into the shared byte-buffer
-/// `pending_dab_bytes`. Other dab-batching terminals (watercolor_batched)
-/// push their own record types into the same buffer — the brush graph
-/// has at most one dab-batching terminal at a time, so the bytes are
-/// unambiguous.
-#[repr(C)]
-#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
-pub struct PaintDabRecord {
-    /// Pen tip in **canvas pixels** (subtracted from layer offset in shader).
-    pub pos: [f32; 2],
-    /// Disc radius in canvas pixels (dab covers `pos ± radius`).
-    pub radius: f32,
-    /// Edge softness as fraction of radius. 0 = hard, 1 = fully feathered.
-    pub softness: f32,
-    /// Premultiplied paint color (rgba). Flow already multiplied in upstream.
-    pub color: [f32; 4],
-}
-
 /// Everything a GPU brush node needs to record render passes.
 ///
 /// Created once per rendering batch (per-segment in divergence, per-frame
@@ -295,15 +269,10 @@ pub struct BrushGpuContext<'a> {
 }
 
 impl<'a> BrushGpuContext<'a> {
-    /// Submit the batched encoder and consume the context.
-    ///
-    /// All dab render passes in this batch are submitted in a single
-    /// `queue.submit()` call — no per-dab submission needed thanks to
-    /// dynamic uniform buffer offsets.
-    ///
-    /// Returns the per-context perf counters so the caller can `+=` them
-    /// into the engine's stroke-level accumulator. The final submit's
-    /// wall clock is folded into `submit_us` before returning.
+    /// Submit the batched encoder and consume the context. Returns the
+    /// per-context perf counters so the caller can fold them into the
+    /// stroke-level accumulator; the final submit's wall clock is
+    /// included in `submit_us`.
     pub fn submit_final(mut self) -> BrushPerfCounters {
         let t = web_time::Instant::now();
         self.queue.submit([self.encoder.finish()]);
@@ -346,14 +315,42 @@ impl<'a> BrushGpuContext<'a> {
         }
     }
 
-    /// Queue a dab record into the shared byte buffer. The terminal
-    /// that owns `flush_dabs` reinterprets the bytes as its own record
-    /// type — see [`PaintDabRecord`] for the `paint` layout. The active
-    /// brush has exactly one dab-batching terminal in its graph, so the
-    /// bytes are unambiguous at flush time.
-    pub fn queue_dab<T: bytemuck::Pod>(&mut self, record: &T) {
-        self.pending_dab_bytes
-            .extend_from_slice(bytemuck::bytes_of(record));
+    /// Pack one dab record for the active compiled brush into
+    /// `pending_dab_bytes` and bump `pending_dab_count`. Every terminal
+    /// (paint, watercolor, smudge, liquify) calls this from its
+    /// `evaluate_gpu` after computing the per-dab geometry; the WGSL
+    /// terminal reinterprets the bytes via its dab layout at flush
+    /// time. The active brush has exactly one dab-batching terminal in
+    /// its graph, so the bytes are unambiguous.
+    ///
+    /// `slot_outputs_owned` must have been populated by the runner's
+    /// `dispatch_gpu` before this call — that's the source of the
+    /// per-node field values the compiled record packer reads.
+    pub fn queue_dab(
+        &mut self,
+        compiled: &CompiledBrush,
+        position: [f32; 2],
+        bbox_radius: f32,
+        radius: f32,
+    ) {
+        let record_start = self.pending_dab_bytes.len();
+        super::wgsl_compile::pack_intrinsic_dab_header(
+            &mut self.pending_dab_bytes,
+            position,
+            bbox_radius,
+            radius,
+        );
+        let outputs = self
+            .slot_outputs_owned
+            .as_ref()
+            .expect("queue_dab requires slot_outputs_owned on gpu_context");
+        super::wgsl_compile::pack_dab_record(compiled, outputs, &mut self.pending_dab_bytes);
+        // Pad to the full record size so the next dab starts aligned.
+        let written = self.pending_dab_bytes.len() - record_start;
+        if written < compiled.dab_record_size {
+            self.pending_dab_bytes
+                .resize(record_start + compiled.dab_record_size, 0);
+        }
         self.pending_dab_count = self.pending_dab_count.saturating_add(1);
         debug_assert!(
             self.pending_dab_count <= MAX_DABS_PER_PHASE,
@@ -443,43 +440,25 @@ impl<'a> BrushGpuContext<'a> {
     /// Compute the layer-clipped per-dab footprint, push the canvas-space
     /// write bbox (so save_points / checkpoints cover the real damage
     /// region), and snapshot the scratch under the dab into
-    /// `scratch read mirror`. Returns `None` if the dab footprint doesn't overlap
-    /// the layer (early-out for the caller — typically `return vec![]`).
+    /// `scratch read mirror`. Returns `None` if the dab footprint doesn't
+    /// overlap the layer (early-out for the caller — typically `return
+    /// vec![]`).
     ///
-    /// Centralizes the canvas → layer-local translation that every brush
-    /// terminal needs (color_output, watercolor, liquify). Getting it
-    /// wrong manifests as strokes/warps shifted by `(offset_x, offset_y)`
-    /// on grown / paste-extent layers — see the liquify regression in
-    /// `tests/liquify.rs::warp_position_correct_on_offset_layer`.
-    ///
-    /// `half_w` / `half_h` are the dab's half-extent in canvas pixels,
-    /// pre-clip. For a normal stamp dab pass `dab_w * 0.5` / `dab_h * 0.5`;
-    /// for liquify pass `radius + displacement` (its disc plus the
-    /// bilinear-sample padding).
-    pub fn prepare_dab_canvas_copy(
-        &mut self,
-        position: [f32; 2],
-        half_w: f32,
-        half_h: f32,
-    ) -> Option<DabFootprint> {
-        self.prepare_dab_canvas_copy_split(position, half_w, half_h, half_w, half_h)
-    }
-
-    /// Generalization of [`Self::prepare_dab_canvas_copy`] that lets callers
-    /// pass distinct write and read half-extents. The write region is the
-    /// dab footprint (`position ± write_half`); the read region is the
-    /// scratch-mirror snapshot footprint (`position ± read_half`). Read
-    /// must be at least as large as write, but a brush that samples the
-    /// scratch at an offset (smudge: per-dab `−motion`; clone: a stroke-
-    /// scoped anchor) sizes the read region wider so the offset sample
-    /// always lies inside the snapshot.
+    /// The write region is the dab footprint (`position ± write_half`);
+    /// the read region is the scratch-mirror snapshot footprint
+    /// (`position ± read_half`). Read must be at least as large as write,
+    /// but a brush that samples the scratch at an offset (smudge: per-dab
+    /// `−motion`; clone: a stroke-scoped anchor) sizes the read region
+    /// wider so the offset sample always lies inside the snapshot. For a
+    /// symmetric dab pass equal write/read halves (e.g. `radius`,
+    /// `radius`, `radius`, `radius`).
     ///
     /// The returned `DabFootprint`'s `origin/size` describe the write
     /// region (so the brush's render-pass viewport covers exactly the
     /// dab footprint); `copy_canvas_origin/copy_local_origin/copy_size`
     /// describe the (larger) read region, matching the read-mirror copy
     /// just issued.
-    pub fn prepare_dab_canvas_copy_split(
+    pub fn prepare_dab_canvas_copy(
         &mut self,
         position: [f32; 2],
         write_half_w: f32,

--- a/crates/darkly/src/brush/mod.rs
+++ b/crates/darkly/src/brush/mod.rs
@@ -175,7 +175,7 @@ pub fn default_graph() -> crate::nodegraph::Graph<BrushWireType> {
     let stamp = graph.add_node(
         "stamp",
         registry.get("stamp").unwrap().ports.clone(),
-        vec![ParamValue::Int(0)], // AlphaMask
+        vec![],
     );
     let terminal = graph.add_node(
         "paint",
@@ -212,9 +212,10 @@ pub fn default_graph() -> crate::nodegraph::Graph<BrushWireType> {
 /// Compile any brush graph into a ready-to-run runner.
 ///
 /// Generates the per-brush WGSL fragment shader and attaches it to
-/// the runner when the graph has a terminal. Brush load fails (with
-/// a string-form `GraphError`-ish error coerced via `panic!` ⇒ TODO)
-/// when any upstream node lacks a `compile_wgsl` implementation.
+/// the runner when the graph has a terminal. WGSL compile failures
+/// (e.g. an upstream node with no `compile_wgsl` implementation) are
+/// logged via `eprintln!` and surfaced as `GraphError::CycleDetected`
+/// so the engine's existing error path handles them.
 pub fn compile_graph(
     graph: &crate::nodegraph::Graph<BrushWireType>,
 ) -> Result<eval::BrushGraphRunner, crate::nodegraph::GraphError> {

--- a/crates/darkly/src/brush/nodes/liquify.rs
+++ b/crates/darkly/src/brush/nodes/liquify.rs
@@ -61,9 +61,8 @@ use crate::brush::pipeline::{
     BrushPipelineEntry, BrushPipelineRegistration, BuildContext, DynamicUniformRing,
 };
 use crate::brush::wgsl_compile::{
-    pack_dab_record, pack_intrinsic_dab_header, pack_intrinsic_uniforms, pack_uniforms,
-    CompileWgslCtx, CompiledBrush, DabField, IntrinsicUniforms, NodeWgsl, WgslType,
-    INTRINSIC_UNIFORMS_SIZE,
+    pack_intrinsic_uniforms, pack_uniforms, CompileWgslCtx, CompiledBrush, DabField,
+    IntrinsicUniforms, NodeWgsl, WgslType, INTRINSIC_UNIFORMS_SIZE,
 };
 use crate::brush::wire::{BrushWireType, ScalarValue};
 use crate::nodegraph::{NodeRegistration, PortDef, UnitType};
@@ -495,23 +494,7 @@ impl BrushNodeEvaluator for LiquifyEvaluator {
         let copy_canvas_y = read_y0.floor();
         Self::insert_copy_origin(gpu, ctx.node_id.0 as u32, [copy_canvas_x, copy_canvas_y]);
 
-        let record_start = gpu.pending_dab_bytes.len();
-        pack_intrinsic_dab_header(&mut gpu.pending_dab_bytes, position, bbox_radius, radius);
-        let outputs = gpu
-            .slot_outputs_owned
-            .as_ref()
-            .expect("liquify requires slot_outputs_owned on gpu_context");
-        pack_dab_record(&compiled, outputs, &mut gpu.pending_dab_bytes);
-        let written = gpu.pending_dab_bytes.len() - record_start;
-        if written < compiled.dab_record_size {
-            gpu.pending_dab_bytes
-                .resize(record_start + compiled.dab_record_size, 0);
-        }
-        gpu.pending_dab_count = gpu.pending_dab_count.saturating_add(1);
-        debug_assert!(
-            gpu.pending_dab_count <= MAX_DABS_PER_PHASE,
-            "liquify dab queue overflowed MAX_DABS_PER_PHASE"
-        );
+        gpu.queue_dab(&compiled, position, bbox_radius, radius);
 
         let meta = LiquifyDabMeta {
             position,
@@ -588,7 +571,13 @@ impl BrushNodeEvaluator for LiquifyEvaluator {
                 .write_buffer(&per_brush.dabs_buffer, 0, &dab_bytes);
 
             for (i, meta) in metas.iter().enumerate() {
-                let _ = gpu.prepare_dab_canvas_copy(meta.position, meta.half[0], meta.half[1]);
+                let _ = gpu.prepare_dab_canvas_copy(
+                    meta.position,
+                    meta.half[0],
+                    meta.half[1],
+                    meta.half[0],
+                    meta.half[1],
+                );
 
                 let scratch_ref = gpu
                     .scratch

--- a/crates/darkly/src/brush/nodes/paint.rs
+++ b/crates/darkly/src/brush/nodes/paint.rs
@@ -44,9 +44,8 @@ use crate::brush::pipeline::{
     BrushPipelineEntry, BrushPipelineRegistration, BuildContext, DynamicUniformRing,
 };
 use crate::brush::wgsl_compile::{
-    pack_dab_record, pack_intrinsic_dab_header, pack_intrinsic_uniforms, pack_uniforms,
-    CompileWgslCtx, CompiledBrush, InputBinding, IntrinsicUniforms, NodeWgsl,
-    INTRINSIC_UNIFORMS_SIZE,
+    pack_intrinsic_uniforms, pack_uniforms, CompileWgslCtx, CompiledBrush, InputBinding,
+    IntrinsicUniforms, NodeWgsl, INTRINSIC_UNIFORMS_SIZE,
 };
 use crate::brush::wire::{BrushWireType, ScalarValue};
 use crate::nodegraph::{NodeRegistration, PortDef, UnitType};
@@ -444,31 +443,7 @@ impl BrushNodeEvaluator for PaintEvaluator {
             None => [local_x0, local_y0, local_x1, local_y1],
         });
 
-        // Pack one dab record: intrinsic header + per-node fields.
-        // The outputs map for the packer was built by the runner's
-        // dispatch_gpu before this call (keyed by `n{id}_{port}`).
-        // Split-borrow `slot_outputs_owned` and `pending_dab_bytes`
-        // — they're disjoint fields, so no clone is needed. Cloning
-        // the HashMap per dab was a multi-millisecond-per-event
-        // disaster at high dab counts.
-        let record_start = gpu.pending_dab_bytes.len();
-        pack_intrinsic_dab_header(&mut gpu.pending_dab_bytes, position, bbox_radius, radius);
-        let outputs = gpu
-            .slot_outputs_owned
-            .as_ref()
-            .expect("paint requires slot_outputs_owned on gpu_context");
-        pack_dab_record(&compiled, outputs, &mut gpu.pending_dab_bytes);
-        // Pad to the full record size so the next dab starts aligned.
-        let written = gpu.pending_dab_bytes.len() - record_start;
-        if written < compiled.dab_record_size {
-            gpu.pending_dab_bytes
-                .resize(record_start + compiled.dab_record_size, 0);
-        }
-        gpu.pending_dab_count = gpu.pending_dab_count.saturating_add(1);
-        debug_assert!(
-            gpu.pending_dab_count <= MAX_DABS_PER_PHASE,
-            "paint dab queue overflowed MAX_DABS_PER_PHASE"
-        );
+        gpu.queue_dab(&compiled, position, bbox_radius, radius);
 
         vec![("dab_size".into(), ScalarValue::Vec2([diameter, diameter]))]
     }

--- a/crates/darkly/src/brush/nodes/smudge.rs
+++ b/crates/darkly/src/brush/nodes/smudge.rs
@@ -21,7 +21,7 @@
 //!    are skipped before queueing — `mix(bg, src, _)` collapses to
 //!    identity in that regime.
 //! 2. `flush_dabs` walks the queue in lockstep. For each dab it calls
-//!    `prepare_dab_canvas_copy_split` (asymmetric read region around
+//!    `prepare_dab_canvas_copy` (asymmetric read region around
 //!    the dab's footprint by `±|motion|` per axis) to sync the
 //!    scratch read mirror, then issues one render pass with instance
 //!    index `i..i+1` so the vertex stage reads `dab_records[i]`.
@@ -54,9 +54,8 @@ use crate::brush::pipeline::{
     BrushPipelineEntry, BrushPipelineRegistration, BuildContext, DynamicUniformRing,
 };
 use crate::brush::wgsl_compile::{
-    pack_dab_record, pack_intrinsic_dab_header, pack_intrinsic_uniforms, pack_uniforms,
-    CompileWgslCtx, CompiledBrush, DabField, IntrinsicUniforms, NodeWgsl, WgslType,
-    INTRINSIC_UNIFORMS_SIZE,
+    pack_intrinsic_uniforms, pack_uniforms, CompileWgslCtx, CompiledBrush, DabField,
+    IntrinsicUniforms, NodeWgsl, WgslType, INTRINSIC_UNIFORMS_SIZE,
 };
 use crate::brush::wire::{BrushWireType, ScalarValue};
 use crate::nodegraph::{NodeRegistration, PortDef, UnitType};
@@ -76,8 +75,8 @@ const STATIONARY_THRESHOLD_PX: f32 = 0.5;
 
 /// CPU-side per-dab footprint info, packed by `evaluate_gpu` in
 /// lockstep with the GPU dab record and drained by `flush_dabs`. Lets
-/// the flush loop call `prepare_dab_canvas_copy_split` without
-/// re-deriving the asymmetric footprint from the upload buffer.
+/// the flush loop call `prepare_dab_canvas_copy` without re-deriving
+/// the asymmetric footprint from the upload buffer.
 #[repr(C)]
 #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
 struct SmudgeDabMeta {
@@ -451,7 +450,7 @@ impl BrushNodeEvaluator for SmudgeEvaluator {
 
         // Pre-compute `copy_origin` (canvas-space top-left of the
         // mirror snapshot) using the same formula
-        // `prepare_dab_canvas_copy_split` will use at flush time. The
+        // `prepare_dab_canvas_copy` will use at flush time. The
         // CPU compute is deterministic from `position` + `read_half`;
         // the flush-time call re-derives the same value before issuing
         // the actual sync.
@@ -461,24 +460,7 @@ impl BrushNodeEvaluator for SmudgeEvaluator {
         let copy_canvas_y = read_y0.floor();
         Self::insert_copy_origin(gpu, ctx.node_id.0 as u32, [copy_canvas_x, copy_canvas_y]);
 
-        // Pack the GPU dab record: intrinsic header + node fields.
-        let record_start = gpu.pending_dab_bytes.len();
-        pack_intrinsic_dab_header(&mut gpu.pending_dab_bytes, position, bbox_radius, radius);
-        let outputs = gpu
-            .slot_outputs_owned
-            .as_ref()
-            .expect("smudge requires slot_outputs_owned on gpu_context");
-        pack_dab_record(&compiled, outputs, &mut gpu.pending_dab_bytes);
-        let written = gpu.pending_dab_bytes.len() - record_start;
-        if written < compiled.dab_record_size {
-            gpu.pending_dab_bytes
-                .resize(record_start + compiled.dab_record_size, 0);
-        }
-        gpu.pending_dab_count = gpu.pending_dab_count.saturating_add(1);
-        debug_assert!(
-            gpu.pending_dab_count <= MAX_DABS_PER_PHASE,
-            "smudge dab queue overflowed MAX_DABS_PER_PHASE"
-        );
+        gpu.queue_dab(&compiled, position, bbox_radius, radius);
 
         // Pack the CPU-side meta in lockstep.
         let meta = SmudgeDabMeta {
@@ -560,7 +542,7 @@ impl BrushNodeEvaluator for SmudgeEvaluator {
                 // Sync the mirror snapshot for this dab. The implicit
                 // barrier from this `copy_texture_to_texture` makes
                 // the subsequent render pass see prior dab writes.
-                let _ = gpu.prepare_dab_canvas_copy_split(
+                let _ = gpu.prepare_dab_canvas_copy(
                     meta.position,
                     meta.write_half[0],
                     meta.write_half[1],

--- a/crates/darkly/src/brush/nodes/stamp.rs
+++ b/crates/darkly/src/brush/nodes/stamp.rs
@@ -6,13 +6,6 @@
 //! emitted `dab` output is premultiplied RGBA that downstream paint
 //! terminals consume.
 //!
-//! ## AlphaMask only
-//!
-//! Only AlphaMask `application` is supported — it inlines as a scalar
-//! multiply. ImageStamp / LightnessMap / GradientMap need texture
-//! sampling that the inline-WGSL surface does not offer; any non-zero
-//! `application` value fails brush load with a clear error.
-//!
 //! ## Ignored ports
 //!
 //! `size_input`, `size`, `rotation`, `rotation_input`, `mirror_*`, and
@@ -24,7 +17,6 @@ use crate::brush::eval::{BrushNodeEvaluator, EvalContext};
 use crate::brush::node::BrushNodeRegistration;
 use crate::brush::wgsl_compile::{CompileWgslCtx, NodeWgsl};
 use crate::brush::wire::{BrushWireType, ScalarValue};
-use crate::gpu::params::ParamDef;
 use crate::nodegraph::{NodeRegistration, PortDef, UnitType};
 
 pub const TYPE_ID: &str = "stamp";
@@ -103,18 +95,7 @@ pub fn register() -> BrushNodeRegistration {
                 PortDef::output("preview", BrushWireType::Texture)
                     .with_description("Brush preview (unused)"),
             ],
-            params: &[
-                // Enum stored as Int. Only `Alpha Mask` (= 0) is
-                // supported on the compiled path; the other modes are
-                // listed here so old brush JSON deserializes without a
-                // schema mismatch, but `compile_wgsl` errors on any
-                // non-zero value.
-                ParamDef::Enum {
-                    name: "application",
-                    options: &["Alpha Mask", "Image Stamp", "Lightness Map", "Gradient Map"],
-                    default: 0,
-                },
-            ],
+            params: &[],
             is_gpu: true,
             is_terminal: false,
             supports_erase: true,
@@ -131,25 +112,11 @@ impl BrushNodeEvaluator for StampEvaluator {
 
     /// Inline `color × mask × flow` into the brush's WGSL. `tip`
     /// carries the upstream scalar coverage expression; the emitted
-    /// `dab` output is premultiplied RGBA. Errors on any `application`
-    /// mode other than AlphaMask — those would need texture sampling
-    /// which the inline-WGSL surface does not support.
+    /// `dab` output is premultiplied RGBA.
     fn compile_wgsl(&self, cctx: &CompileWgslCtx) -> Result<NodeWgsl, String> {
         let mut wgsl = NodeWgsl::default();
         if !cctx.consumed_outputs.contains("dab") {
             return Ok(wgsl);
-        }
-        let application = match cctx.params.first() {
-            Some(crate::gpu::params::ParamValue::Int(v)) => *v,
-            _ => 0,
-        };
-        if application != 0 {
-            return Err(format!(
-                "stamp.application = {application} (expected AlphaMask = 0); \
-                 ImageStamp / LightnessMap / GradientMap require a sampled \
-                 RGBA tip texture and are not supported. Use a procedural \
-                 tip (circle node) instead.",
-            ));
         }
         let mask = cctx.input("tip").as_f32();
         let color = cctx.input("color").as_vec4();

--- a/crates/darkly/src/brush/nodes/watercolor.rs
+++ b/crates/darkly/src/brush/nodes/watercolor.rs
@@ -49,8 +49,8 @@ use crate::brush::pipeline::{
     BrushPipelineEntry, BrushPipelineRegistration, BuildContext, DynamicUniformRing,
 };
 use crate::brush::wgsl_compile::{
-    pack_dab_record, pack_intrinsic_dab_header, pack_intrinsic_uniforms, pack_uniforms,
-    CompileWgslCtx, CompiledBrush, IntrinsicUniforms, NodeWgsl, WgslType, INTRINSIC_UNIFORMS_SIZE,
+    pack_intrinsic_uniforms, pack_uniforms, CompileWgslCtx, CompiledBrush, IntrinsicUniforms,
+    NodeWgsl, WgslType, INTRINSIC_UNIFORMS_SIZE,
 };
 use crate::brush::wire::{BrushWireType, ScalarValue};
 use crate::nodegraph::{NodeRegistration, PortDef, UnitType};
@@ -722,23 +722,7 @@ impl BrushNodeEvaluator for WatercolorEvaluator {
             None => [local_x0, local_y0, local_x1, local_y1],
         });
 
-        let record_start = gpu.pending_dab_bytes.len();
-        pack_intrinsic_dab_header(&mut gpu.pending_dab_bytes, position, bbox_radius, radius);
-        let outputs = gpu
-            .slot_outputs_owned
-            .as_ref()
-            .expect("watercolor requires slot_outputs_owned");
-        pack_dab_record(&compiled, outputs, &mut gpu.pending_dab_bytes);
-        let written = gpu.pending_dab_bytes.len() - record_start;
-        if written < compiled.dab_record_size {
-            gpu.pending_dab_bytes
-                .resize(record_start + compiled.dab_record_size, 0);
-        }
-        gpu.pending_dab_count = gpu.pending_dab_count.saturating_add(1);
-        debug_assert!(
-            gpu.pending_dab_count <= MAX_DABS_PER_PHASE,
-            "watercolor dab queue overflowed MAX_DABS_PER_PHASE"
-        );
+        gpu.queue_dab(&compiled, position, bbox_radius, radius);
 
         vec![("dab_size".into(), ScalarValue::Vec2([diameter, diameter]))]
     }

--- a/crates/darkly/src/brush/pipeline.rs
+++ b/crates/darkly/src/brush/pipeline.rs
@@ -1,6 +1,6 @@
 //! Central brush pipeline registry, plumbing pipelines, and shared infra.
 //!
-//! Each terminal-mode brush node (stamp, liquify, watercolor, …) declares
+//! Each brush terminal node (paint, liquify, watercolor, smudge) declares
 //! its own GPU pipeline alongside its node `register()` — see
 //! [`crate::brush::nodes`].  Their `BrushPipelineRegistration`s are
 //! harvested at [`BrushPipelines::new`] time and stored in a typed map.
@@ -8,9 +8,9 @@
 //! `scratch_blit_r8` — are format-bridging plumbing and live directly on
 //! [`BrushPipelines`].
 //!
-//! ## Per-mode pipeline contract
+//! ## Per-node pipeline contract
 //!
-//! Each per-mode pipeline:
+//! Each per-node pipeline:
 //!
 //! - is a `struct` implementing [`BrushPipelineEntry`];
 //! - is built by a `fn build(ctx: &BuildContext) -> Self` constructor;
@@ -112,16 +112,16 @@ pub fn align_up(value: u64, alignment: u64) -> u64 {
     (value + alignment - 1) & !(alignment - 1)
 }
 
-// ── Per-mode pipeline contract ───────────────────────────────────────────
+// ── Per-node pipeline contract ───────────────────────────────────────────
 
-/// Borrowed view of all shared brush infra a per-mode pipeline can read
+/// Borrowed view of all shared brush infra a per-node pipeline can read
 /// while it builds itself.  Constructed once by [`BrushPipelines::new`]
 /// and passed to every `BrushPipelineRegistration::build`.
 pub struct BuildContext<'a> {
     pub device: &'a wgpu::Device,
     pub queue: &'a wgpu::Queue,
     /// `group(0)` layout — single dynamic-offset uniform buffer.  Every
-    /// per-mode pipeline binds its dab uniforms here.
+    /// per-node pipeline binds its dab uniforms here.
     pub uniform_bgl: &'a wgpu::BindGroupLayout,
     /// Texture + linear sampler — bound where composites need to modulate
     /// fragment output by the selection mask.
@@ -141,7 +141,7 @@ impl<'a> BuildContext<'a> {
     /// Allocate the standard `(ring, bind_group)` pair every pipeline uses
     /// to feed its dynamic-offset uniform buffer.  Concentrates the
     /// `DynamicUniformRing::new` + `uniform_bgl` create_bind_group dance in
-    /// one place so per-mode `build()` functions don't repeat it.
+    /// one place so per-node `build()` functions don't repeat it.
     pub fn make_uniform_ring<U>(
         &self,
         label_ring: &str,
@@ -169,10 +169,10 @@ impl<'a> BuildContext<'a> {
     }
 }
 
-/// One per-mode brush pipeline, type-erased so the registry can store many
+/// One per-node brush pipeline, type-erased so the registry can store many
 /// kinds in a single map.  Consumers downcast via [`BrushPipelines::get`].
 ///
-/// Not `Sync`: per-mode pipelines own a [`DynamicUniformRing`] backed by
+/// Not `Sync`: per-node pipelines own a [`DynamicUniformRing`] backed by
 /// a `Cell<u32>` write cursor (intentional — see `DynamicUniformRing`'s
 /// doc).  The brush engine is single-threaded.
 pub trait BrushPipelineEntry: Any {
@@ -218,14 +218,14 @@ pub fn plumbing_registrations() -> Vec<BrushPipelineRegistration> {
     vec![crate::brush::composite_pipeline::composite_pipeline_registration()]
 }
 
-// ── BrushPipelines: shared infra + plumbing + per-mode registry ──────────
+// ── BrushPipelines: shared infra + plumbing + per-node registry ──────────
 
 /// Central brush GPU pipeline owner.
 ///
 /// Holds the bind-group layouts and samplers every brush composite
 /// shares, the three plumbing pipelines (`blit`, `mask_blit`,
 /// `scratch_blit_r8`) that have no owning node, and a typed map of
-/// per-mode pipelines harvested from every brush node's
+/// per-node pipelines harvested from every brush node's
 /// [`BrushNodeRegistration::pipelines`](crate::brush::node::BrushNodeRegistration).
 ///
 /// Constructed once at engine init.  See
@@ -259,7 +259,7 @@ pub struct BrushPipelines {
     mask_blit_pipeline: wgpu::RenderPipeline,
     scratch_blit_r8_pipeline: wgpu::RenderPipeline,
 
-    // ── Per-mode pipelines (modular, looked up by id) ────────────────
+    // ── Per-node pipelines (modular, looked up by id) ────────────────
     entries: HashMap<&'static str, Box<dyn BrushPipelineEntry>>,
 
     // ── Shared compiled-brush preview pipeline cache ─────────────────
@@ -546,7 +546,7 @@ impl BrushPipelines {
                 cache: None,
             });
 
-        // ── Per-mode pipelines: harvested from node registrations ──
+        // ── Per-node pipelines: harvested from node registrations ──
         let build_ctx = BuildContext {
             device,
             queue,
@@ -589,7 +589,7 @@ impl BrushPipelines {
         }
     }
 
-    /// BGL used by every per-mode pipeline's dynamic-offset uniform
+    /// BGL used by every per-node pipeline's dynamic-offset uniform
     /// buffer (group 0). Exposed so per-brush compiled pipelines
     /// built lazily after `BrushPipelines::new` can bind their own
     /// uniform ring against the same layout. See
@@ -598,7 +598,7 @@ impl BrushPipelines {
         &self.uniform_bgl
     }
 
-    /// Look up a per-mode pipeline by id.  Panics if the id is not
+    /// Look up a per-node pipeline by id.  Panics if the id is not
     /// registered or the type doesn't match — both are programming
     /// errors discovered at the first paint.
     pub fn get<P: BrushPipelineEntry>(&self, id: &'static str) -> &P {

--- a/crates/darkly/src/brush/state.rs
+++ b/crates/darkly/src/brush/state.rs
@@ -35,6 +35,8 @@ pub struct BrushState {
     /// double-click-to-reset on toolbar scrubs — reset returns to the
     /// brush's shipped value, not the node-type registration default.
     /// Keyed by (node_id, port_name); raw values (not display-space).
+    /// Written by `engine::brush_graph::snapshot_brush_defaults`; read
+    /// by the exposed-port query that builds `ExposedPortInfo`.
     pub defaults: HashMap<(NodeId, String), f32>,
 
     /// Bumped on every brush-graph mutation (`compile_active`). Used both

--- a/crates/darkly/tests/wgsl_compile.rs
+++ b/crates/darkly/tests/wgsl_compile.rs
@@ -3,14 +3,11 @@
 //!
 //! Asserts:
 //!
-//! 1. **Non-compilable graphs fail cleanly** — a graph wiring a node
-//!    that returns `Err` from `compile_wgsl` produces a `CompileError`
-//!    rather than panicking.
-//! 2. **Identical topologies hash to the same id** — two structurally
+//! 1. **Identical topologies hash to the same id** — two structurally
 //!    identical graphs (independent of node ID allocation) hash to the
 //!    same `topology_hash` so the per-brush pipeline cache shares
 //!    pipelines.
-//! 3. **The Rough Ink builtin compiles end-to-end** — the framework
+//! 2. **The Rough Ink builtin compiles end-to-end** — the framework
 //!    handles a real graph with random + curve + circle + stamp +
 //!    paint and produces non-empty WGSL.
 
@@ -38,61 +35,6 @@ fn empty_graph_errors_cleanly() {
     let err = compile_brush_to_wgsl(&graph, &plan, &evals())
         .expect_err("empty graph has no terminal — must error");
     assert!(matches!(err, CompileError::NoTerminal));
-}
-
-#[test]
-fn non_compilable_node_errors_with_type_id() {
-    // A `stamp` node with `application != AlphaMask` returns Err from
-    // `compile_wgsl` — the only built-in node that can fail to
-    // compile. The compiler must surface a `NodeNotCompilable`
-    // carrying the offending type_id rather than panicking.
-    let reg = registry();
-    let mut graph = Graph::<BrushWireType>::new();
-    let pen = graph.add_node(
-        "pen_input",
-        reg.get("pen_input").unwrap().ports.clone(),
-        vec![],
-    );
-    let circle = graph.add_node(
-        "circle",
-        reg.get("circle").unwrap().ports.clone(),
-        vec![darkly::gpu::params::ParamValue::Int(0)],
-    );
-    let stamp = graph.add_node(
-        "stamp",
-        reg.get("stamp").unwrap().ports.clone(),
-        // application = 1 → ImageStamp mode → compile_wgsl errors
-        vec![darkly::gpu::params::ParamValue::Int(1)],
-    );
-    let term = graph.add_node("paint", reg.get("paint").unwrap().ports.clone(), vec![]);
-    for (fnode, fport, tnode, tport) in [
-        (pen, "position", term, "position"),
-        (circle, "texture", stamp, "tip"),
-        (stamp, "dab", term, "rgba"),
-    ] {
-        graph
-            .connect(
-                PortRef {
-                    node: fnode,
-                    port: fport.into(),
-                },
-                PortRef {
-                    node: tnode,
-                    port: tport.into(),
-                },
-            )
-            .unwrap();
-    }
-    let plan = compile(&graph, reg.as_map()).unwrap();
-    let err = compile_brush_to_wgsl(&graph, &plan, &evals())
-        .expect_err("stamp.application != AlphaMask must fail to compile");
-    match err {
-        CompileError::NodeNotCompilable { type_id, reason } => {
-            assert_eq!(type_id, "stamp");
-            assert!(!reason.is_empty());
-        }
-        other => panic!("expected NodeNotCompilable, got {other:?}"),
-    }
 }
 
 #[test]


### PR DESCRIPTION
Brush subsystem slop + dead-code sweep

Mechanical pass over CODECLEANUP §3/§6 findings in the brush module.

## Changes

- **Drop `FORMAT_VERSION` shim.** Pre-release; no migrations. Removed
  the constant, the `format_version` field on `BrushMetadata`, the
  forward-version reject check in `Brush::from_bytes`, and the
  `future_version_rejected` test.

- **Fix the misleading `compile_graph` TODO doc.** The doc claimed
  errors propagated via `panic!`; the code uses `eprintln!` +
  `GraphError::CycleDetected`. Rewrote the doc to match what the code
  actually does.

- **Centralize per-dab record packing on `BrushGpuContext`.** The
  handoff prescribed deleting per-terminal `MAX_DABS_PER_PHASE`
  asserts on the assumption `queue_dab` was the central path; on
  inspection it was the opposite — `queue_dab<T: Pod>` was dead, the
  inert `PaintDabRecord` struct documented its layout, and all four
  terminals had bit-identical 11-line `header + record + pad +
  count++ + assert` blocks. Replaced the dead helper with a real
  `queue_dab(&CompiledBrush, position, bbox_radius, radius)` that
  packs the intrinsic header, dispatches to `pack_dab_record`, pads
  to `dab_record_size`, increments the count and asserts. paint,
  watercolor, smudge, liquify each collapse from 11 lines to one
  call. Deletes the unused `PaintDabRecord` and the per-terminal
  asserts/imports.

- **Extract `build_eval_ctx`.** Three near-identical `EvalContext`
  construction blocks in `execute_cpu`, `dispatch_gpu`,
  `dispatch_lifecycle` collapse to a single free function. Empty
  param/port slices use `&[]` (no per-call `Vec::new()`).

- **Delete the dead `stamp.application` enum variants and param.**
  Only `AlphaMask` was supported; the other three rejected at
  compile-time. Removed the param entirely (single-option enum is
  meaningless), the unreachable error branch in `compile_wgsl`, the
  `ParamValue::Int(0)` at the three stamp callers, and the
  `non_compilable_node_errors_with_type_id` test that depended on the
  failure path.

- **Pointer to `BrushState.defaults` consumer.** Field has a live
  reader (`engine::brush_graph` builds `ExposedPortInfo` reset
  defaults from it); added a doc line so future sweeps don't re-flag.

- **Delete `let _spacing = …` no-op in `checkpoint_ring` test.**

- **Collapse `prepare_dab_canvas_copy` wrapper.** The 3-arg wrapper
  forwarded to the 5-arg `_split` form with `read == write`. Deleted
  the wrapper, renamed `_split` → `prepare_dab_canvas_copy`. Liquify
  passes its half twice (symmetric); smudge unchanged shape, just
  renamed.

- **Trim over-explained docstrings.** `submit_final` and
  `EvalContext` doc lose the obvious parts; the load-bearing perf
  rationale on `EvalContext::input`'s linear scan stays.

- **Rephrase the "per-mode" vocabulary.** Brushes are no longer
  enum-dispatched; replaced `per-mode` with `per-node` throughout
  `pipeline.rs` (and rewrote a header line that also still said
  "terminal-mode").

## Skipped

- **`stamp.preview` output port.** The brush-preview handoff is still
  queued and explicitly identifies this port as the recovery anchor
  for the brush-shape-aware hover cursor; left in place per the
  handoff's instruction.

## Test plan

- `cargo fmt --all -- --check` ✓
- `cargo clippy --workspace --all-targets --exclude darkly-wasm -- -D warnings` ✓
- `cargo clippy -p darkly-wasm --target wasm32-unknown-unknown ...` ✓
- `cargo test --workspace --exclude darkly-wasm -- --test-threads=1` ✓
- `wasm-pack build --release --target web` ✓
- `tsc --noEmit` + `vitest` + `vite build` ✓
