### PR TITLE
Brush gpu context decompose

### DIFF
--- a/crates/darkly/src/brush/eval.rs
+++ b/crates/darkly/src/brush/eval.rs
@@ -295,8 +295,8 @@ pub trait BrushNodeEvaluator: Send + Sync {
     ///
     /// Terminal nodes that own preview rendering (e.g. `color_output`)
     /// also override this — they read a `brush_preview` input texture and
-    /// blit it into `gpu.preview_mask_view`, then publish placement info
-    /// via `gpu.brush_preview_info`.
+    /// blit it into `gpu.preview.mask_view`, then publish placement info
+    /// via `gpu.preview.info`.
     fn render_preview(
         &self,
         ctx: &EvalContext,
@@ -765,7 +765,7 @@ impl BrushGraphRunner {
     /// produce shape-appropriate outputs (e.g. stamp emits a B&W tip
     /// texture sized to the brush's canvas-pixel extent), terminals
     /// consume them and render into the overlay's preview mask, publishing
-    /// placement info via `gpu.brush_preview_info`.
+    /// placement info via `gpu.preview.info`.
     pub fn render_preview_pipeline(&mut self, gpu: &mut BrushGpuContext) {
         self.dispatch_gpu(gpu, |ev, ctx, gpu| ev.render_preview(ctx, gpu));
     }

--- a/crates/darkly/src/brush/eval.rs
+++ b/crates/darkly/src/brush/eval.rs
@@ -225,21 +225,16 @@ fn remap_scalar(value: f32, src: (f32, f32), dst: (f32, f32)) -> f32 {
 /// declaration plus the enum dispatch below.
 fn apply_lifecycle(lifecycle: super::node::Lifecycle, gpu: &mut BrushGpuContext) {
     use super::node::Lifecycle;
+    let Some(stroke) = &gpu.stroke else { return };
     match lifecycle {
         Lifecycle::None => {}
         Lifecycle::ClearScratchToTransparent => {
-            if let Some(scratch) = gpu.scratch.as_deref() {
-                scratch.clear_to_transparent(&mut gpu.encoder);
-            }
+            stroke.scratch.clear_to_transparent(&mut gpu.encoder);
         }
         Lifecycle::SeedScratchFromPreStroke => {
-            let Some(pre_stroke) = gpu.pre_stroke_texture else {
-                return;
-            };
-            let Some(scratch) = gpu.scratch.as_deref() else {
-                return;
-            };
-            scratch.seed_from_pre_stroke(&mut gpu.encoder, pre_stroke);
+            stroke
+                .scratch
+                .seed_from_pre_stroke(&mut gpu.encoder, stroke.pre_stroke_texture);
         }
     }
 }
@@ -792,8 +787,8 @@ impl BrushGraphRunner {
         // these to pack per-dab records and uniforms.
         let is_compiled = self.compiled.is_some();
         if let Some(compiled) = &self.compiled {
-            gpu.compiled_brush = Some(compiled.clone());
-            gpu.slot_outputs_owned = Some(self.build_slot_outputs());
+            gpu.dab_batch.compiled_brush = Some(compiled.clone());
+            gpu.dab_batch.slot_outputs = Some(self.build_slot_outputs());
         }
 
         let n = self.plan.steps.len();
@@ -874,7 +869,7 @@ impl BrushGraphRunner {
     /// needs it cleared at stroke-start; no point copy-pasting that
     /// line per terminal.
     pub fn begin_stroke(&mut self, gpu: &mut BrushGpuContext) {
-        gpu.clear_pending_dabs();
+        gpu.dab_batch.clear();
         let registry = crate::brush::registry();
         self.dispatch_lifecycle(gpu, false, |type_id, ev, ctx, gpu| {
             let lifecycle = registry

--- a/crates/darkly/src/brush/gpu_context.rs
+++ b/crates/darkly/src/brush/gpu_context.rs
@@ -29,11 +29,10 @@ pub const MAX_PREVIEW_MASK_SIDE: u32 = 512;
 /// so the linear-upsampling overlay sample has enough texels to read.
 pub const MIN_PREVIEW_MASK_SIDE: u32 = 128;
 
-/// Brush perf counters. Lives both per-`BrushGpuContext` (drained at
-/// `submit_final`) and per-engine (accumulated across all contexts of a
-/// stroke via [`AddAssign`]). The bench harness reads interval-deltas
-/// against the engine-side accumulator via
-/// [`crate::engine::BrushPerfDelta::between`].
+/// Per-context brush perf counters. Drained at `submit_final` and folded
+/// into the engine-side accumulator via [`AddAssign`]. Engine-only events
+/// (mid-stroke full re-renders) live directly on `DarklyEngine`, not on
+/// this struct — the per-context value would always be zero.
 ///
 /// `submit_us` is wall-clock around `queue.submit()`. The per-flush
 /// counters describe workload (dab volume, union-bbox area), not host
@@ -43,10 +42,6 @@ pub struct BrushPerfCounters {
     /// Number of `place_dab` invocations during this counter's lifetime.
     /// Exposed by `engine.test_stroke_total_dabs()` for integration tests.
     pub dabs_placed: u32,
-    /// Number of mid-stroke full-re-render fallbacks. Per-engine only —
-    /// per-context value is always zero. Exposed by
-    /// `engine.test_stroke_full_rerender_events()`.
-    pub full_rerender_events: u32,
     /// Wall-clock microseconds inside `queue.submit()` (final + ring-flush).
     pub submit_us: u64,
     /// Number of `queue.submit()` calls.
@@ -95,13 +90,9 @@ impl BrushPerfCounters {
 impl std::ops::AddAssign for BrushPerfCounters {
     /// Merge per-context counters into the engine-side stroke accumulator
     /// (or any two accumulators in general). Scalars saturating-add;
-    /// per-flush vectors append in order. `full_rerender_events` is
-    /// per-engine state; per-context counters always contribute zero.
+    /// per-flush vectors append in order.
     fn add_assign(&mut self, mut rhs: Self) {
         self.dabs_placed = self.dabs_placed.saturating_add(rhs.dabs_placed);
-        self.full_rerender_events = self
-            .full_rerender_events
-            .saturating_add(rhs.full_rerender_events);
         self.submit_us = self.submit_us.saturating_add(rhs.submit_us);
         self.submits = self.submits.saturating_add(rhs.submits);
         self.dab_flushes = self.dab_flushes.saturating_add(rhs.dab_flushes);
@@ -119,10 +110,222 @@ impl std::ops::AddAssign for BrushPerfCounters {
 /// any dab-batching terminal. Sized so the per-phase dab buffer is
 /// trivial VRAM cost (16384 records × ~32-byte typical record ≈ 512
 /// KB) and well above what any realistic stroke phase will reach
-/// (~30 dabs even at high stabilisation). `queue_dab` debug-asserts
-/// on this — overflow panics loudly in test/dev so the constant gets
-/// bumped rather than silently truncating in release.
+/// (~30 dabs even at high stabilisation). `DabBatch::queue_dab`
+/// debug-asserts on this — overflow panics loudly in test/dev so the
+/// constant gets bumped rather than silently truncating in release.
 pub const MAX_DABS_PER_PHASE: u32 = 16384;
+
+/// Resources needed to render to a real paint target — present during a
+/// real stroke and during the palette-thumbnail render, absent during a
+/// cursor-hover preview where the terminal writes to the overlay mask
+/// instead.
+///
+/// Bundling these four fields together makes their joint Some-ness a
+/// type-level invariant: a code path that holds a `&StrokeResources`
+/// can rely on the scratch *and* the pre-stroke snapshot being live.
+/// Read-mirror / write-bbox helpers hang off this struct so consumers
+/// reach for "the stroke" rather than picking individual fields out of a
+/// flat bag.
+pub struct StrokeResources<'a> {
+    /// The stroke scratch (write side + R/W-hazard read mirror).
+    /// Held mutably so the read mirror can lazy-grow to fit the current
+    /// dab's footprint.
+    pub scratch: &'a mut Scratch,
+    /// The paint target the terminal is committing to: a layer (RGBA8)
+    /// or mask (R8). Format awareness lives in `GpuPaintTarget`'s brush
+    /// extension (`commit_brush_dab`, `save_pre_stroke_snapshot`,
+    /// `commit_scratch_blit`) — terminals call uniform methods on the
+    /// paint target and never branch on R8 vs RGBA8.
+    pub paint_target: GpuPaintTarget<'a>,
+    /// Pre-stroke layer snapshot. Supplied by `StrokeBuffer::save_pre_stroke`
+    /// at the start of a stroke.
+    pub pre_stroke_texture: &'a wgpu::Texture,
+    /// Bind group (canvas-copy BGL) over `pre_stroke_texture`, pre-built
+    /// by `StrokeBuffer` so `color_output::commit` can bind it as the
+    /// composite background without recreating bind groups every event.
+    pub pre_stroke_bind_group: &'a wgpu::BindGroup,
+}
+
+/// Cursor-hover preview state. Populated by `brush_graph::regenerate_brush_preview`
+/// to drive the overlay's preview-mask texture; absent during a real stroke.
+pub struct PreviewState<'a> {
+    /// Preview mask target. Populated by the engine during preview regen;
+    /// terminal `render_preview` hooks blit their preview texture into it.
+    ///
+    /// Used as the fallback when `mask_overlay` is `None` — tests
+    /// pre-allocate a fixed-size mask and stuff a view in here. The
+    /// engine driver leaves this `None` and grows the mask on demand
+    /// via [`BrushGpuContext::ensure_preview_mask`] through
+    /// `mask_overlay`.
+    pub mask_view: Option<&'a wgpu::TextureView>,
+    pub mask_size: (u32, u32),
+    /// Mutable handle to the overlay that owns the preview-mask texture.
+    /// Held by the engine driver so a terminal's `render_preview` can
+    /// grow the mask via [`BrushGpuContext::ensure_preview_mask`] when
+    /// the brush's bbox would otherwise stairstep through the overlay's
+    /// linear sampler. `None` in tests that build the context manually
+    /// with a fixed-size pre-allocated mask.
+    pub mask_overlay: Option<&'a mut ToolOverlay>,
+    /// Set by a terminal's `render_preview` hook to publish overlay
+    /// placement info (extent + rotation) to the engine. The engine reads
+    /// this after `render_preview_pipeline` returns. `None` outside the
+    /// preview path; first-write-wins if multiple terminals try to publish
+    /// (unusual — typically one terminal owns the preview).
+    pub info: Option<BrushPreviewInfo>,
+}
+
+/// Per-batch dab ledger. Populated by whichever dab-batching terminal is
+/// active in the graph during a single pen event and drained by that
+/// terminal's `flush_dabs` hook. Always present on `BrushGpuContext`
+/// (empty when no terminal queues anything — cursor-hover, no-op
+/// strokes); methods hang off it so the per-batch lifecycle is visible
+/// at the call site.
+///
+/// A brush graph has at most one dab-batching terminal at a time, so
+/// the byte layouts of `bytes` and `meta_bytes` are unambiguous — each
+/// terminal reinterprets via `bytemuck::cast_slice` against its own
+/// record type.
+#[derive(Default)]
+pub struct DabBatch {
+    /// Dabs queued during a single pen event. Bytes written by
+    /// `bytemuck::bytes_of` on each terminal's own record struct — the
+    /// WGSL binding reinterprets them as that terminal's `Dab` type.
+    /// Empty for brushes that don't use a dab-batching terminal.
+    pub bytes: Vec<u8>,
+    /// Number of dab records currently in `bytes`. Each terminal's
+    /// record size is constant per terminal, so `bytes.len() == count *
+    /// sizeof(Record)`; the count is tracked explicitly so flush code
+    /// doesn't need to know the record size.
+    pub count: u32,
+    /// Layer-local bounding box covered by the queued dabs, as
+    /// `[x0, y0, x1, y1]`. The terminal's `flush_dabs` reads it as a
+    /// workload metric (recorded into `BrushPerfCounters` for the bench
+    /// harness). `None` when the queue is empty.
+    pub bbox: Option<[u32; 4]>,
+    /// Terminal-private per-dab CPU meta, packed by `evaluate_gpu` in
+    /// lockstep with [`Self::bytes`] and drained by the terminal's
+    /// `flush_dabs` hook. Only used by per-dab-feedback terminals
+    /// (`smudge`, `liquify`) that need CPU-side state at flush time to
+    /// drive mirror-snapshot copies without re-deriving footprints from
+    /// GPU memory. The framework doesn't interpret these bytes — the
+    /// owning terminal reinterprets them via `bytemuck::cast_slice`
+    /// against its own meta record struct.
+    pub meta_bytes: Vec<u8>,
+    /// Union of canvas-pixel rects the current dab's passes write to.
+    /// The node that issues the write is the only thing that knows the
+    /// real footprint — `stroke_engine` can't derive it from `info.pos`
+    /// because the graph may offset the dab (scatter, wobble, future
+    /// position-modulating nodes). Each pass unions its rect into this
+    /// via [`Self::push_write_bbox`]; `stroke_engine` reads it after
+    /// `execute_gpu` for the save-point bbox and resets it before the
+    /// next dab.
+    pub write_canvas_bbox: Option<crate::coord::CanvasRect>,
+    /// Compiled WGSL for this brush, populated by the engine before
+    /// stroke evaluation. Read by the terminal's `evaluate_gpu` and
+    /// `flush_dabs` to know the dab record / uniform layouts and the
+    /// pipeline topology hash.
+    pub compiled_brush: Option<Arc<CompiledBrush>>,
+    /// Name → value map of every output slot in the brush graph, built
+    /// by the runner's `dispatch_gpu` immediately after `execute_cpu`
+    /// and held for the duration of the dispatch pass. Keys follow the
+    /// `n{node_id}_{port_name}` convention used by
+    /// [`crate::brush::wgsl::CompileWgslCtx::dab_field_name`]. The
+    /// terminal reads from this to pack per-dab records and uniforms.
+    pub slot_outputs: Option<HashMap<String, ScalarValue>>,
+}
+
+impl DabBatch {
+    /// Pack one dab record for the active compiled brush into [`Self::bytes`]
+    /// and bump [`Self::count`]. Every terminal (paint, watercolor, smudge,
+    /// liquify) calls this from its `evaluate_gpu` after computing the
+    /// per-dab geometry; the WGSL terminal reinterprets the bytes via its
+    /// dab layout at flush time.
+    ///
+    /// [`Self::slot_outputs`] must have been populated by the runner's
+    /// `dispatch_gpu` before this call — that's the source of the per-node
+    /// field values the compiled record packer reads.
+    pub fn queue_dab(
+        &mut self,
+        compiled: &CompiledBrush,
+        position: [f32; 2],
+        bbox_radius: f32,
+        radius: f32,
+    ) {
+        let record_start = self.bytes.len();
+        super::wgsl::pack_intrinsic_dab_header(&mut self.bytes, position, bbox_radius, radius);
+        let outputs = self
+            .slot_outputs
+            .as_ref()
+            .expect("queue_dab requires slot_outputs on DabBatch");
+        super::wgsl::pack_dab_record(compiled, outputs, &mut self.bytes);
+        // Pad to the full record size so the next dab starts aligned.
+        let written = self.bytes.len() - record_start;
+        if written < compiled.dab_record_size {
+            self.bytes
+                .resize(record_start + compiled.dab_record_size, 0);
+        }
+        self.count = self.count.saturating_add(1);
+        debug_assert!(
+            self.count <= MAX_DABS_PER_PHASE,
+            "dab queue overflowed MAX_DABS_PER_PHASE ({MAX_DABS_PER_PHASE}); \
+             bump the constant or flush more often",
+        );
+    }
+
+    /// Drain the compute-dab queue. Returns the raw bytes (caller
+    /// reinterprets via `bytemuck::cast_slice`) and the dab count. Also
+    /// clears [`Self::bbox`]. The terminal-private [`Self::meta_bytes`]
+    /// is *not* drained here — the caller drains it directly via
+    /// [`Self::take_meta`] when it needs to walk per-dab meta inside its
+    /// `flush_dabs` loop. Called from a terminal's `flush_dabs` hook
+    /// once the dispatch is encoded.
+    pub fn take(&mut self) -> (Vec<u8>, u32) {
+        let bytes = std::mem::take(&mut self.bytes);
+        let count = std::mem::take(&mut self.count);
+        self.bbox = None;
+        (bytes, count)
+    }
+
+    /// Drain the per-dab CPU meta queue. Symmetric with [`Self::take`];
+    /// callers `bytemuck::cast_slice` the returned bytes against their
+    /// meta record type.
+    pub fn take_meta(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.meta_bytes)
+    }
+
+    /// Discard the compute-dab queue without dispatching. Used at stroke
+    /// begin / rewind to drop any state from a prior context, and by
+    /// `flush_dabs` when its early-out path runs (empty queue, no
+    /// scratch, etc.) so a follow-up dispatch doesn't see stale state.
+    pub fn clear(&mut self) {
+        self.bytes.clear();
+        self.count = 0;
+        self.bbox = None;
+        self.meta_bytes.clear();
+    }
+
+    /// Union a write-pass footprint into [`Self::write_canvas_bbox`].
+    /// Called by any GPU node whose pass writes to the stroke scratch,
+    /// so `stroke_engine` can record a save-point bbox that matches what
+    /// was actually drawn.
+    pub fn push_write_bbox(&mut self, bbox: crate::coord::CanvasRect) {
+        if bbox.is_empty() {
+            return;
+        }
+        self.write_canvas_bbox = Some(match self.write_canvas_bbox {
+            Some(prev) => prev.union(bbox),
+            None => bbox,
+        });
+    }
+}
+
+impl<'a> StrokeResources<'a> {
+    /// Reset the per-dab read-mirror cache so the first node that needs
+    /// the read mirror this dab actually issues a fresh copy.
+    pub fn reset_per_dab_read_cache(&mut self) {
+        self.scratch.reset_read_origin_cache();
+    }
+}
 
 /// Everything a GPU brush node needs to record render passes.
 ///
@@ -131,141 +334,47 @@ pub const MAX_DABS_PER_PHASE: u32 = 16384;
 /// records its render passes into the encoder.  Dynamic uniform buffer
 /// offsets allow all dabs to share one encoder without per-dab submission.
 /// Call `submit_final()` when the batch is complete.
+///
+/// Fields fall into three groups:
+///
+/// - **Always-present GPU primitives** (encoder, device, queue, pipelines,
+///   selection bind group, canvas dims, blend mode, perf): used by every
+///   path; live flat on the struct because there's no mode-dependence to
+///   encode.
+/// - **Mode-dependent state** (`stroke`, `preview`): grouped into
+///   `Option`-wrapped sub-structs. `stroke` is `Some` during a real
+///   stroke or palette-thumbnail render; `preview` is `Some` during
+///   cursor-hover preview regen. The two are mutually exclusive in
+///   practice, but the type does not enforce it — only their joint
+///   construction at the engine boundary does.
+/// - **Per-batch ledger** (`dab_batch`): the dab-queueing machinery the
+///   compiled brush populates. Always present; default-empty when no
+///   terminal queues anything.
 pub struct BrushGpuContext<'a> {
     pub encoder: wgpu::CommandEncoder,
     pub device: &'a wgpu::Device,
     pub queue: &'a wgpu::Queue,
     pub pipelines: &'a BrushPipelines,
-    /// The stroke scratch (write side + R/W-hazard read mirror).
-    /// `Some` during stroke evaluation and palette-thumbnail rendering;
-    /// `None` in cursor-preview mode where only `render_preview_pipeline`
-    /// runs (no scratch is needed because the preview writes to
-    /// `preview_mask_view` instead).
-    ///
-    /// Held mutably so `prepare_dab_canvas_copy` can lazy-grow the read
-    /// mirror to fit the current dab's footprint.
-    pub scratch: Option<&'a mut Scratch>,
-    pub canvas_width: u32,
-    pub canvas_height: u32,
-    /// The paint target the terminal is committing to: a layer (RGBA8) or
-    /// mask (R8). `None` in preview mode (no commit happens).
-    ///
-    /// Replaces the loose `layer_view` / `layer_texture` / `layer_width` /
-    /// `layer_height` / `layer_offset_x` / `layer_offset_y` fields. All those
-    /// values are now `gpu.paint_target.X`. Format awareness lives in
-    /// `GpuPaintTarget`'s brush extension (`commit_brush_dab`,
-    /// `save_pre_stroke_snapshot`, `commit_scratch_blit`) — terminals call
-    /// uniform methods on the paint target and never branch on R8 vs RGBA8.
-    pub paint_target: Option<GpuPaintTarget<'a>>,
     /// Selection mask bind group (or default 1x1 white when no selection).
     pub selection_bind_group: &'a wgpu::BindGroup,
-    /// In cursor-preview mode where `scratch` is `None`, this is the
-    /// preview render target view that terminals' `render_preview` hooks
-    /// write into.  Aliased only for codepaths that need *some* texture
-    /// view (e.g. early-out checks).  `None` in stroke mode.
-    pub preview_target_view: Option<&'a wgpu::TextureView>,
+    pub canvas_width: u32,
+    pub canvas_height: u32,
     /// Composite blend mode override: 0 = source-over (paint), 1 = destination-out (erase).
     /// Set per-stroke by the engine based on the active tool.
     pub blend_mode: u32,
-    /// Preview mask target. Populated by the engine during preview regen;
-    /// terminal `render_preview` hooks blit their preview texture into it.
-    /// `None` during stroke evaluation (the preview path isn't running).
-    ///
-    /// Used as the fallback when `preview_mask_overlay` is `None` —
-    /// tests pre-allocate a fixed-size mask and stuff a view in here.
-    /// The engine driver leaves this `None` and grows the mask on
-    /// demand via [`Self::ensure_preview_mask`] through
-    /// `preview_mask_overlay`.
-    pub preview_mask_view: Option<&'a wgpu::TextureView>,
-    pub preview_mask_size: (u32, u32),
-    /// Mutable handle to the overlay that owns the preview-mask
-    /// texture. Held by the engine driver so a terminal's
-    /// `render_preview` can grow the mask via
-    /// [`Self::ensure_preview_mask`] when the brush's bbox would
-    /// otherwise stairstep through the overlay's linear sampler.
-    /// `None` in tests that build the context manually with a
-    /// fixed-size pre-allocated mask.
-    pub preview_mask_overlay: Option<&'a mut ToolOverlay>,
-    /// Set by a terminal's `render_preview` hook to publish overlay
-    /// placement info (extent + rotation) to the engine. The engine reads
-    /// this after `render_preview_pipeline` returns. `None` outside the
-    /// preview path; first-write-wins if multiple terminals try to publish
-    /// (unusual — typically one terminal owns the preview).
-    pub brush_preview_info: Option<BrushPreviewInfo>,
-    /// Pre-stroke layer snapshot. Supplied by `StrokeBuffer::save_pre_stroke`
-    /// at the start of a stroke. `Some` during a stroke, `None` in preview.
-    pub pre_stroke_texture: Option<&'a wgpu::Texture>,
-    /// Bind group (canvas-copy BGL) over `pre_stroke_texture`, pre-built
-    /// by `StrokeBuffer` so `color_output::commit` can bind it as the
-    /// composite background without recreating bind groups every event.
-    pub pre_stroke_bind_group: Option<&'a wgpu::BindGroup>,
-    /// Union of canvas-pixel rects the current dab's passes write to. The
-    /// node that issues the write is the only thing that knows the real
-    /// footprint — stroke_engine can't derive it from `info.pos` because
-    /// the graph may offset the dab (scatter, wobble, future
-    /// position-modulating nodes). Each pass unions its rect into this via
-    /// `push_dab_write_bbox`; stroke_engine reads it after `execute_gpu`
-    /// for the save-point bbox and resets it before the next dab. `None`
-    /// outside stroke evaluation.
-    pub dab_write_canvas_bbox: Option<crate::coord::CanvasRect>,
-
     /// Host-side counters for this context's lifetime. Written by the
     /// stroke engine + compute terminals via `record_*` helpers; drained
     /// by `submit_final` so the engine can `+= ` the result into its own
     /// stroke-level accumulator.
     pub perf: BrushPerfCounters,
 
-    /// Dabs queued by whichever dab-batching terminal is active in the
-    /// graph during a single pen event. Drained by that terminal's
-    /// `flush_dabs` hook (one render pass for `paint`; two render
-    /// passes — pickup atlas + composite — for `watercolor_batched`).
-    /// The bytes are written by `bytemuck::bytes_of` on each terminal's
-    /// own record struct — the WGSL binding reinterprets them as that
-    /// terminal's `Dab` type. A brush graph has at most one
-    /// dab-batching terminal at a time, so the bytes are unambiguous.
-    ///
-    /// Empty for brushes that don't use a dab-batching terminal.
-    pub pending_dab_bytes: Vec<u8>,
-    /// Number of dab records currently in `pending_dab_bytes`.
-    /// Each terminal's record size is constant per terminal, so
-    /// `bytes.len() == count * sizeof(Record)`; the count is tracked
-    /// explicitly so flush code doesn't need to know the record size.
-    pub pending_dab_count: u32,
-    /// Layer-local bounding box covered by the queued dabs, as
-    /// `[x0, y0, x1, y1]`. The terminal's `flush_dabs` reads it as a
-    /// workload metric (recorded into `BrushPerfCounters` for the bench
-    /// harness). `None` when the queue is empty. Per-flush `flush_dabs`
-    /// implementations may also use it for a discriminator-or-clip
-    /// decision, but neither shipped terminal does today —
-    /// hardware-blend writes scale per-fragment, not per-bbox-pixel.
-    pub pending_dabs_bbox: Option<[u32; 4]>,
-
-    /// Terminal-private per-dab CPU meta, packed by `evaluate_gpu` in
-    /// lockstep with [`Self::pending_dab_bytes`] and drained by the
-    /// terminal's `flush_dabs` hook. Only used by per-dab-feedback
-    /// terminals (`smudge`, `liquify`) that need
-    /// CPU-side state at flush time to drive mirror-snapshot copies
-    /// without re-deriving footprints from GPU memory. The framework
-    /// doesn't interpret these bytes — the owning terminal reinterprets
-    /// them via `bytemuck::cast_slice` against its own meta record
-    /// struct. Cleared together with `pending_dab_bytes` by
-    /// [`Self::clear_pending_dabs`] and [`Self::take_pending_dabs`].
-    pub pending_dab_meta_bytes: Vec<u8>,
-
-    /// Compiled WGSL for this brush, populated by the engine before
-    /// stroke evaluation. Read by the terminal's `evaluate_gpu` and
-    /// `flush_dabs` to know the dab record / uniform layouts and the
-    /// pipeline topology hash.
-    pub compiled_brush: Option<Arc<CompiledBrush>>,
-
-    /// Name → value map of every output slot in the brush graph,
-    /// built by the runner's `dispatch_gpu` immediately after
-    /// `execute_cpu` and held for the duration of the dispatch pass.
-    /// Keys follow the `n{node_id}_{port_name}` convention used by
-    /// [`crate::brush::wgsl::CompileWgslCtx::dab_field_name`].
-    /// The terminal reads from this to pack per-dab records and
-    /// uniforms.
-    pub slot_outputs_owned: Option<HashMap<String, ScalarValue>>,
+    /// Stroke-mode resources (real stroke + palette-thumbnail render).
+    /// `None` in cursor-hover preview where no commit happens.
+    pub stroke: Option<StrokeResources<'a>>,
+    /// Cursor-hover preview state. `None` during a real stroke.
+    pub preview: Option<PreviewState<'a>>,
+    /// Per-batch dab ledger — see [`DabBatch`].
+    pub dab_batch: DabBatch,
 }
 
 impl<'a> BrushGpuContext<'a> {
@@ -280,15 +389,6 @@ impl<'a> BrushGpuContext<'a> {
         self.perf.submit_us = self.perf.submit_us.saturating_add(us);
         self.perf.submits = self.perf.submits.saturating_add(1);
         self.perf
-    }
-
-    /// Reset per-dab read-mirror state.  Called by the stroke engine
-    /// before each dab so the first node that needs the read mirror this
-    /// dab actually issues a fresh copy.  No-op in cursor-preview mode.
-    pub fn reset_per_dab_read_cache(&mut self) {
-        if let Some(scratch) = self.scratch.as_deref_mut() {
-            scratch.reset_read_origin_cache();
-        }
     }
 
     /// If any uniform ring is nearly full, submit the current encoder,
@@ -315,126 +415,33 @@ impl<'a> BrushGpuContext<'a> {
         }
     }
 
-    /// Pack one dab record for the active compiled brush into
-    /// `pending_dab_bytes` and bump `pending_dab_count`. Every terminal
-    /// (paint, watercolor, smudge, liquify) calls this from its
-    /// `evaluate_gpu` after computing the per-dab geometry; the WGSL
-    /// terminal reinterprets the bytes via its dab layout at flush
-    /// time. The active brush has exactly one dab-batching terminal in
-    /// its graph, so the bytes are unambiguous.
-    ///
-    /// `slot_outputs_owned` must have been populated by the runner's
-    /// `dispatch_gpu` before this call — that's the source of the
-    /// per-node field values the compiled record packer reads.
-    pub fn queue_dab(
-        &mut self,
-        compiled: &CompiledBrush,
-        position: [f32; 2],
-        bbox_radius: f32,
-        radius: f32,
-    ) {
-        let record_start = self.pending_dab_bytes.len();
-        super::wgsl::pack_intrinsic_dab_header(
-            &mut self.pending_dab_bytes,
-            position,
-            bbox_radius,
-            radius,
-        );
-        let outputs = self
-            .slot_outputs_owned
-            .as_ref()
-            .expect("queue_dab requires slot_outputs_owned on gpu_context");
-        super::wgsl::pack_dab_record(compiled, outputs, &mut self.pending_dab_bytes);
-        // Pad to the full record size so the next dab starts aligned.
-        let written = self.pending_dab_bytes.len() - record_start;
-        if written < compiled.dab_record_size {
-            self.pending_dab_bytes
-                .resize(record_start + compiled.dab_record_size, 0);
-        }
-        self.pending_dab_count = self.pending_dab_count.saturating_add(1);
-        debug_assert!(
-            self.pending_dab_count <= MAX_DABS_PER_PHASE,
-            "dab queue overflowed MAX_DABS_PER_PHASE ({MAX_DABS_PER_PHASE}); \
-             bump the constant or flush more often",
-        );
-    }
-
-    /// Drain the compute-dab queue. Returns the raw bytes (caller
-    /// reinterprets via `bytemuck::cast_slice`) and the dab count. Also
-    /// clears `pending_dabs_bbox`. The terminal-private
-    /// `pending_dab_meta_bytes` is *not* drained here — the caller
-    /// drains it directly via [`Self::take_pending_dab_meta`] when it
-    /// needs to walk per-dab meta inside its `flush_dabs` loop. Called
-    /// from a terminal's `flush_dabs` hook once the dispatch is encoded.
-    pub fn take_pending_dabs(&mut self) -> (Vec<u8>, u32) {
-        let bytes = std::mem::take(&mut self.pending_dab_bytes);
-        let count = std::mem::take(&mut self.pending_dab_count);
-        self.pending_dabs_bbox = None;
-        (bytes, count)
-    }
-
-    /// Drain the per-dab CPU meta queue. Symmetric with
-    /// [`Self::take_pending_dabs`]; callers `bytemuck::cast_slice` the
-    /// returned bytes against their meta record type.
-    pub fn take_pending_dab_meta(&mut self) -> Vec<u8> {
-        std::mem::take(&mut self.pending_dab_meta_bytes)
-    }
-
-    /// Discard the compute-dab queue without dispatching. Used at stroke
-    /// begin / rewind to drop any state from a prior context, and by
-    /// `flush_dabs` when its early-out path runs (empty queue, no
-    /// scratch, etc.) so a follow-up dispatch doesn't see stale state.
-    pub fn clear_pending_dabs(&mut self) {
-        self.pending_dab_bytes.clear();
-        self.pending_dab_count = 0;
-        self.pending_dabs_bbox = None;
-        self.pending_dab_meta_bytes.clear();
-    }
-
     /// Ensure the preview mask is sized to fit a brush footprint of
     /// `bbox_radius` canvas pixels half-extent. Reallocates if needed,
     /// rounding the requested side up to the next power of two so
     /// neighbouring slider-scrub values hit the cache. Returns
     /// `(view, width, height)`.
     ///
-    /// When `preview_mask_overlay` is bound (engine driver path), the
+    /// When `preview.mask_overlay` is bound (engine driver path), the
     /// overlay's preview-mask texture grows on demand up to
     /// [`MAX_PREVIEW_MASK_SIDE`]. When it's `None` (test path), the
-    /// caller's pre-allocated `preview_mask_view` / `preview_mask_size`
-    /// is returned unchanged.
+    /// caller's pre-allocated `preview.mask_view` / `preview.mask_size`
+    /// is returned unchanged. Returns `None` if there is no preview state.
     pub fn ensure_preview_mask(
         &mut self,
         bbox_radius: f32,
     ) -> Option<(wgpu::TextureView, u32, u32)> {
+        let preview = self.preview.as_mut()?;
         let requested = ((bbox_radius * 2.0).ceil() as u32).max(1);
         let side = requested
             .next_power_of_two()
             .clamp(MIN_PREVIEW_MASK_SIDE, MAX_PREVIEW_MASK_SIDE);
-        if let Some(overlay) = self.preview_mask_overlay.as_mut() {
+        if let Some(overlay) = preview.mask_overlay.as_mut() {
             let view = overlay.ensure_preview_mask(self.device, side, side).clone();
             return Some((view, side, side));
         }
         // Test fallback — return the pre-allocated mask as-is.
-        let view = self.preview_mask_view?;
-        Some((
-            view.clone(),
-            self.preview_mask_size.0,
-            self.preview_mask_size.1,
-        ))
-    }
-
-    /// Union a write-pass footprint into `dab_write_canvas_bbox`. Called by
-    /// any GPU node whose pass writes to the stroke scratch, so
-    /// stroke_engine can record a save-point bbox that matches what was
-    /// actually drawn.
-    pub fn push_dab_write_bbox(&mut self, bbox: crate::coord::CanvasRect) {
-        if bbox.is_empty() {
-            return;
-        }
-        self.dab_write_canvas_bbox = Some(match self.dab_write_canvas_bbox {
-            Some(prev) => prev.union(bbox),
-            None => bbox,
-        });
+        let view = preview.mask_view?;
+        Some((view.clone(), preview.mask_size.0, preview.mask_size.1))
     }
 
     /// Compute the layer-clipped per-dab footprint, push the canvas-space
@@ -442,7 +449,7 @@ impl<'a> BrushGpuContext<'a> {
     /// region), and snapshot the scratch under the dab into
     /// `scratch read mirror`. Returns `None` if the dab footprint doesn't
     /// overlap the layer (early-out for the caller — typically `return
-    /// vec![]`).
+    /// vec![]`) or if there is no stroke context.
     ///
     /// The write region is the dab footprint (`position ± write_half`);
     /// the read region is the scratch-mirror snapshot footprint
@@ -470,8 +477,8 @@ impl<'a> BrushGpuContext<'a> {
             read_half_w >= write_half_w && read_half_h >= write_half_h,
             "read region must enclose write region",
         );
-        let pt = self.paint_target.as_ref()?;
-        let pt_canvas = pt.canvas_extent();
+        let stroke = self.stroke.as_mut()?;
+        let pt_canvas = stroke.paint_target.canvas_extent();
 
         let layer_x0 = pt_canvas.x0() as f32;
         let layer_y0 = pt_canvas.y0() as f32;
@@ -515,19 +522,30 @@ impl<'a> BrushGpuContext<'a> {
         let write_bbox_y = write_y0.floor() as i32;
         let write_bbox_w = (write_x1.ceil() as i32 - write_bbox_x) as u32;
         let write_bbox_h = (write_y1.ceil() as i32 - write_bbox_y) as u32;
-        self.push_dab_write_bbox(crate::coord::CanvasRect::from_xywh(
-            write_bbox_x,
-            write_bbox_y,
-            write_bbox_w,
-            write_bbox_h,
-        ));
+        self.dab_batch
+            .push_write_bbox(crate::coord::CanvasRect::from_xywh(
+                write_bbox_x,
+                write_bbox_y,
+                write_bbox_w,
+                write_bbox_h,
+            ));
 
         // The read mirror is filled from the stroke scratch, which is
         // layer-sized and indexed in layer-local pixels — translate
         // before issuing the copy.
+        // Re-borrow stroke for the scratch copy (push_write_bbox above
+        // took `&mut self.dab_batch`, which is disjoint from `self.stroke`).
+        let stroke = self.stroke.as_mut().expect("stroke just observed Some");
         let copy_local_x = (copy_canvas_x - pt_canvas.x0()) as u32;
         let copy_local_y = (copy_canvas_y - pt_canvas.y0()) as u32;
-        self.sync_scratch_read_mirror(copy_local_x, copy_local_y, copy_w, copy_h);
+        stroke.scratch.sync_read_mirror(
+            self.device,
+            &mut self.encoder,
+            copy_local_x,
+            copy_local_y,
+            copy_w,
+            copy_h,
+        );
 
         Some(DabFootprint {
             layer_offset: [pt_canvas.x0(), pt_canvas.y0()],
@@ -552,7 +570,7 @@ impl<'a> BrushGpuContext<'a> {
     /// bg) need this, and both compute the same footprint from the same
     /// position — the cache prevents a redundant copy per dab.
     ///
-    /// No-op in cursor-preview mode (no scratch).
+    /// No-op in cursor-preview mode (no stroke resources).
     pub fn sync_scratch_read_mirror(
         &mut self,
         origin_x: u32,
@@ -560,8 +578,8 @@ impl<'a> BrushGpuContext<'a> {
         width: u32,
         height: u32,
     ) {
-        if let Some(scratch) = self.scratch.as_deref_mut() {
-            scratch.sync_read_mirror(
+        if let Some(stroke) = self.stroke.as_mut() {
+            stroke.scratch.sync_read_mirror(
                 self.device,
                 &mut self.encoder,
                 origin_x,

--- a/crates/darkly/src/brush/nodes/liquify.rs
+++ b/crates/darkly/src/brush/nodes/liquify.rs
@@ -391,7 +391,7 @@ impl LiquifyEvaluator {
     }
 
     fn insert_copy_origin(gpu: &mut BrushGpuContext, node_id: u32, value: [f32; 2]) {
-        if let Some(outputs) = gpu.slot_outputs_owned.as_mut() {
+        if let Some(outputs) = gpu.dab_batch.slot_outputs.as_mut() {
             outputs.insert(
                 format!("n{}_copy_origin", node_id),
                 ScalarValue::Vec2(value),
@@ -410,13 +410,14 @@ impl BrushNodeEvaluator for LiquifyEvaluator {
         ctx: &EvalContext,
         gpu: &mut BrushGpuContext,
     ) -> Vec<(String, ScalarValue)> {
-        let Some(compiled) = gpu.compiled_brush.clone() else {
+        let Some(compiled) = gpu.dab_batch.compiled_brush.clone() else {
             debug_assert!(false, "liquify requires compiled_brush on gpu_context");
             return vec![];
         };
-        let Some(paint_target) = gpu.paint_target.as_ref() else {
+        let Some(stroke) = gpu.stroke.as_ref() else {
             return vec![];
         };
+        let paint_target = &stroke.paint_target;
         let position = ctx.input("position").as_vec2();
         let strength = ctx.input_f32("strength").clamp(0.0, 1.0);
         let distance = ctx.input_f32("distance");
@@ -462,16 +463,17 @@ impl BrushNodeEvaluator for LiquifyEvaluator {
         let bbox_y = cy0.floor() as i32;
         let bbox_w = (cx1.ceil() as i32 - bbox_x) as u32;
         let bbox_h = (cy1.ceil() as i32 - bbox_y) as u32;
-        gpu.push_dab_write_bbox(crate::coord::CanvasRect::from_xywh(
-            bbox_x, bbox_y, bbox_w, bbox_h,
-        ));
         let layer_w = canvas_ext.width;
         let layer_h = canvas_ext.height;
         let local_x0 = (bbox_x - canvas_ext.x0()).max(0) as u32;
         let local_y0 = (bbox_y - canvas_ext.y0()).max(0) as u32;
         let local_x1 = (local_x0 + bbox_w).min(layer_w);
         let local_y1 = (local_y0 + bbox_h).min(layer_h);
-        gpu.pending_dabs_bbox = Some(match gpu.pending_dabs_bbox {
+        gpu.dab_batch
+            .push_write_bbox(crate::coord::CanvasRect::from_xywh(
+                bbox_x, bbox_y, bbox_w, bbox_h,
+            ));
+        gpu.dab_batch.bbox = Some(match gpu.dab_batch.bbox {
             Some([x0, y0, x1, y1]) => [
                 x0.min(local_x0),
                 y0.min(local_y0),
@@ -494,32 +496,34 @@ impl BrushNodeEvaluator for LiquifyEvaluator {
         let copy_canvas_y = read_y0.floor();
         Self::insert_copy_origin(gpu, ctx.node_id.0 as u32, [copy_canvas_x, copy_canvas_y]);
 
-        gpu.queue_dab(&compiled, position, bbox_radius, radius);
+        gpu.dab_batch
+            .queue_dab(&compiled, position, bbox_radius, radius);
 
         let meta = LiquifyDabMeta {
             position,
             half: [read_half, read_half],
         };
-        gpu.pending_dab_meta_bytes
+        gpu.dab_batch
+            .meta_bytes
             .extend_from_slice(bytemuck::bytes_of(&meta));
 
         vec![("dab_size".into(), ScalarValue::Vec2([diameter, diameter]))]
     }
 
     fn flush_dabs(&self, _ctx: &EvalContext, gpu: &mut BrushGpuContext) {
-        if gpu.pending_dab_count == 0 {
+        if gpu.dab_batch.count == 0 {
             return;
         }
-        let Some(compiled) = gpu.compiled_brush.clone() else {
+        let Some(compiled) = gpu.dab_batch.compiled_brush.clone() else {
             debug_assert!(false, "liquify::flush_dabs requires compiled_brush");
             return;
         };
 
-        let bbox = gpu.pending_dabs_bbox.unwrap_or([0, 0, 0, 0]);
+        let bbox = gpu.dab_batch.bbox.unwrap_or([0, 0, 0, 0]);
         let union_w = bbox[2].saturating_sub(bbox[0]);
         let union_h = bbox[3].saturating_sub(bbox[1]);
-        let (dab_bytes, total_dabs) = gpu.take_pending_dabs();
-        let meta_bytes = gpu.take_pending_dab_meta();
+        let (dab_bytes, total_dabs) = gpu.dab_batch.take();
+        let meta_bytes = gpu.dab_batch.take_meta();
         if total_dabs == 0 {
             return;
         }
@@ -535,10 +539,11 @@ impl BrushNodeEvaluator for LiquifyEvaluator {
         let pipeline_ref = gpu.pipelines.get::<LiquifyPipeline>("liquify");
         ensure_per_brush_pipeline(gpu, pipeline_ref, &compiled);
 
-        let paint_target = gpu
-            .paint_target
+        let stroke = gpu
+            .stroke
             .as_ref()
-            .expect("liquify::flush_dabs requires paint_target");
+            .expect("liquify::flush_dabs requires stroke resources");
+        let paint_target = &stroke.paint_target;
         let canvas_ext = paint_target.canvas_extent();
         let layer_offset = [canvas_ext.x0(), canvas_ext.y0()];
         let layer_size = [canvas_ext.width, canvas_ext.height];
@@ -556,9 +561,10 @@ impl BrushNodeEvaluator for LiquifyEvaluator {
             },
         );
         let outputs = gpu
-            .slot_outputs_owned
+            .dab_batch
+            .slot_outputs
             .as_ref()
-            .expect("liquify::flush_dabs requires slot_outputs_owned");
+            .expect("liquify::flush_dabs requires dab_batch.slot_outputs");
         pack_uniforms(&compiled, outputs, &mut uniform_bytes);
 
         pipeline_ref.with_pipeline(compiled.topology_hash, |per_brush| {
@@ -579,10 +585,11 @@ impl BrushNodeEvaluator for LiquifyEvaluator {
                     meta.half[1],
                 );
 
-                let scratch_ref = gpu
-                    .scratch
-                    .as_deref()
-                    .expect("liquify::flush_dabs requires Scratch");
+                let scratch_ref = &*gpu
+                    .stroke
+                    .as_ref()
+                    .expect("liquify::flush_dabs requires stroke resources")
+                    .scratch;
                 let read_bg = scratch_ref.read_mirror_bind_group();
                 let write_view = scratch_ref.write_view();
 
@@ -621,18 +628,15 @@ impl BrushNodeEvaluator for LiquifyEvaluator {
     }
 
     fn commit(&self, _ctx: &EvalContext, gpu: &mut BrushGpuContext) {
-        let Some(paint_target) = gpu.paint_target.as_ref() else {
+        let Some(stroke) = gpu.stroke.as_ref() else {
             return;
         };
-        let Some(scratch) = gpu.scratch.as_deref() else {
-            return;
-        };
-        paint_target.commit_scratch_blit(
+        stroke.paint_target.commit_scratch_blit(
             gpu.device,
             &mut gpu.encoder,
             gpu.pipelines,
-            scratch.write_view(),
-            scratch.write_texture(),
+            stroke.scratch.write_view(),
+            stroke.scratch.write_texture(),
         );
     }
 

--- a/crates/darkly/src/brush/nodes/paint.rs
+++ b/crates/darkly/src/brush/nodes/paint.rs
@@ -3,7 +3,7 @@
 //!
 //! ## What this terminal does
 //!
-//! Per-dab records queue up via [`BrushGpuContext::pending_dab_bytes`];
+//! Per-dab records queue up on [`BrushGpuContext::dab_batch`];
 //! one instanced render pass drains them at phase end.
 //!
 //! - **The fragment shader is generated per-brush at brush load** by
@@ -384,16 +384,17 @@ impl BrushNodeEvaluator for PaintEvaluator {
         ctx: &EvalContext,
         gpu: &mut BrushGpuContext,
     ) -> Vec<(String, ScalarValue)> {
-        let Some(compiled) = gpu.compiled_brush.clone() else {
+        let Some(compiled) = gpu.dab_batch.compiled_brush.clone() else {
             // Compiled brush wasn't attached — programming error in
             // the engine wiring. Panic in debug, drop dab silently in
             // release so we don't blow up an in-flight stroke.
             debug_assert!(false, "paint requires compiled_brush on gpu_context");
             return vec![];
         };
-        let Some(paint_target) = gpu.paint_target.as_ref() else {
+        let Some(stroke) = gpu.stroke.as_ref() else {
             return vec![];
         };
+        let paint_target = &stroke.paint_target;
         let position = ctx.input("position").as_vec2();
         let radius = Self::effective_radius(ctx);
         let diameter = radius * 2.0;
@@ -424,16 +425,17 @@ impl BrushNodeEvaluator for PaintEvaluator {
         let bbox_y = cy0.floor() as i32;
         let bbox_w = (cx1.ceil() as i32 - bbox_x) as u32;
         let bbox_h = (cy1.ceil() as i32 - bbox_y) as u32;
-        gpu.push_dab_write_bbox(crate::coord::CanvasRect::from_xywh(
-            bbox_x, bbox_y, bbox_w, bbox_h,
-        ));
         let layer_w = canvas_ext.width;
         let layer_h = canvas_ext.height;
         let local_x0 = (bbox_x - canvas_ext.x0()).max(0) as u32;
         let local_y0 = (bbox_y - canvas_ext.y0()).max(0) as u32;
         let local_x1 = (local_x0 + bbox_w).min(layer_w);
         let local_y1 = (local_y0 + bbox_h).min(layer_h);
-        gpu.pending_dabs_bbox = Some(match gpu.pending_dabs_bbox {
+        gpu.dab_batch
+            .push_write_bbox(crate::coord::CanvasRect::from_xywh(
+                bbox_x, bbox_y, bbox_w, bbox_h,
+            ));
+        gpu.dab_batch.bbox = Some(match gpu.dab_batch.bbox {
             Some([x0, y0, x1, y1]) => [
                 x0.min(local_x0),
                 y0.min(local_y0),
@@ -443,24 +445,25 @@ impl BrushNodeEvaluator for PaintEvaluator {
             None => [local_x0, local_y0, local_x1, local_y1],
         });
 
-        gpu.queue_dab(&compiled, position, bbox_radius, radius);
+        gpu.dab_batch
+            .queue_dab(&compiled, position, bbox_radius, radius);
 
         vec![("dab_size".into(), ScalarValue::Vec2([diameter, diameter]))]
     }
 
     fn flush_dabs(&self, _ctx: &EvalContext, gpu: &mut BrushGpuContext) {
-        if gpu.pending_dab_count == 0 {
+        if gpu.dab_batch.count == 0 {
             return;
         }
-        let Some(compiled) = gpu.compiled_brush.clone() else {
+        let Some(compiled) = gpu.dab_batch.compiled_brush.clone() else {
             debug_assert!(false, "paint::flush_dabs requires compiled_brush");
             return;
         };
 
-        let bbox = gpu.pending_dabs_bbox.unwrap_or([0, 0, 0, 0]);
+        let bbox = gpu.dab_batch.bbox.unwrap_or([0, 0, 0, 0]);
         let union_w = bbox[2].saturating_sub(bbox[0]);
         let union_h = bbox[3].saturating_sub(bbox[1]);
-        let (dab_bytes, total_dabs) = gpu.take_pending_dabs();
+        let (dab_bytes, total_dabs) = gpu.dab_batch.take();
         if total_dabs == 0 {
             return;
         }
@@ -477,14 +480,12 @@ impl BrushNodeEvaluator for PaintEvaluator {
         // amortised across thousands of dabs.
         ensure_per_brush_pipeline(gpu, pipeline_ref, &compiled);
 
-        let scratch = gpu
-            .scratch
-            .as_deref()
-            .expect("paint::flush_dabs requires Scratch");
-        let paint_target = gpu
-            .paint_target
+        let stroke = gpu
+            .stroke
             .as_ref()
-            .expect("paint::flush_dabs requires paint_target");
+            .expect("paint::flush_dabs requires stroke resources");
+        let scratch = &*stroke.scratch;
+        let paint_target = &stroke.paint_target;
         let canvas_ext = paint_target.canvas_extent();
         let layer_offset = [canvas_ext.x0(), canvas_ext.y0()];
         let layer_size = [canvas_ext.width, canvas_ext.height];
@@ -504,9 +505,10 @@ impl BrushNodeEvaluator for PaintEvaluator {
             },
         );
         let outputs = gpu
-            .slot_outputs_owned
+            .dab_batch
+            .slot_outputs
             .as_ref()
-            .expect("paint::flush_dabs requires slot_outputs_owned");
+            .expect("paint::flush_dabs requires dab_batch.slot_outputs");
         pack_uniforms(&compiled, outputs, &mut uniform_bytes);
 
         pipeline_ref.with_pipeline(compiled.topology_hash, |per_brush| {
@@ -561,23 +563,17 @@ impl BrushNodeEvaluator for PaintEvaluator {
     }
 
     fn commit(&self, ctx: &EvalContext, gpu: &mut BrushGpuContext) {
-        let Some(pre_stroke_bg) = gpu.pre_stroke_bind_group else {
-            return;
-        };
-        let Some(scratch) = gpu.scratch.as_deref() else {
-            return;
-        };
-        let Some(paint_target) = gpu.paint_target.as_ref() else {
+        let Some(stroke) = gpu.stroke.as_ref() else {
             return;
         };
         let opacity = ctx.input_f32("opacity").clamp(0.0, 1.0);
-        paint_target.commit_brush_dab(
+        stroke.paint_target.commit_brush_dab(
             &mut gpu.encoder,
             gpu.pipelines,
             gpu.queue,
-            scratch.write_bind_group(),
+            stroke.scratch.write_bind_group(),
             gpu.selection_bind_group,
-            pre_stroke_bg,
+            stroke.pre_stroke_bind_group,
             opacity,
             gpu.blend_mode,
             /* fg_premultiplied */ true,

--- a/crates/darkly/src/brush/nodes/smudge.rs
+++ b/crates/darkly/src/brush/nodes/smudge.rs
@@ -12,10 +12,10 @@
 //!
 //! ## Per-dab flush
 //!
-//! 1. `evaluate_gpu` packs one record into [`BrushGpuContext::pending_dab_bytes`]
-//!    *and* one [`SmudgeDabMeta`] into the parallel CPU-side
-//!    [`BrushGpuContext::pending_dab_meta_bytes`] queue, plus the
-//!    pre-computed canvas-space `copy_origin` into `slot_outputs_owned`
+//! 1. `evaluate_gpu` packs one record into [`BrushGpuContext::dab_batch`]'s
+//!    `bytes` *and* one [`SmudgeDabMeta`] into the parallel CPU-side
+//!    `meta_bytes` queue, plus the pre-computed canvas-space
+//!    `copy_origin` into `dab_batch.slot_outputs`
 //!    so the framework's `pack_dab_record` picks it up via this node's
 //!    `copy_origin` dab field. Stationary dabs (`|motion| < 0.5 px`)
 //!    are skipped before queueing — `mix(bg, src, _)` collapses to
@@ -354,12 +354,12 @@ impl SmudgeEvaluator {
         (effective_size * SIZE_REFERENCE_PX * 0.5).max(0.5)
     }
 
-    /// Insert `copy_origin` into `slot_outputs_owned` under this
+    /// Insert `copy_origin` into `dab_batch.slot_outputs` under this
     /// node's dab-field key so the framework's `pack_dab_record`
     /// picks it up via the `copy_origin` `DabField` declared in
     /// `compile_wgsl`.
     fn insert_copy_origin(gpu: &mut BrushGpuContext, node_id: u32, value: [f32; 2]) {
-        if let Some(outputs) = gpu.slot_outputs_owned.as_mut() {
+        if let Some(outputs) = gpu.dab_batch.slot_outputs.as_mut() {
             outputs.insert(
                 format!("n{}_copy_origin", node_id),
                 ScalarValue::Vec2(value),
@@ -378,13 +378,14 @@ impl BrushNodeEvaluator for SmudgeEvaluator {
         ctx: &EvalContext,
         gpu: &mut BrushGpuContext,
     ) -> Vec<(String, ScalarValue)> {
-        let Some(compiled) = gpu.compiled_brush.clone() else {
+        let Some(compiled) = gpu.dab_batch.compiled_brush.clone() else {
             debug_assert!(false, "smudge requires compiled_brush on gpu_context");
             return vec![];
         };
-        let Some(paint_target) = gpu.paint_target.as_ref() else {
+        let Some(stroke) = gpu.stroke.as_ref() else {
             return vec![];
         };
+        let paint_target = &stroke.paint_target;
         let position = ctx.input("position").as_vec2();
         let motion = ctx.input("motion").as_vec2();
         let radius = Self::effective_radius(ctx);
@@ -419,16 +420,17 @@ impl BrushNodeEvaluator for SmudgeEvaluator {
         let bbox_y = cy0.floor() as i32;
         let bbox_w = (cx1.ceil() as i32 - bbox_x) as u32;
         let bbox_h = (cy1.ceil() as i32 - bbox_y) as u32;
-        gpu.push_dab_write_bbox(crate::coord::CanvasRect::from_xywh(
-            bbox_x, bbox_y, bbox_w, bbox_h,
-        ));
         let layer_w = canvas_ext.width;
         let layer_h = canvas_ext.height;
         let local_x0 = (bbox_x - canvas_ext.x0()).max(0) as u32;
         let local_y0 = (bbox_y - canvas_ext.y0()).max(0) as u32;
         let local_x1 = (local_x0 + bbox_w).min(layer_w);
         let local_y1 = (local_y0 + bbox_h).min(layer_h);
-        gpu.pending_dabs_bbox = Some(match gpu.pending_dabs_bbox {
+        gpu.dab_batch
+            .push_write_bbox(crate::coord::CanvasRect::from_xywh(
+                bbox_x, bbox_y, bbox_w, bbox_h,
+            ));
+        gpu.dab_batch.bbox = Some(match gpu.dab_batch.bbox {
             Some([x0, y0, x1, y1]) => [
                 x0.min(local_x0),
                 y0.min(local_y0),
@@ -460,7 +462,8 @@ impl BrushNodeEvaluator for SmudgeEvaluator {
         let copy_canvas_y = read_y0.floor();
         Self::insert_copy_origin(gpu, ctx.node_id.0 as u32, [copy_canvas_x, copy_canvas_y]);
 
-        gpu.queue_dab(&compiled, position, bbox_radius, radius);
+        gpu.dab_batch
+            .queue_dab(&compiled, position, bbox_radius, radius);
 
         // Pack the CPU-side meta in lockstep.
         let meta = SmudgeDabMeta {
@@ -468,26 +471,27 @@ impl BrushNodeEvaluator for SmudgeEvaluator {
             write_half: [write_half_w, write_half_h],
             read_half: [read_half_w, read_half_h],
         };
-        gpu.pending_dab_meta_bytes
+        gpu.dab_batch
+            .meta_bytes
             .extend_from_slice(bytemuck::bytes_of(&meta));
 
         vec![("dab_size".into(), ScalarValue::Vec2([diameter, diameter]))]
     }
 
     fn flush_dabs(&self, _ctx: &EvalContext, gpu: &mut BrushGpuContext) {
-        if gpu.pending_dab_count == 0 {
+        if gpu.dab_batch.count == 0 {
             return;
         }
-        let Some(compiled) = gpu.compiled_brush.clone() else {
+        let Some(compiled) = gpu.dab_batch.compiled_brush.clone() else {
             debug_assert!(false, "smudge::flush_dabs requires compiled_brush");
             return;
         };
 
-        let bbox = gpu.pending_dabs_bbox.unwrap_or([0, 0, 0, 0]);
+        let bbox = gpu.dab_batch.bbox.unwrap_or([0, 0, 0, 0]);
         let union_w = bbox[2].saturating_sub(bbox[0]);
         let union_h = bbox[3].saturating_sub(bbox[1]);
-        let (dab_bytes, total_dabs) = gpu.take_pending_dabs();
-        let meta_bytes = gpu.take_pending_dab_meta();
+        let (dab_bytes, total_dabs) = gpu.dab_batch.take();
+        let meta_bytes = gpu.dab_batch.take_meta();
         if total_dabs == 0 {
             return;
         }
@@ -503,10 +507,11 @@ impl BrushNodeEvaluator for SmudgeEvaluator {
         let pipeline_ref = gpu.pipelines.get::<SmudgePipeline>("smudge");
         ensure_per_brush_pipeline(gpu, pipeline_ref, &compiled);
 
-        let paint_target = gpu
-            .paint_target
+        let stroke = gpu
+            .stroke
             .as_ref()
-            .expect("smudge::flush_dabs requires paint_target");
+            .expect("smudge::flush_dabs requires stroke resources");
+        let paint_target = &stroke.paint_target;
         let canvas_ext = paint_target.canvas_extent();
         let layer_offset = [canvas_ext.x0(), canvas_ext.y0()];
         let layer_size = [canvas_ext.width, canvas_ext.height];
@@ -524,9 +529,10 @@ impl BrushNodeEvaluator for SmudgeEvaluator {
             },
         );
         let outputs = gpu
-            .slot_outputs_owned
+            .dab_batch
+            .slot_outputs
             .as_ref()
-            .expect("smudge::flush_dabs requires slot_outputs_owned");
+            .expect("smudge::flush_dabs requires dab_batch.slot_outputs");
         pack_uniforms(&compiled, outputs, &mut uniform_bytes);
 
         pipeline_ref.with_pipeline(compiled.topology_hash, |per_brush| {
@@ -552,10 +558,11 @@ impl BrushNodeEvaluator for SmudgeEvaluator {
 
                 // Fresh read-mirror bind group each iteration — a
                 // mid-loop grow can rebuild it.
-                let scratch_ref = gpu
-                    .scratch
-                    .as_deref()
-                    .expect("smudge::flush_dabs requires Scratch");
+                let scratch_ref = &*gpu
+                    .stroke
+                    .as_ref()
+                    .expect("smudge::flush_dabs requires stroke resources")
+                    .scratch;
                 let read_bg = scratch_ref.read_mirror_bind_group();
                 let write_view = scratch_ref.write_view();
 
@@ -597,18 +604,15 @@ impl BrushNodeEvaluator for SmudgeEvaluator {
     /// finished image; commit just copies it across. `gpu.blend_mode`
     /// is ignored — erase semantics aren't meaningful for a smear.
     fn commit(&self, _ctx: &EvalContext, gpu: &mut BrushGpuContext) {
-        let Some(paint_target) = gpu.paint_target.as_ref() else {
+        let Some(stroke) = gpu.stroke.as_ref() else {
             return;
         };
-        let Some(scratch) = gpu.scratch.as_deref() else {
-            return;
-        };
-        paint_target.commit_scratch_blit(
+        stroke.paint_target.commit_scratch_blit(
             gpu.device,
             &mut gpu.encoder,
             gpu.pipelines,
-            scratch.write_view(),
-            scratch.write_texture(),
+            stroke.scratch.write_view(),
+            stroke.scratch.write_texture(),
         );
     }
 
@@ -635,7 +639,7 @@ impl BrushNodeEvaluator for SmudgeEvaluator {
         let opacity_expr = cctx.input("opacity").as_f32();
 
         // Per-dab `copy_origin` field. The terminal's `evaluate_gpu`
-        // inserts this into `slot_outputs_owned` so the packer reads
+        // inserts this into `dab_batch.slot_outputs` so the packer reads
         // it through the standard `pack_dab_record` path.
         let copy_origin_field = cctx.dab_field_name("copy_origin");
         let key = copy_origin_field.clone();

--- a/crates/darkly/src/brush/nodes/watercolor.rs
+++ b/crates/darkly/src/brush/nodes/watercolor.rs
@@ -672,13 +672,14 @@ impl BrushNodeEvaluator for WatercolorEvaluator {
         ctx: &EvalContext,
         gpu: &mut BrushGpuContext,
     ) -> Vec<(String, ScalarValue)> {
-        let Some(compiled) = gpu.compiled_brush.clone() else {
+        let Some(compiled) = gpu.dab_batch.compiled_brush.clone() else {
             debug_assert!(false, "watercolor requires compiled_brush on gpu_context");
             return vec![];
         };
-        let Some(paint_target) = gpu.paint_target.as_ref() else {
+        let Some(stroke) = gpu.stroke.as_ref() else {
             return vec![];
         };
+        let paint_target = &stroke.paint_target;
         let position = ctx.input("position").as_vec2();
         let radius = Self::effective_radius(ctx);
         let diameter = radius * 2.0;
@@ -703,16 +704,17 @@ impl BrushNodeEvaluator for WatercolorEvaluator {
         let bbox_y = cy0.floor() as i32;
         let bbox_w = (cx1.ceil() as i32 - bbox_x) as u32;
         let bbox_h = (cy1.ceil() as i32 - bbox_y) as u32;
-        gpu.push_dab_write_bbox(crate::coord::CanvasRect::from_xywh(
-            bbox_x, bbox_y, bbox_w, bbox_h,
-        ));
         let layer_w = canvas_ext.width;
         let layer_h = canvas_ext.height;
         let local_x0 = (bbox_x - canvas_ext.x0()).max(0) as u32;
         let local_y0 = (bbox_y - canvas_ext.y0()).max(0) as u32;
         let local_x1 = (local_x0 + bbox_w).min(layer_w);
         let local_y1 = (local_y0 + bbox_h).min(layer_h);
-        gpu.pending_dabs_bbox = Some(match gpu.pending_dabs_bbox {
+        gpu.dab_batch
+            .push_write_bbox(crate::coord::CanvasRect::from_xywh(
+                bbox_x, bbox_y, bbox_w, bbox_h,
+            ));
+        gpu.dab_batch.bbox = Some(match gpu.dab_batch.bbox {
             Some([x0, y0, x1, y1]) => [
                 x0.min(local_x0),
                 y0.min(local_y0),
@@ -722,52 +724,50 @@ impl BrushNodeEvaluator for WatercolorEvaluator {
             None => [local_x0, local_y0, local_x1, local_y1],
         });
 
-        gpu.queue_dab(&compiled, position, bbox_radius, radius);
+        gpu.dab_batch
+            .queue_dab(&compiled, position, bbox_radius, radius);
 
         vec![("dab_size".into(), ScalarValue::Vec2([diameter, diameter]))]
     }
 
     fn flush_dabs(&self, ctx: &EvalContext, gpu: &mut BrushGpuContext) {
-        if gpu.pending_dab_count == 0 {
+        if gpu.dab_batch.count == 0 {
             return;
         }
-        let Some(compiled) = gpu.compiled_brush.clone() else {
+        let Some(compiled) = gpu.dab_batch.compiled_brush.clone() else {
             debug_assert!(false, "watercolor::flush_dabs requires compiled_brush");
             return;
         };
 
-        let bbox = gpu.pending_dabs_bbox.unwrap_or([0, 0, 0, 0]);
+        let bbox = gpu.dab_batch.bbox.unwrap_or([0, 0, 0, 0]);
         let union_w = bbox[2].saturating_sub(bbox[0]);
         let union_h = bbox[3].saturating_sub(bbox[1]);
-        let (dab_bytes, total_dabs) = gpu.take_pending_dabs();
+        let (dab_bytes, total_dabs) = gpu.dab_batch.take();
         if total_dabs == 0 {
             return;
         }
         gpu.perf
             .record_dab_flush_workload(total_dabs, union_w, union_h);
 
-        let pre_stroke_bg = match gpu.pre_stroke_bind_group {
-            Some(bg) => bg,
-            None => return,
+        let Some(stroke) = gpu.stroke.as_ref() else {
+            return;
         };
-        let pre_stroke_tex = match gpu.pre_stroke_texture {
-            Some(t) => t,
-            None => return,
-        };
-        let pre_stroke_size = [pre_stroke_tex.width(), pre_stroke_tex.height()];
+        let pre_stroke_bg = stroke.pre_stroke_bind_group;
+        let pre_stroke_size = [
+            stroke.pre_stroke_texture.width(),
+            stroke.pre_stroke_texture.height(),
+        ];
 
         let pipeline_ref = gpu.pipelines.get::<WatercolorPipeline>("watercolor");
 
         ensure_per_brush_pipeline(gpu, pipeline_ref, &compiled);
 
-        let scratch = gpu
-            .scratch
-            .as_deref()
-            .expect("watercolor::flush_dabs requires Scratch");
-        let paint_target = gpu
-            .paint_target
+        let stroke = gpu
+            .stroke
             .as_ref()
-            .expect("watercolor::flush_dabs requires paint_target");
+            .expect("watercolor::flush_dabs requires stroke resources");
+        let scratch = &*stroke.scratch;
+        let paint_target = &stroke.paint_target;
         let canvas_ext = paint_target.canvas_extent();
         let pre_stroke_origin = [canvas_ext.x0(), canvas_ext.y0()];
         let layer_offset = [canvas_ext.x0(), canvas_ext.y0()];
@@ -787,9 +787,10 @@ impl BrushNodeEvaluator for WatercolorEvaluator {
             },
         );
         let outputs = gpu
-            .slot_outputs_owned
+            .dab_batch
+            .slot_outputs
             .as_ref()
-            .expect("watercolor::flush_dabs requires slot_outputs_owned");
+            .expect("watercolor::flush_dabs requires dab_batch.slot_outputs");
         pack_uniforms(&compiled, outputs, &mut composite_uniform_bytes);
 
         // Pickup size is a stroke-level scrub — the lifecycle context
@@ -886,23 +887,17 @@ impl BrushNodeEvaluator for WatercolorEvaluator {
     }
 
     fn commit(&self, ctx: &EvalContext, gpu: &mut BrushGpuContext) {
-        let Some(pre_stroke_bg) = gpu.pre_stroke_bind_group else {
-            return;
-        };
-        let Some(scratch) = gpu.scratch.as_deref() else {
-            return;
-        };
-        let Some(paint_target) = gpu.paint_target.as_ref() else {
+        let Some(stroke) = gpu.stroke.as_ref() else {
             return;
         };
         let opacity = ctx.input_f32("opacity").clamp(0.0, 1.0);
-        paint_target.commit_brush_dab(
+        stroke.paint_target.commit_brush_dab(
             &mut gpu.encoder,
             gpu.pipelines,
             gpu.queue,
-            scratch.write_bind_group(),
+            stroke.scratch.write_bind_group(),
             gpu.selection_bind_group,
-            pre_stroke_bg,
+            stroke.pre_stroke_bind_group,
             opacity,
             gpu.blend_mode,
             /* fg_premultiplied */ true,

--- a/crates/darkly/src/brush/preview_renderer.rs
+++ b/crates/darkly/src/brush/preview_renderer.rs
@@ -14,7 +14,7 @@
 //! `set_preview_theme`), not the active paint color, so all previews
 //! share a consistent palette.
 
-use super::gpu_context::{BrushGpuContext, BrushPerfCounters};
+use super::gpu_context::{BrushGpuContext, BrushPerfCounters, DabBatch, StrokeResources};
 use super::paint_info::PaintInformation;
 use super::pipeline::BrushPipelines;
 use super::spacing::SpacingConfig;
@@ -179,28 +179,20 @@ impl BrushPreviewRenderer {
                     device,
                     queue,
                     pipelines,
-                    scratch: Some(scratch),
+                    selection_bind_group: sel_bg,
                     canvas_width: width,
                     canvas_height: height,
-                    // Preview render target is canvas-aligned RGBA8.
-                    paint_target: Some(paint_target),
-                    selection_bind_group: sel_bg,
-                    preview_target_view: None,
                     blend_mode: 0,
-                    preview_mask_view: None,
-                    preview_mask_size: (0, 0),
-                    preview_mask_overlay: None,
-                    brush_preview_info: None,
-                    pre_stroke_texture: Some(pre_stroke_texture),
-                    pre_stroke_bind_group: Some(pre_stroke_bind_group),
-                    dab_write_canvas_bbox: None,
                     perf: BrushPerfCounters::default(),
-                    pending_dab_bytes: Vec::new(),
-                    pending_dab_count: 0,
-                    pending_dabs_bbox: None,
-                    pending_dab_meta_bytes: Vec::new(),
-                    compiled_brush: None,
-                    slot_outputs_owned: None,
+                    // Preview render target is canvas-aligned RGBA8.
+                    stroke: Some(StrokeResources {
+                        scratch,
+                        paint_target,
+                        pre_stroke_texture,
+                        pre_stroke_bind_group,
+                    }),
+                    preview: None,
+                    dab_batch: DabBatch::default(),
                 }
             }};
         }

--- a/crates/darkly/src/brush/stroke_engine.rs
+++ b/crates/darkly/src/brush/stroke_engine.rs
@@ -358,10 +358,12 @@ impl StrokeEngine {
 
         // Per-dab context state: reset the read-mirror cache so the first
         // node that needs a canvas region this dab actually issues the copy.
-        gpu.reset_per_dab_read_cache();
+        if let Some(stroke) = gpu.stroke.as_mut() {
+            stroke.reset_per_dab_read_cache();
+        }
         // Reset the write-bbox accumulator so each terminal's passes can
         // publish their footprint fresh. Read back after execute_gpu below.
-        gpu.dab_write_canvas_bbox = None;
+        gpu.dab_batch.write_canvas_bbox = None;
         self.runner.execute_gpu(gpu);
 
         gpu.flush_if_needed();
@@ -380,7 +382,7 @@ impl StrokeEngine {
         // else the graph did). Fall back to the `info.pos ± radius`
         // envelope for graphs without a scratch-writing terminal, so they
         // still get sensible checkpoint bounds.
-        let canvas_bbox = gpu.dab_write_canvas_bbox.unwrap_or_else(|| {
+        let canvas_bbox = gpu.dab_batch.write_canvas_bbox.unwrap_or_else(|| {
             let diameter = self.effective_diameter();
             let half = diameter * 0.5;
             let x = (info.pos[0] - half).floor() as i32;

--- a/crates/darkly/src/brush/wgsl/mod.rs
+++ b/crates/darkly/src/brush/wgsl/mod.rs
@@ -498,7 +498,7 @@ pub fn render_compiled_preview(
     radius: f32,
     rotation_rad: f32,
 ) -> Option<()> {
-    let compiled = gpu.compiled_brush.clone()?;
+    let compiled = gpu.dab_batch.compiled_brush.clone()?;
     // Brush-intrinsic bbox in canvas pixels — this is the dab's
     // footprint as it will be deposited on the canvas, and what the
     // overlay quad consumes via `half_extent_canvas_px` below.
@@ -536,7 +536,7 @@ pub fn render_compiled_preview(
     let mut uniform_bytes: Vec<u8> = Vec::with_capacity(total_uniform_size);
     pack_intrinsic_uniforms(&mut uniform_bytes, intrinsic);
     let empty_outputs;
-    let outputs = match gpu.slot_outputs_owned.as_ref() {
+    let outputs = match gpu.dab_batch.slot_outputs.as_ref() {
         Some(o) => o,
         None => {
             empty_outputs = HashMap::new();
@@ -579,10 +579,12 @@ pub fn render_compiled_preview(
     // spans `±half_extent_canvas_px`, and the mask sampler maps
     // UV [0, 1] across the quad. With the dab filling the mask's
     // inscribed disc by construction (above), this matches.
-    gpu.brush_preview_info = Some(crate::brush::eval::BrushPreviewInfo {
-        half_extent_canvas_px: [bbox_canvas_px, bbox_canvas_px],
-        rotation_rad,
-    });
+    if let Some(preview) = gpu.preview.as_mut() {
+        preview.info = Some(crate::brush::eval::BrushPreviewInfo {
+            half_extent_canvas_px: [bbox_canvas_px, bbox_canvas_px],
+            rotation_rad,
+        });
+    }
     Some(())
 }
 

--- a/crates/darkly/src/engine/brush_graph.rs
+++ b/crates/darkly/src/engine/brush_graph.rs
@@ -212,7 +212,9 @@ impl DarklyEngine {
         &mut self,
         pen: crate::brush::paint_info::PaintInformation,
     ) {
-        use crate::brush::gpu_context::{BrushGpuContext, BrushPerfCounters};
+        use crate::brush::gpu_context::{
+            BrushGpuContext, BrushPerfCounters, DabBatch, PreviewState,
+        };
 
         // Compile under a read guard; drop the guard before any GPU
         // work to keep the critical section narrow. The guard is held
@@ -265,36 +267,27 @@ impl DarklyEngine {
             device: &self.gpu.device,
             queue: &self.gpu.queue,
             pipelines: &self.brush_pipelines,
-            // The preview pipeline doesn't touch the stroke scratch — the
-            // terminal's `render_preview` writes to the preview mask
-            // through `preview_mask_overlay` instead. No `Scratch` is
-            // needed; any accidental call to a scratch accessor will
-            // panic, exposing the bug.
-            scratch: None,
+            selection_bind_group: sel_bg,
             canvas_width: 0,
             canvas_height: 0,
-            // No layer / pre-stroke state in preview — commit isn't called,
-            // and `render_preview` writes to the preview mask.
-            paint_target: None,
-            selection_bind_group: sel_bg,
-            preview_target_view: None,
             blend_mode: 0,
-            // Tests pre-allocate `preview_mask_view`; the engine path
-            // grows the mask on demand via `preview_mask_overlay`.
-            preview_mask_view: None,
-            preview_mask_size: (0, 0),
-            preview_mask_overlay: Some(overlay),
-            brush_preview_info: None,
-            pre_stroke_texture: None,
-            pre_stroke_bind_group: None,
-            dab_write_canvas_bbox: None,
             perf: BrushPerfCounters::default(),
-            pending_dab_bytes: Vec::new(),
-            pending_dab_count: 0,
-            pending_dabs_bbox: None,
-            pending_dab_meta_bytes: Vec::new(),
-            compiled_brush: None,
-            slot_outputs_owned: None,
+            // The preview pipeline doesn't touch the stroke scratch / paint
+            // target — the terminal's `render_preview` writes to the
+            // preview mask through `mask_overlay` instead. No
+            // `StrokeResources` is supplied; any accidental scratch /
+            // paint-target access will see `None` and either early-out or
+            // panic, exposing the bug.
+            stroke: None,
+            // Tests pre-allocate `mask_view`; the engine path grows the
+            // mask on demand via `mask_overlay`.
+            preview: Some(PreviewState {
+                mask_view: None,
+                mask_size: (0, 0),
+                mask_overlay: Some(overlay),
+                info: None,
+            }),
+            dab_batch: DabBatch::default(),
         };
 
         self.brush_pipelines.reset_uniform_rings();
@@ -303,7 +296,7 @@ impl DarklyEngine {
         runner.execute_cpu();
         runner.render_preview_pipeline(&mut gpu_ctx);
 
-        let info = gpu_ctx.brush_preview_info;
+        let info = gpu_ctx.preview.as_ref().and_then(|p| p.info);
         let command_buf = gpu_ctx.encoder.finish();
         self.gpu.queue.submit([command_buf]);
 

--- a/crates/darkly/src/engine/mod.rs
+++ b/crates/darkly/src/engine/mod.rs
@@ -424,6 +424,13 @@ pub struct DarklyEngine {
     /// per-event `BrushGpuContext` `+=`'s its drained counters into here.
     pub(crate) brush_perf: BrushPerfCounters,
 
+    /// Mid-stroke full re-render fallbacks during this stroke (the
+    /// per-engine counterpart to `brush_perf` — see [`BrushPerfCounters`]
+    /// docs on why this isn't a field there). Bumped in `painting.rs`
+    /// when the checkpoint ring's coverage invariant fails; surfaced
+    /// via `test_stroke_full_rerender_events`.
+    pub(crate) brush_full_rerender_events: u32,
+
     /// Snapshot of `brush_perf` taken on the last `drain_brush_perf_delta`
     /// call. Subtracted from the current accumulator on each drain to
     /// produce a per-interval delta. Reset to default at `begin_stroke`
@@ -532,6 +539,7 @@ impl DarklyEngine {
             thumbnail_version: 0,
             layer_growth_capped: false,
             brush_perf: BrushPerfCounters::default(),
+            brush_full_rerender_events: 0,
             last_brush_perf: BrushPerfCounters::default(),
             last_frame_phases: FrameRenderPhases::default(),
         };
@@ -762,7 +770,7 @@ impl DarklyEngine {
     /// checkpoint ring's coverage invariant kept fallback at zero across
     /// a stroke.
     pub fn test_stroke_full_rerender_events(&self) -> u32 {
-        self.brush_perf.full_rerender_events
+        self.brush_full_rerender_events
     }
 
     /// Total dabs placed during the most recent stroke. `brush_perf` is

--- a/crates/darkly/src/engine/painting.rs
+++ b/crates/darkly/src/engine/painting.rs
@@ -4,7 +4,7 @@ use super::rendering::commit_undo_region;
 use super::types::StrokeOp;
 use super::{DarklyEngine, PendingUndoCommit, ReadbackContext};
 use crate::brush::checkpoint_ring::CheckpointRing;
-use crate::brush::gpu_context::{BrushGpuContext, BrushPerfCounters};
+use crate::brush::gpu_context::{BrushGpuContext, BrushPerfCounters, DabBatch, StrokeResources};
 use crate::brush::paint_info::PaintInformation;
 use crate::brush::spacing::SpacingConfig;
 use crate::brush::stroke_buffer::StrokeBuffer;
@@ -285,6 +285,7 @@ impl DarklyEngine {
         // post-`begin_stroke` drain subtracts against zero rather than
         // the previous stroke's totals.
         self.brush_perf = BrushPerfCounters::default();
+        self.brush_full_rerender_events = 0;
         self.last_brush_perf = BrushPerfCounters::default();
         // GPU setup is deferred to first stroke_to (lazy init).
     }
@@ -901,31 +902,23 @@ impl DarklyEngine {
                         device: &self.gpu.device,
                         queue: &self.gpu.queue,
                         pipelines: &self.brush_pipelines,
-                        scratch: Some(scratch),
+                        selection_bind_group: sel_bg,
                         canvas_width: canvas_w,
                         canvas_height: canvas_h,
-                        paint_target: Some(paint_target),
-                        selection_bind_group: sel_bg,
-                        preview_target_view: None,
                         // blend_mode applies at commit (paint vs. erase).
                         // Per-dab passes hard-code source-over — the
                         // scratch is a coverage accumulator, and only the
                         // commit composite reads this value.
                         blend_mode: self.brush_blend_mode,
-                        preview_mask_view: None,
-                        preview_mask_size: (0, 0),
-                        preview_mask_overlay: None,
-                        brush_preview_info: None,
-                        pre_stroke_texture: Some(pre_stroke_texture),
-                        pre_stroke_bind_group: Some(pre_stroke_bind_group),
-                        dab_write_canvas_bbox: None,
                         perf: BrushPerfCounters::default(),
-                        pending_dab_bytes: Vec::new(),
-                        pending_dab_count: 0,
-                        pending_dabs_bbox: None,
-                        pending_dab_meta_bytes: Vec::new(),
-                        compiled_brush: None,
-                        slot_outputs_owned: None,
+                        stroke: Some(StrokeResources {
+                            scratch,
+                            paint_target,
+                            pre_stroke_texture,
+                            pre_stroke_bind_group,
+                        }),
+                        preview: None,
+                        dab_batch: DabBatch::default(),
                     }
                 }};
             }
@@ -982,7 +975,7 @@ impl DarklyEngine {
                     // Only the former is a "mid-stroke full re-render
                     // fallback" worth counting.
                     if self.checkpoint_ring.has_any_valid() {
-                        self.brush_perf.full_rerender_events += 1;
+                        self.brush_full_rerender_events += 1;
                     }
                     engine.reset_render_state();
                     self.checkpoint_ring.clear();
@@ -1096,8 +1089,7 @@ impl DarklyEngine {
             // field level, leaving `&mut self.dab_pool` free.
             let layer_tex = self.compositor.node_texture(layer_id);
             if let Some(layer_tex) = layer_tex {
-                let canvas_view = layer_tex.view();
-                let paint_target = GpuPaintTarget::from_node(layer_tex, canvas_w, canvas_h);
+                let _paint_target = GpuPaintTarget::from_node(layer_tex, canvas_w, canvas_h);
                 let mut gpu_ctx = BrushGpuContext {
                     encoder: self.gpu.device.create_command_encoder(
                         &wgpu::CommandEncoderDescriptor {
@@ -1107,31 +1099,18 @@ impl DarklyEngine {
                     device: &self.gpu.device,
                     queue: &self.gpu.queue,
                     pipelines: &self.brush_pipelines,
-                    // No stroke buffer in this defensive fallback — `move_to`
-                    // only updates stabilizer state and never reaches into
-                    // scratch.  Anything that does would panic, which is the
-                    // correct signal that the fallback was reached.
-                    scratch: None,
+                    selection_bind_group: sel_bg,
                     canvas_width: canvas_w,
                     canvas_height: canvas_h,
-                    paint_target: Some(paint_target),
-                    selection_bind_group: sel_bg,
-                    preview_target_view: Some(canvas_view),
                     blend_mode: self.brush_blend_mode,
-                    preview_mask_view: None,
-                    preview_mask_size: (0, 0),
-                    preview_mask_overlay: None,
-                    brush_preview_info: None,
-                    pre_stroke_texture: None,
-                    pre_stroke_bind_group: None,
-                    dab_write_canvas_bbox: None,
                     perf: BrushPerfCounters::default(),
-                    pending_dab_bytes: Vec::new(),
-                    pending_dab_count: 0,
-                    pending_dabs_bbox: None,
-                    pending_dab_meta_bytes: Vec::new(),
-                    compiled_brush: None,
-                    slot_outputs_owned: None,
+                    // No stroke buffer in this defensive fallback — `move_to`
+                    // only updates stabilizer state and never reaches into
+                    // scratch. Anything that does would panic, which is the
+                    // correct signal that the fallback was reached.
+                    stroke: None,
+                    preview: None,
+                    dab_batch: DabBatch::default(),
                 };
                 self.brush_pipelines.reset_uniform_rings();
                 engine.move_to(info, &mut gpu_ctx);

--- a/crates/darkly/tests/brush_begin_stroke_lifecycle.rs
+++ b/crates/darkly/tests/brush_begin_stroke_lifecycle.rs
@@ -18,10 +18,11 @@ use std::sync::Arc;
 
 use darkly::brush::compile_graph;
 use darkly::brush::eval::BrushGraphRunner;
-use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters};
+use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters, DabBatch, StrokeResources};
 use darkly::brush::pipeline::BrushPipelines;
-use darkly::brush::scratch::Scratch;
+use darkly::brush::stroke_buffer::StrokeBuffer;
 use darkly::brush::wire::BrushWireType;
+use darkly::gpu::paint_target::GpuPaintTarget;
 use darkly::gpu::test_utils::{readback_texture, test_device};
 use darkly::nodegraph::Graph;
 
@@ -91,24 +92,25 @@ fn run_begin_stroke(graph: &Graph<BrushWireType>, setup: Setup) -> Vec<u8> {
     let device = Arc::new(device);
     let queue = Arc::new(queue);
     let pipelines = BrushPipelines::new(&device, &queue);
-    let mut scratch = Scratch::new(
-        &device,
-        W,
-        H,
-        pipelines.canvas_copy_bind_group_layout(),
-        pipelines.canvas_copy_sampler(),
-    );
+    // StrokeBuffer owns scratch + pre_stroke (texture, view, bind group),
+    // which is the exact bundle `StrokeResources` wants. Whichever lifecycle
+    // the terminal declares, only one of the two textures is read — the
+    // other is harmlessly present.
+    let mut stroke_buffer = StrokeBuffer::new(&device, W, H, &pipelines);
+    // Dummy paint target — `apply_lifecycle` never reads it, but the new
+    // `StrokeResources` shape requires it. Reuse the pre-stroke texture as
+    // a stand-in (same RGBA8 / W×H format).
+    let (paint_target_tex, paint_target_view) = make_pre_stroke(&device);
 
     // Build pre-stroke (if needed) and pre-fill scratch (if needed) on
     // the same device/queue the runner uses — wgpu rejects cross-device
     // resource use.
-    let pre_stroke = match &setup {
+    match &setup {
         Setup::PreStrokeWithSentinel => {
-            let (tex, view) = make_pre_stroke(&device);
             paint_solid(
                 &device,
                 &queue,
-                &view,
+                stroke_buffer.pre_stroke_view(),
                 wgpu::Color {
                     r: SENTINEL_RGBA[0] as f64 / 255.0,
                     g: SENTINEL_RGBA[1] as f64 / 255.0,
@@ -116,11 +118,14 @@ fn run_begin_stroke(graph: &Graph<BrushWireType>, setup: Setup) -> Vec<u8> {
                     a: SENTINEL_RGBA[3] as f64 / 255.0,
                 },
             );
-            Some(tex)
         }
         Setup::ScratchPrefilled(color) => {
-            paint_solid(&device, &queue, scratch.write_view(), *color);
-            None
+            paint_solid(
+                &device,
+                &queue,
+                stroke_buffer.scratch_mut().write_view(),
+                *color,
+            );
         }
     };
 
@@ -128,32 +133,31 @@ fn run_begin_stroke(graph: &Graph<BrushWireType>, setup: Setup) -> Vec<u8> {
     let encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
         label: Some("begin-stroke"),
     });
+    let (scratch, pre_stroke_tex, pre_stroke_bg) = stroke_buffer.parts_for_brush_ctx();
     let mut ctx = BrushGpuContext {
         encoder,
         device: &device,
         queue: &queue,
         pipelines: &pipelines,
-        scratch: Some(&mut scratch),
+        selection_bind_group: pipelines.default_selection_bind_group(),
         canvas_width: W,
         canvas_height: H,
-        paint_target: None,
-        selection_bind_group: pipelines.default_selection_bind_group(),
-        preview_target_view: None,
         blend_mode: 0,
-        preview_mask_view: None,
-        preview_mask_size: (0, 0),
-        preview_mask_overlay: None,
-        brush_preview_info: None,
-        pre_stroke_texture: pre_stroke.as_ref(),
-        pre_stroke_bind_group: None,
-        dab_write_canvas_bbox: None,
         perf: BrushPerfCounters::default(),
-        pending_dab_bytes: Vec::new(),
-        pending_dab_count: 0,
-        pending_dabs_bbox: None,
-        pending_dab_meta_bytes: Vec::new(),
-        compiled_brush: None,
-        slot_outputs_owned: None,
+        stroke: Some(StrokeResources {
+            scratch,
+            paint_target: GpuPaintTarget::from_canvas_texture(
+                &paint_target_tex,
+                &paint_target_view,
+                wgpu::TextureFormat::Rgba8Unorm,
+                W,
+                H,
+            ),
+            pre_stroke_texture: pre_stroke_tex,
+            pre_stroke_bind_group: pre_stroke_bg,
+        }),
+        preview: None,
+        dab_batch: DabBatch::default(),
     };
     runner.begin_stroke(&mut ctx);
     queue.submit([ctx.encoder.finish()]);
@@ -161,7 +165,7 @@ fn run_begin_stroke(graph: &Graph<BrushWireType>, setup: Setup) -> Vec<u8> {
     readback_texture(
         &device,
         &queue,
-        scratch.write_texture(),
+        stroke_buffer.scratch().write_texture(),
         wgpu::TextureFormat::Rgba8Unorm,
         W,
         H,

--- a/crates/darkly/tests/brush_preserves_pixels_outside_dab.rs
+++ b/crates/darkly/tests/brush_preserves_pixels_outside_dab.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, OnceLock};
 
 use darkly::brush::compile_graph;
 use darkly::brush::eval::BrushGraphRunner;
-use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters};
+use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters, DabBatch, StrokeResources};
 use darkly::brush::paint_info::PaintInformation;
 use darkly::brush::pipeline::BrushPipelines;
 use darkly::brush::stroke_buffer::StrokeBuffer;
@@ -81,35 +81,25 @@ fn render_one_dab(brush_name: &str, color: [f32; 4], canvas: &[u8]) -> Vec<u8> {
                 device: &device,
                 queue: &queue,
                 pipelines: &pipelines,
-                scratch: Some(scratch),
+                selection_bind_group: pipelines.default_selection_bind_group(),
                 canvas_width: CANVAS,
                 canvas_height: CANVAS,
-                paint_target: Some(
-                    darkly::gpu::paint_target::GpuPaintTarget::from_canvas_texture(
+                blend_mode: 0,
+                perf: BrushPerfCounters::default(),
+                stroke: Some(StrokeResources {
+                    scratch,
+                    paint_target: darkly::gpu::paint_target::GpuPaintTarget::from_canvas_texture(
                         &layer_texture,
                         &layer_view,
                         wgpu::TextureFormat::Rgba8Unorm,
                         CANVAS,
                         CANVAS,
                     ),
-                ),
-                selection_bind_group: pipelines.default_selection_bind_group(),
-                preview_target_view: None,
-                blend_mode: 0,
-                preview_mask_view: None,
-                preview_mask_size: (0, 0),
-                preview_mask_overlay: None,
-                brush_preview_info: None,
-                pre_stroke_texture: Some(pre_stroke_tex),
-                pre_stroke_bind_group: Some(pre_stroke_bg),
-                dab_write_canvas_bbox: None,
-                perf: BrushPerfCounters::default(),
-                pending_dab_bytes: Vec::new(),
-                pending_dab_count: 0,
-                pending_dabs_bbox: None,
-                pending_dab_meta_bytes: Vec::new(),
-                compiled_brush: None,
-                slot_outputs_owned: None,
+                    pre_stroke_texture: pre_stroke_tex,
+                    pre_stroke_bind_group: pre_stroke_bg,
+                }),
+                preview: None,
+                dab_batch: DabBatch::default(),
             }
         }};
     }

--- a/crates/darkly/tests/liquify.rs
+++ b/crates/darkly/tests/liquify.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, OnceLock};
 
 use darkly::brush::compile_graph;
 use darkly::brush::eval::BrushGraphRunner;
-use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters};
+use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters, DabBatch, StrokeResources};
 use darkly::brush::nodes::liquify::LIQUIFY_SPACING_PX;
 use darkly::brush::paint_info::PaintInformation;
 use darkly::brush::pipeline::BrushPipelines;
@@ -101,35 +101,25 @@ fn render_liquify_dabs(size_override: f32, dabs: &[([f32; 2], f32, f32)]) -> Vec
                 device: &device,
                 queue: &queue,
                 pipelines: &pipelines,
-                scratch: Some(scratch),
+                selection_bind_group: pipelines.default_selection_bind_group(),
                 canvas_width: CANVAS,
                 canvas_height: CANVAS,
-                paint_target: Some(
-                    darkly::gpu::paint_target::GpuPaintTarget::from_canvas_texture(
+                blend_mode: 0,
+                perf: BrushPerfCounters::default(),
+                stroke: Some(StrokeResources {
+                    scratch,
+                    paint_target: darkly::gpu::paint_target::GpuPaintTarget::from_canvas_texture(
                         &layer_texture,
                         &layer_view,
                         wgpu::TextureFormat::Rgba8Unorm,
                         CANVAS,
                         CANVAS,
                     ),
-                ),
-                selection_bind_group: pipelines.default_selection_bind_group(),
-                preview_target_view: None,
-                blend_mode: 0,
-                preview_mask_view: None,
-                preview_mask_size: (0, 0),
-                preview_mask_overlay: None,
-                brush_preview_info: None,
-                pre_stroke_texture: Some(pre_stroke_tex),
-                pre_stroke_bind_group: Some(pre_stroke_bg),
-                dab_write_canvas_bbox: None,
-                perf: BrushPerfCounters::default(),
-                pending_dab_bytes: Vec::new(),
-                pending_dab_count: 0,
-                pending_dabs_bbox: None,
-                pending_dab_meta_bytes: Vec::new(),
-                compiled_brush: None,
-                slot_outputs_owned: None,
+                    pre_stroke_texture: pre_stroke_tex,
+                    pre_stroke_bind_group: pre_stroke_bg,
+                }),
+                preview: None,
+                dab_batch: DabBatch::default(),
             }
         }};
     }

--- a/crates/darkly/tests/paint_basic.rs
+++ b/crates/darkly/tests/paint_basic.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, OnceLock};
 
 use darkly::brush::compile_graph;
 use darkly::brush::eval::BrushGraphRunner;
-use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters};
+use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters, DabBatch, StrokeResources};
 use darkly::brush::paint_info::PaintInformation;
 use darkly::brush::pipeline::BrushPipelines;
 use darkly::brush::stroke_buffer::StrokeBuffer;
@@ -96,35 +96,25 @@ fn render_single_dab_with_pressure(
                 device: &device,
                 queue: &queue,
                 pipelines: &pipelines,
-                scratch: Some(scratch),
+                selection_bind_group: pipelines.default_selection_bind_group(),
                 canvas_width: CANVAS,
                 canvas_height: CANVAS,
-                paint_target: Some(
-                    darkly::gpu::paint_target::GpuPaintTarget::from_canvas_texture(
+                blend_mode: 0,
+                perf: BrushPerfCounters::default(),
+                stroke: Some(StrokeResources {
+                    scratch,
+                    paint_target: darkly::gpu::paint_target::GpuPaintTarget::from_canvas_texture(
                         &layer_texture,
                         &layer_view,
                         wgpu::TextureFormat::Rgba8Unorm,
                         CANVAS,
                         CANVAS,
                     ),
-                ),
-                selection_bind_group: pipelines.default_selection_bind_group(),
-                preview_target_view: None,
-                blend_mode: 0,
-                preview_mask_view: None,
-                preview_mask_size: (0, 0),
-                preview_mask_overlay: None,
-                brush_preview_info: None,
-                pre_stroke_texture: Some(pre_stroke_tex),
-                pre_stroke_bind_group: Some(pre_stroke_bg),
-                dab_write_canvas_bbox: None,
-                perf: BrushPerfCounters::default(),
-                pending_dab_bytes: Vec::new(),
-                pending_dab_count: 0,
-                pending_dabs_bbox: None,
-                pending_dab_meta_bytes: Vec::new(),
-                compiled_brush: None,
-                slot_outputs_owned: None,
+                    pre_stroke_texture: pre_stroke_tex,
+                    pre_stroke_bind_group: pre_stroke_bg,
+                }),
+                preview: None,
+                dab_batch: DabBatch::default(),
             }
         }};
     }

--- a/crates/darkly/tests/preview_liquify.rs
+++ b/crates/darkly/tests/preview_liquify.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use darkly::brush::compile_graph;
 use darkly::brush::eval::BrushGraphRunner;
-use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters};
+use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters, DabBatch, PreviewState};
 use darkly::brush::paint_info::PaintInformation;
 use darkly::brush::pipeline::BrushPipelines;
 use darkly::gpu::test_utils::{readback_texture, test_device};
@@ -65,27 +65,19 @@ fn liquify_preview_shows_neutral_gray_disc() {
         device: &device,
         queue: &queue,
         pipelines: &pipelines,
-        scratch: None,
+        selection_bind_group: pipelines.default_selection_bind_group(),
         canvas_width: PREVIEW_SIDE,
         canvas_height: PREVIEW_SIDE,
-        paint_target: None,
-        selection_bind_group: pipelines.default_selection_bind_group(),
-        preview_target_view: Some(&target_view),
         blend_mode: 0,
-        preview_mask_view: Some(&target_view),
-        preview_mask_size: (PREVIEW_SIDE, PREVIEW_SIDE),
-        preview_mask_overlay: None,
-        brush_preview_info: None,
-        pre_stroke_texture: None,
-        pre_stroke_bind_group: None,
-        dab_write_canvas_bbox: None,
         perf: BrushPerfCounters::default(),
-        pending_dab_bytes: Vec::new(),
-        pending_dab_count: 0,
-        pending_dabs_bbox: None,
-        pending_dab_meta_bytes: Vec::new(),
-        compiled_brush: None,
-        slot_outputs_owned: None,
+        stroke: None,
+        preview: Some(PreviewState {
+            mask_view: Some(&target_view),
+            mask_size: (PREVIEW_SIDE, PREVIEW_SIDE),
+            mask_overlay: None,
+            info: None,
+        }),
+        dab_batch: DabBatch::default(),
     };
 
     let info = PaintInformation {
@@ -97,7 +89,9 @@ fn liquify_preview_shows_neutral_gray_disc() {
     runner.execute_cpu();
     runner.render_preview_pipeline(&mut ctx);
     let _published = ctx
-        .brush_preview_info
+        .preview
+        .as_ref()
+        .and_then(|p| p.info)
         .expect("liquify publishes brush_preview_info");
     queue.submit([ctx.encoder.finish()]);
 
@@ -165,27 +159,19 @@ fn liquify_preview_softness_reshapes_falloff() {
             device: &device,
             queue: &queue,
             pipelines: &pipelines,
-            scratch: None,
+            selection_bind_group: pipelines.default_selection_bind_group(),
             canvas_width: PREVIEW_SIDE,
             canvas_height: PREVIEW_SIDE,
-            paint_target: None,
-            selection_bind_group: pipelines.default_selection_bind_group(),
-            preview_target_view: Some(&target_view),
             blend_mode: 0,
-            preview_mask_view: Some(&target_view),
-            preview_mask_size: (PREVIEW_SIDE, PREVIEW_SIDE),
-            preview_mask_overlay: None,
-            brush_preview_info: None,
-            pre_stroke_texture: None,
-            pre_stroke_bind_group: None,
-            dab_write_canvas_bbox: None,
             perf: BrushPerfCounters::default(),
-            pending_dab_bytes: Vec::new(),
-            pending_dab_count: 0,
-            pending_dabs_bbox: None,
-            pending_dab_meta_bytes: Vec::new(),
-            compiled_brush: None,
-            slot_outputs_owned: None,
+            stroke: None,
+            preview: Some(PreviewState {
+                mask_view: Some(&target_view),
+                mask_size: (PREVIEW_SIDE, PREVIEW_SIDE),
+                mask_overlay: None,
+                info: None,
+            }),
+            dab_batch: DabBatch::default(),
         };
         let info = PaintInformation {
             pos: [PREVIEW_SIDE as f32 * 0.5, PREVIEW_SIDE as f32 * 0.5],
@@ -196,7 +182,9 @@ fn liquify_preview_softness_reshapes_falloff() {
         runner.execute_cpu();
         runner.render_preview_pipeline(&mut ctx);
         let half_extent = ctx
-            .brush_preview_info
+            .preview
+            .as_ref()
+            .and_then(|p| p.info)
             .expect("liquify publishes preview info")
             .half_extent_canvas_px[0];
         queue.submit([ctx.encoder.finish()]);

--- a/crates/darkly/tests/preview_paint.rs
+++ b/crates/darkly/tests/preview_paint.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use darkly::brush::compile_graph;
 use darkly::brush::eval::BrushGraphRunner;
-use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters};
+use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters, DabBatch, PreviewState};
 use darkly::brush::paint_info::PaintInformation;
 use darkly::brush::pipeline::BrushPipelines;
 use darkly::gpu::test_utils::{readback_texture, test_device};
@@ -70,27 +70,19 @@ fn render_preview(brush_name: &str, size_override: f32, color: [f32; 4]) -> Prev
         device: &device,
         queue: &queue,
         pipelines: &pipelines,
-        scratch: None,
+        selection_bind_group: pipelines.default_selection_bind_group(),
         canvas_width: PREVIEW_SIDE,
         canvas_height: PREVIEW_SIDE,
-        paint_target: None,
-        selection_bind_group: pipelines.default_selection_bind_group(),
-        preview_target_view: Some(&target_view),
         blend_mode: 0,
-        preview_mask_view: Some(&target_view),
-        preview_mask_size: (PREVIEW_SIDE, PREVIEW_SIDE),
-        preview_mask_overlay: None,
-        brush_preview_info: None,
-        pre_stroke_texture: None,
-        pre_stroke_bind_group: None,
-        dab_write_canvas_bbox: None,
         perf: BrushPerfCounters::default(),
-        pending_dab_bytes: Vec::new(),
-        pending_dab_count: 0,
-        pending_dabs_bbox: None,
-        pending_dab_meta_bytes: Vec::new(),
-        compiled_brush: None,
-        slot_outputs_owned: None,
+        stroke: None,
+        preview: Some(PreviewState {
+            mask_view: Some(&target_view),
+            mask_size: (PREVIEW_SIDE, PREVIEW_SIDE),
+            mask_overlay: None,
+            info: None,
+        }),
+        dab_batch: DabBatch::default(),
     };
 
     let info = PaintInformation {
@@ -102,7 +94,9 @@ fn render_preview(brush_name: &str, size_override: f32, color: [f32; 4]) -> Prev
     runner.execute_cpu();
     runner.render_preview_pipeline(&mut ctx);
     let published = ctx
-        .brush_preview_info
+        .preview
+        .as_ref()
+        .and_then(|p| p.info)
         .expect("paint publishes brush_preview_info");
     queue.submit([ctx.encoder.finish()]);
 

--- a/crates/darkly/tests/preview_rotation.rs
+++ b/crates/darkly/tests/preview_rotation.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use darkly::brush::compile_graph;
 use darkly::brush::eval::BrushGraphRunner;
-use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters};
+use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters, DabBatch, PreviewState};
 use darkly::brush::paint_info::PaintInformation;
 use darkly::brush::pipeline::BrushPipelines;
 use darkly::brush::registry;
@@ -113,27 +113,19 @@ fn pen_tilt_direction_drives_preview_rotation() {
         device: &device,
         queue: &queue,
         pipelines: &pipelines,
-        scratch: None,
+        selection_bind_group: pipelines.default_selection_bind_group(),
         canvas_width: PREVIEW_SIDE,
         canvas_height: PREVIEW_SIDE,
-        paint_target: None,
-        selection_bind_group: pipelines.default_selection_bind_group(),
-        preview_target_view: Some(&target_view),
         blend_mode: 0,
-        preview_mask_view: Some(&target_view),
-        preview_mask_size: (PREVIEW_SIDE, PREVIEW_SIDE),
-        preview_mask_overlay: None,
-        brush_preview_info: None,
-        pre_stroke_texture: None,
-        pre_stroke_bind_group: None,
-        dab_write_canvas_bbox: None,
         perf: BrushPerfCounters::default(),
-        pending_dab_bytes: Vec::new(),
-        pending_dab_count: 0,
-        pending_dabs_bbox: None,
-        pending_dab_meta_bytes: Vec::new(),
-        compiled_brush: None,
-        slot_outputs_owned: None,
+        stroke: None,
+        preview: Some(PreviewState {
+            mask_view: Some(&target_view),
+            mask_size: (PREVIEW_SIDE, PREVIEW_SIDE),
+            mask_overlay: None,
+            info: None,
+        }),
+        dab_batch: DabBatch::default(),
     };
 
     // Non-zero pen tilt direction. The runner's `seed_sensors` writes
@@ -152,7 +144,9 @@ fn pen_tilt_direction_drives_preview_rotation() {
     runner.render_preview_pipeline(&mut ctx);
 
     let rotation = ctx
-        .brush_preview_info
+        .preview
+        .as_ref()
+        .and_then(|p| p.info)
         .expect("paint publishes brush_preview_info during preview")
         .rotation_rad;
 

--- a/crates/darkly/tests/preview_smudge.rs
+++ b/crates/darkly/tests/preview_smudge.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use darkly::brush::compile_graph;
 use darkly::brush::eval::BrushGraphRunner;
-use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters};
+use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters, DabBatch, PreviewState};
 use darkly::brush::paint_info::PaintInformation;
 use darkly::brush::pipeline::BrushPipelines;
 use darkly::gpu::test_utils::{readback_texture, test_device};
@@ -67,27 +67,19 @@ fn smudge_preview_shows_neutral_gray_footprint() {
         device: &device,
         queue: &queue,
         pipelines: &pipelines,
-        scratch: None,
+        selection_bind_group: pipelines.default_selection_bind_group(),
         canvas_width: PREVIEW_SIDE,
         canvas_height: PREVIEW_SIDE,
-        paint_target: None,
-        selection_bind_group: pipelines.default_selection_bind_group(),
-        preview_target_view: Some(&target_view),
         blend_mode: 0,
-        preview_mask_view: Some(&target_view),
-        preview_mask_size: (PREVIEW_SIDE, PREVIEW_SIDE),
-        preview_mask_overlay: None,
-        brush_preview_info: None,
-        pre_stroke_texture: None,
-        pre_stroke_bind_group: None,
-        dab_write_canvas_bbox: None,
         perf: BrushPerfCounters::default(),
-        pending_dab_bytes: Vec::new(),
-        pending_dab_count: 0,
-        pending_dabs_bbox: None,
-        pending_dab_meta_bytes: Vec::new(),
-        compiled_brush: None,
-        slot_outputs_owned: None,
+        stroke: None,
+        preview: Some(PreviewState {
+            mask_view: Some(&target_view),
+            mask_size: (PREVIEW_SIDE, PREVIEW_SIDE),
+            mask_overlay: None,
+            info: None,
+        }),
+        dab_batch: DabBatch::default(),
     };
 
     let info = PaintInformation {
@@ -99,7 +91,9 @@ fn smudge_preview_shows_neutral_gray_footprint() {
     runner.execute_cpu();
     runner.render_preview_pipeline(&mut ctx);
     let published = ctx
-        .brush_preview_info
+        .preview
+        .as_ref()
+        .and_then(|p| p.info)
         .expect("smudge publishes brush_preview_info");
     queue.submit([ctx.encoder.finish()]);
 

--- a/crates/darkly/tests/preview_unit_invariance.rs
+++ b/crates/darkly/tests/preview_unit_invariance.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use darkly::brush::compile_graph;
 use darkly::brush::eval::BrushGraphRunner;
-use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters};
+use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters, DabBatch, PreviewState};
 use darkly::brush::paint_info::PaintInformation;
 use darkly::brush::pipeline::BrushPipelines;
 use darkly::gpu::test_utils::{readback_texture, test_device};
@@ -91,32 +91,24 @@ fn render_big_round() -> Out {
         device: &device,
         queue: &queue,
         pipelines: &pipelines,
-        scratch: None,
+        selection_bind_group: pipelines.default_selection_bind_group(),
         canvas_width: PREVIEW_SIDE,
         canvas_height: PREVIEW_SIDE,
-        paint_target: None,
-        selection_bind_group: pipelines.default_selection_bind_group(),
-        preview_target_view: Some(&target_view),
         blend_mode: 0,
+        perf: BrushPerfCounters::default(),
+        stroke: None,
         // Drive the test-fallback path on `ensure_preview_mask` — the
         // production clamp path needs a real `ToolOverlay`, which is
         // heavier to construct than this test needs. The undersized
         // mask reproduces the exact same target-vs-canvas unit
         // mismatch the production clamp triggers.
-        preview_mask_view: Some(&target_view),
-        preview_mask_size: (PREVIEW_SIDE, PREVIEW_SIDE),
-        preview_mask_overlay: None,
-        brush_preview_info: None,
-        pre_stroke_texture: None,
-        pre_stroke_bind_group: None,
-        dab_write_canvas_bbox: None,
-        perf: BrushPerfCounters::default(),
-        pending_dab_bytes: Vec::new(),
-        pending_dab_count: 0,
-        pending_dabs_bbox: None,
-        pending_dab_meta_bytes: Vec::new(),
-        compiled_brush: None,
-        slot_outputs_owned: None,
+        preview: Some(PreviewState {
+            mask_view: Some(&target_view),
+            mask_size: (PREVIEW_SIDE, PREVIEW_SIDE),
+            mask_overlay: None,
+            info: None,
+        }),
+        dab_batch: DabBatch::default(),
     };
 
     let info = PaintInformation {
@@ -128,7 +120,9 @@ fn render_big_round() -> Out {
     runner.execute_cpu();
     runner.render_preview_pipeline(&mut ctx);
     let published = ctx
-        .brush_preview_info
+        .preview
+        .as_ref()
+        .and_then(|p| p.info)
         .expect("render_compiled_preview publishes BrushPreviewInfo");
     queue.submit([ctx.encoder.finish()]);
 

--- a/crates/darkly/tests/preview_watercolor.rs
+++ b/crates/darkly/tests/preview_watercolor.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use darkly::brush::compile_graph;
 use darkly::brush::eval::BrushGraphRunner;
-use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters};
+use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters, DabBatch, PreviewState};
 use darkly::brush::paint_info::PaintInformation;
 use darkly::brush::pipeline::BrushPipelines;
 use darkly::gpu::test_utils::{readback_texture, test_device};
@@ -68,27 +68,19 @@ fn render_preview(brush_name: &str, size_override: f32, color: [f32; 4]) -> Prev
         device: &device,
         queue: &queue,
         pipelines: &pipelines,
-        scratch: None,
+        selection_bind_group: pipelines.default_selection_bind_group(),
         canvas_width: PREVIEW_SIDE,
         canvas_height: PREVIEW_SIDE,
-        paint_target: None,
-        selection_bind_group: pipelines.default_selection_bind_group(),
-        preview_target_view: Some(&target_view),
         blend_mode: 0,
-        preview_mask_view: Some(&target_view),
-        preview_mask_size: (PREVIEW_SIDE, PREVIEW_SIDE),
-        preview_mask_overlay: None,
-        brush_preview_info: None,
-        pre_stroke_texture: None,
-        pre_stroke_bind_group: None,
-        dab_write_canvas_bbox: None,
         perf: BrushPerfCounters::default(),
-        pending_dab_bytes: Vec::new(),
-        pending_dab_count: 0,
-        pending_dabs_bbox: None,
-        pending_dab_meta_bytes: Vec::new(),
-        compiled_brush: None,
-        slot_outputs_owned: None,
+        stroke: None,
+        preview: Some(PreviewState {
+            mask_view: Some(&target_view),
+            mask_size: (PREVIEW_SIDE, PREVIEW_SIDE),
+            mask_overlay: None,
+            info: None,
+        }),
+        dab_batch: DabBatch::default(),
     };
 
     let info = PaintInformation {
@@ -100,7 +92,9 @@ fn render_preview(brush_name: &str, size_override: f32, color: [f32; 4]) -> Prev
     runner.execute_cpu();
     runner.render_preview_pipeline(&mut ctx);
     let published = ctx
-        .brush_preview_info
+        .preview
+        .as_ref()
+        .and_then(|p| p.info)
         .expect("watercolor publishes brush_preview_info");
     queue.submit([ctx.encoder.finish()]);
 

--- a/crates/darkly/tests/probe_liquify.rs
+++ b/crates/darkly/tests/probe_liquify.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use darkly::brush::compile_graph;
 use darkly::brush::eval::BrushGraphRunner;
-use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters};
+use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters, DabBatch, PreviewState};
 use darkly::brush::paint_info::PaintInformation;
 use darkly::brush::pipeline::BrushPipelines;
 use darkly::gpu::test_utils::{readback_texture, test_device};
@@ -52,27 +52,19 @@ fn probe_softness_zero() {
         device: &device,
         queue: &queue,
         pipelines: &pipelines,
-        scratch: None,
+        selection_bind_group: pipelines.default_selection_bind_group(),
         canvas_width: PREVIEW_SIDE,
         canvas_height: PREVIEW_SIDE,
-        paint_target: None,
-        selection_bind_group: pipelines.default_selection_bind_group(),
-        preview_target_view: Some(&view),
         blend_mode: 0,
-        preview_mask_view: Some(&view),
-        preview_mask_size: (PREVIEW_SIDE, PREVIEW_SIDE),
-        preview_mask_overlay: None,
-        brush_preview_info: None,
-        pre_stroke_texture: None,
-        pre_stroke_bind_group: None,
-        dab_write_canvas_bbox: None,
         perf: BrushPerfCounters::default(),
-        pending_dab_bytes: Vec::new(),
-        pending_dab_count: 0,
-        pending_dabs_bbox: None,
-        pending_dab_meta_bytes: Vec::new(),
-        compiled_brush: None,
-        slot_outputs_owned: None,
+        stroke: None,
+        preview: Some(PreviewState {
+            mask_view: Some(&view),
+            mask_size: (PREVIEW_SIDE, PREVIEW_SIDE),
+            mask_overlay: None,
+            info: None,
+        }),
+        dab_batch: DabBatch::default(),
     };
     let info = PaintInformation {
         pos: [128.0, 128.0],
@@ -82,7 +74,7 @@ fn probe_softness_zero() {
     runner.seed_sensors(&info, [1.0, 1.0, 1.0, 1.0], 0, 0);
     runner.execute_cpu();
     runner.render_preview_pipeline(&mut ctx);
-    let bpi = ctx.brush_preview_info.unwrap();
+    let bpi = ctx.preview.as_ref().and_then(|p| p.info).unwrap();
     eprintln!("bbox_half = {:?}", bpi.half_extent_canvas_px);
     queue.submit([ctx.encoder.finish()]);
     let rgba = readback_texture(

--- a/crates/darkly/tests/rough_ink.rs
+++ b/crates/darkly/tests/rough_ink.rs
@@ -21,7 +21,7 @@ use std::sync::{Arc, OnceLock};
 
 use darkly::brush::compile_graph;
 use darkly::brush::eval::BrushGraphRunner;
-use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters};
+use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters, DabBatch, StrokeResources};
 use darkly::brush::paint_info::PaintInformation;
 use darkly::brush::pipeline::BrushPipelines;
 use darkly::brush::registry;
@@ -179,35 +179,25 @@ macro_rules! make_ctx {
             device: &$h.device,
             queue: &$h.queue,
             pipelines: &$h.pipelines,
-            scratch: Some(_scratch),
+            selection_bind_group: $h.pipelines.default_selection_bind_group(),
             canvas_width: CANVAS,
             canvas_height: CANVAS,
-            paint_target: Some(
-                darkly::gpu::paint_target::GpuPaintTarget::from_canvas_texture(
+            blend_mode: 0,
+            perf: BrushPerfCounters::default(),
+            stroke: Some(StrokeResources {
+                scratch: _scratch,
+                paint_target: darkly::gpu::paint_target::GpuPaintTarget::from_canvas_texture(
                     &$h.layer_texture,
                     &$h.layer_view,
                     wgpu::TextureFormat::Rgba8Unorm,
                     CANVAS,
                     CANVAS,
                 ),
-            ),
-            selection_bind_group: $h.pipelines.default_selection_bind_group(),
-            preview_target_view: None,
-            blend_mode: 0,
-            preview_mask_view: None,
-            preview_mask_size: (0, 0),
-            preview_mask_overlay: None,
-            brush_preview_info: None,
-            pre_stroke_texture: Some(_pre_stroke_texture),
-            pre_stroke_bind_group: Some(_pre_stroke_bind_group),
-            dab_write_canvas_bbox: None,
-            perf: BrushPerfCounters::default(),
-            pending_dab_bytes: Vec::new(),
-            pending_dab_count: 0,
-            pending_dabs_bbox: None,
-            pending_dab_meta_bytes: Vec::new(),
-            compiled_brush: None,
-            slot_outputs_owned: None,
+                pre_stroke_texture: _pre_stroke_texture,
+                pre_stroke_bind_group: _pre_stroke_bind_group,
+            }),
+            preview: None,
+            dab_batch: DabBatch::default(),
         }
     }};
 }

--- a/crates/darkly/tests/smudge.rs
+++ b/crates/darkly/tests/smudge.rs
@@ -16,7 +16,7 @@ use std::sync::{Arc, OnceLock};
 
 use darkly::brush::compile_graph;
 use darkly::brush::eval::BrushGraphRunner;
-use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters};
+use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters, DabBatch, StrokeResources};
 use darkly::brush::paint_info::PaintInformation;
 use darkly::brush::pipeline::BrushPipelines;
 use darkly::brush::stroke_buffer::StrokeBuffer;
@@ -107,35 +107,25 @@ fn render_smudge_dabs(size_override: f32, dabs: &[([f32; 2], [f32; 2])]) -> Vec<
                 device: &device,
                 queue: &queue,
                 pipelines: &pipelines,
-                scratch: Some(scratch),
+                selection_bind_group: pipelines.default_selection_bind_group(),
                 canvas_width: CANVAS,
                 canvas_height: CANVAS,
-                paint_target: Some(
-                    darkly::gpu::paint_target::GpuPaintTarget::from_canvas_texture(
+                blend_mode: 0,
+                perf: BrushPerfCounters::default(),
+                stroke: Some(StrokeResources {
+                    scratch,
+                    paint_target: darkly::gpu::paint_target::GpuPaintTarget::from_canvas_texture(
                         &layer_texture,
                         &layer_view,
                         wgpu::TextureFormat::Rgba8Unorm,
                         CANVAS,
                         CANVAS,
                     ),
-                ),
-                selection_bind_group: pipelines.default_selection_bind_group(),
-                preview_target_view: None,
-                blend_mode: 0,
-                preview_mask_view: None,
-                preview_mask_size: (0, 0),
-                preview_mask_overlay: None,
-                brush_preview_info: None,
-                pre_stroke_texture: Some(pre_stroke_tex),
-                pre_stroke_bind_group: Some(pre_stroke_bg),
-                dab_write_canvas_bbox: None,
-                perf: BrushPerfCounters::default(),
-                pending_dab_bytes: Vec::new(),
-                pending_dab_count: 0,
-                pending_dabs_bbox: None,
-                pending_dab_meta_bytes: Vec::new(),
-                compiled_brush: None,
-                slot_outputs_owned: None,
+                    pre_stroke_texture: pre_stroke_tex,
+                    pre_stroke_bind_group: pre_stroke_bg,
+                }),
+                preview: None,
+                dab_batch: DabBatch::default(),
             }
         }};
     }

--- a/crates/darkly/tests/watercolor.rs
+++ b/crates/darkly/tests/watercolor.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, OnceLock};
 
 use darkly::brush::compile_graph;
 use darkly::brush::eval::BrushGraphRunner;
-use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters};
+use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters, DabBatch, StrokeResources};
 use darkly::brush::paint_info::PaintInformation;
 use darkly::brush::pipeline::BrushPipelines;
 use darkly::brush::stroke_buffer::StrokeBuffer;
@@ -99,35 +99,25 @@ fn render_dabs_on(
                 device: &device,
                 queue: &queue,
                 pipelines: &pipelines,
-                scratch: Some(scratch),
+                selection_bind_group: pipelines.default_selection_bind_group(),
                 canvas_width: CANVAS,
                 canvas_height: CANVAS,
-                paint_target: Some(
-                    darkly::gpu::paint_target::GpuPaintTarget::from_canvas_texture(
+                blend_mode: 0,
+                perf: BrushPerfCounters::default(),
+                stroke: Some(StrokeResources {
+                    scratch,
+                    paint_target: darkly::gpu::paint_target::GpuPaintTarget::from_canvas_texture(
                         &layer_texture,
                         &layer_view,
                         wgpu::TextureFormat::Rgba8Unorm,
                         CANVAS,
                         CANVAS,
                     ),
-                ),
-                selection_bind_group: pipelines.default_selection_bind_group(),
-                preview_target_view: None,
-                blend_mode: 0,
-                preview_mask_view: None,
-                preview_mask_size: (0, 0),
-                preview_mask_overlay: None,
-                brush_preview_info: None,
-                pre_stroke_texture: Some(pre_stroke_tex),
-                pre_stroke_bind_group: Some(pre_stroke_bg),
-                dab_write_canvas_bbox: None,
-                perf: BrushPerfCounters::default(),
-                pending_dab_bytes: Vec::new(),
-                pending_dab_count: 0,
-                pending_dabs_bbox: None,
-                pending_dab_meta_bytes: Vec::new(),
-                compiled_brush: None,
-                slot_outputs_owned: None,
+                    pre_stroke_texture: pre_stroke_tex,
+                    pre_stroke_bind_group: pre_stroke_bg,
+                }),
+                preview: None,
+                dab_batch: DabBatch::default(),
             }
         }};
     }
@@ -306,35 +296,25 @@ fn begin_stroke_clears_scratch_so_rewind_drops_defunct_pigment() {
                 device: &device,
                 queue: &queue,
                 pipelines: &pipelines,
-                scratch: Some(scratch),
+                selection_bind_group: pipelines.default_selection_bind_group(),
                 canvas_width: CANVAS,
                 canvas_height: CANVAS,
-                paint_target: Some(
-                    darkly::gpu::paint_target::GpuPaintTarget::from_canvas_texture(
+                blend_mode: 0,
+                perf: BrushPerfCounters::default(),
+                stroke: Some(StrokeResources {
+                    scratch,
+                    paint_target: darkly::gpu::paint_target::GpuPaintTarget::from_canvas_texture(
                         &layer_texture,
                         &layer_view,
                         wgpu::TextureFormat::Rgba8Unorm,
                         CANVAS,
                         CANVAS,
                     ),
-                ),
-                selection_bind_group: pipelines.default_selection_bind_group(),
-                preview_target_view: None,
-                blend_mode: 0,
-                preview_mask_view: None,
-                preview_mask_size: (0, 0),
-                preview_mask_overlay: None,
-                brush_preview_info: None,
-                pre_stroke_texture: Some(pre_stroke_tex),
-                pre_stroke_bind_group: Some(pre_stroke_bg),
-                dab_write_canvas_bbox: None,
-                perf: BrushPerfCounters::default(),
-                pending_dab_bytes: Vec::new(),
-                pending_dab_count: 0,
-                pending_dabs_bbox: None,
-                pending_dab_meta_bytes: Vec::new(),
-                compiled_brush: None,
-                slot_outputs_owned: None,
+                    pre_stroke_texture: pre_stroke_tex,
+                    pre_stroke_bind_group: pre_stroke_bg,
+                }),
+                preview: None,
+                dab_batch: DabBatch::default(),
             }
         }};
     }


### PR DESCRIPTION
## Summary

- Decompose `BrushGpuContext`'s 22-field flat struct into three typed groupings — `stroke: Option<StrokeResources>` (scratch + paint_target + pre_stroke_*), `preview: Option<PreviewState>` (mask + overlay + published info), and `dab_batch: DabBatch` (the per-batch dab ledger). The two `Option`s are mutually exclusive by construction, so "preview vs stroke mode" is now a type-level signal instead of "these fields are nil when irrelevant."
- Delete dead field `preview_target_view` (never read anywhere) and its setters in 7 test files + the painting.rs fallback.
- Hoist `full_rerender_events` off `BrushPerfCounters` onto `DarklyEngine` (per-engine event; the per-context value was always zero).
- Centralise the `MAX_DABS_PER_PHASE` debug_assert on `DabBatch::queue_dab` so terminals don't each carry their own check.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --exclude darkly-wasm -- -D warnings`
- [x] `cargo clippy -p darkly-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings`
- [x] `cargo test --workspace --exclude darkly-wasm -- --test-threads=1` (all suites pass, including the four lifecycle/begin_stroke regression tests and the per-terminal preview tests)
- [x] `wasm-pack build --release --target web` (frontend/wasm)
- [x] `npx tsc --noEmit` + `npm run build` + `npm test` (frontend)
