### PR TITLE
GPU subsystem code cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --workspace --all-targets --exclude darkly-wasm -- -D warnings
+      - run: cargo clippy --workspace --all-targets --exclude darkly-wasm --features darkly/testing -- -D warnings
 
   clippy-wasm:
     name: clippy (wasm32)
@@ -63,7 +63,7 @@ jobs:
       - name: cargo llvm-cov
         env:
           WGPU_BACKEND: vulkan
-        run: cargo llvm-cov --workspace --exclude darkly-wasm --lcov --output-path lcov.info -- --test-threads=1
+        run: cargo llvm-cov --workspace --exclude darkly-wasm --features darkly/testing --lcov --output-path lcov.info -- --test-threads=1
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,10 +184,13 @@ Run at commit time only — not during iterative debugging. Use `cargo check` fo
 
 ```bash
 cargo fmt --all -- --check
-RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --exclude darkly-wasm -- -D warnings
+RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --exclude darkly-wasm --features darkly/testing -- -D warnings
 RUSTFLAGS="-D warnings" cargo clippy -p darkly-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings
+# `--features darkly/testing` exposes `gpu::test_utils`, `blocking_read`, and
+# the engine's `test_readback_*` accessors that integration tests rely on
+# (compile-time gate enforcing CLAUDE.md "No Blocking GPU Readbacks").
 # `--test-threads=1` is mandatory: GPU-touching integration tests (`engine.rs`, `blend_modes.rs`, etc.) share a process-wide wgpu device and SIGSEGV when run in parallel.
-cargo test --workspace --exclude darkly-wasm -- --test-threads=1
+cargo test --workspace --exclude darkly-wasm --features darkly/testing -- --test-threads=1
 (cd frontend/wasm && wasm-pack build --release --target web --out-dir pkg)
 # `vite build` only transpiles — `tsc --noEmit` is the actual TS gate.
 (cd frontend && npx tsc --noEmit)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "serde_json",
  "serde_yml",
  "slotmap",
+ "smallvec",
  "syn",
  "thiserror 1.0.69",
  "web-time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ quick-xml = "0.36"
 base64 = "0.22"
 thiserror = "1.0"
 slotmap = { version = "1.0", features = ["serde"] }
+smallvec = "1"
 
 # WASM
 wasm-bindgen = "=0.2.114"

--- a/crates/darkly/Cargo.toml
+++ b/crates/darkly/Cargo.toml
@@ -6,6 +6,11 @@ license.workspace = true
 
 [features]
 profile = []
+# Enables blocking GPU readbacks, `gpu::test_utils`, and `*::test_readback_*`
+# accessors. WebGPU/WASM deadlocks on these (see CLAUDE.md "No Blocking GPU
+# Readbacks"); the feature exists so `cargo test` and the bench bins can opt
+# in while production / WASM builds cannot reach the API at all.
+testing = []
 
 [dependencies]
 wgpu = { workspace = true }
@@ -22,11 +27,20 @@ quick-xml = { workspace = true }
 base64 = { workspace = true }
 thiserror = { workspace = true }
 slotmap = { workspace = true }
+smallvec = { workspace = true }
 
 [dev-dependencies]
 pollster = "0.4"
 naga = { version = "28.0", features = ["wgsl-in"] }
 syn = { version = "2", features = ["visit", "full"] }
+
+[[bin]]
+name = "stroke_replay_bench"
+required-features = ["testing"]
+
+[[bin]]
+name = "stroke_replay_matrix"
+required-features = ["testing"]
 
 [lints]
 workspace = true

--- a/crates/darkly/src/engine/brush_graph.rs
+++ b/crates/darkly/src/engine/brush_graph.rs
@@ -226,7 +226,8 @@ impl DarklyEngine {
                 Ok(r) => r,
                 Err(_) => {
                     drop(tool);
-                    self.compositor.clear_overlay_preview_mask();
+                    self.compositor.tool_overlay_mut().clear_preview_mask();
+                    self.compositor.mark_needs_present();
                     self.brush_preview_info = None;
                     return;
                 }
@@ -301,10 +302,13 @@ impl DarklyEngine {
         self.gpu.queue.submit([command_buf]);
 
         if info.is_some() {
-            self.compositor.use_overlay_preview_mask();
+            self.compositor
+                .tool_overlay_mut()
+                .use_preview_mask_as_mask();
         } else {
-            self.compositor.clear_overlay_preview_mask();
+            self.compositor.tool_overlay_mut().clear_preview_mask();
         }
+        self.compositor.mark_needs_present();
         self.brush_preview_info = info;
     }
 

--- a/crates/darkly/src/engine/layers.rs
+++ b/crates/darkly/src/engine/layers.rs
@@ -488,7 +488,7 @@ impl DarklyEngine {
                 let opacity = blend.opacity;
                 let blend_mode_gpu = blend.blend_mode.gpu_value;
                 let isolated = self.host_renders_isolated(layer_id);
-                self.compositor.update_layer_uniforms_full(
+                self.compositor.update_layer_uniforms(
                     &self.gpu.queue,
                     layer_id,
                     opacity,

--- a/crates/darkly/src/engine/layers.rs
+++ b/crates/darkly/src/engine/layers.rs
@@ -61,13 +61,18 @@ impl DarklyEngine {
         let id =
             self.doc
                 .add_void_layer(void_type.to_string(), display_label, params.clone(), anchor);
-        self.compositor.ensure_void_layer(
-            &self.gpu.device,
-            &self.gpu.queue,
-            id,
+        // Build the trait object here (engine), then hand it to the
+        // compositor — the compositor stops caring about `(type_id,
+        // params)` as a pair, owning only the constructed `Box<dyn Void>`.
+        let format = self.compositor.canvas_content_format();
+        let void = self.compositor.void_registry_mut().create_void(
             void_type,
             &params,
+            &self.gpu.device,
+            format,
         );
+        self.compositor
+            .ensure_void_layer(&self.gpu.device, &self.gpu.queue, id, void);
         self.compositor.mark_dirty();
 
         let parent = self.doc.parent_of(id);
@@ -88,20 +93,15 @@ impl DarklyEngine {
         if !self.doc.is_node_editable(layer_id) {
             return;
         }
-        let (old_params, void_type) = match self.doc.find_node(layer_id) {
-            Some(LayerNode::Layer(Layer::Void(v))) => (v.params.clone(), v.void_type.clone()),
+        let old_params = match self.doc.find_node(layer_id) {
+            Some(LayerNode::Layer(Layer::Void(v))) => v.params.clone(),
             _ => return,
         };
         if let Some(LayerNode::Layer(Layer::Void(v))) = self.doc.find_node_mut(layer_id) {
             v.params = new_params.clone();
         }
-        self.compositor.update_void_layer_params(
-            &self.gpu.device,
-            &self.gpu.queue,
-            layer_id,
-            &void_type,
-            &new_params,
-        );
+        self.compositor
+            .update_void_layer_params(&self.gpu.queue, layer_id, &new_params);
         self.compositor.mark_dirty();
 
         self.coalesce_property_undo(PropertyAction::new(

--- a/crates/darkly/src/engine/mod.rs
+++ b/crates/darkly/src/engine/mod.rs
@@ -600,7 +600,7 @@ impl DarklyEngine {
     /// Current overlay preview mask dimensions. Test-only accessor.
     #[cfg(any(test, feature = "testing"))]
     pub fn compositor_preview_mask_size(&self) -> (u32, u32) {
-        self.compositor.tool_overlay_ref().preview_mask_size()
+        self.compositor.tool_overlay().preview_mask_size()
     }
 
     /// Blocking readback of the overlay's preview mask texture. Test-only.
@@ -608,7 +608,8 @@ impl DarklyEngine {
     pub fn test_readback_overlay_preview_mask(&self) -> Vec<u8> {
         let tex = self
             .compositor
-            .overlay_preview_mask_texture()
+            .tool_overlay()
+            .preview_mask_texture()
             .expect("preview mask not allocated");
         let (w, h) = self.compositor_preview_mask_size();
         crate::gpu::test_utils::readback_texture(

--- a/crates/darkly/src/engine/mod.rs
+++ b/crates/darkly/src/engine/mod.rs
@@ -598,11 +598,13 @@ impl DarklyEngine {
     }
 
     /// Current overlay preview mask dimensions. Test-only accessor.
+    #[cfg(any(test, feature = "testing"))]
     pub fn compositor_preview_mask_size(&self) -> (u32, u32) {
         self.compositor.tool_overlay_ref().preview_mask_size()
     }
 
     /// Blocking readback of the overlay's preview mask texture. Test-only.
+    #[cfg(any(test, feature = "testing"))]
     pub fn test_readback_overlay_preview_mask(&self) -> Vec<u8> {
         let tex = self
             .compositor
@@ -677,6 +679,7 @@ impl DarklyEngine {
     /// modifier). For test assertions only. Format and extent come from the
     /// texture's own metadata — callers don't need to know whether the id
     /// refers to a layer or a modifier.
+    #[cfg(any(test, feature = "testing"))]
     pub fn test_readback_layer(&self, node_id: LayerId) -> Vec<u8> {
         let tex = self
             .compositor
@@ -697,6 +700,7 @@ impl DarklyEngine {
     /// only. Returns canvas-sized RGBA8 pixels (padding excluded). Forces an
     /// offscreen composite first because headless `render()` skips the
     /// compositor (no surface to present to).
+    #[cfg(any(test, feature = "testing"))]
     pub fn test_readback_canvas(&mut self) -> Vec<u8> {
         self.compositor
             .render_offscreen(&self.gpu.device, &self.gpu.queue, &mut self.doc);
@@ -719,6 +723,7 @@ impl DarklyEngine {
     /// handling, the transparency checker, OOB workspace background, etc. —
     /// which `test_readback_canvas` cannot cover because it reads the
     /// pre-present composite cache.
+    #[cfg(any(test, feature = "testing"))]
     pub fn test_readback_present(&mut self) -> Vec<u8> {
         self.compositor
             .test_present_to_canvas(&self.gpu.device, &self.gpu.queue, &mut self.doc)
@@ -736,6 +741,7 @@ impl DarklyEngine {
     /// Blocking readback of a mask modifier's R8 texture. For test assertions
     /// only. Resolves the mask modifier on the host and reads its texture
     /// from the unified node-texture pool. Returns one byte per pixel.
+    #[cfg(any(test, feature = "testing"))]
     pub fn test_readback_mask(&self, host_id: LayerId) -> Vec<u8> {
         let mask_id = self
             .doc

--- a/crates/darkly/src/engine/modifiers/selection.rs
+++ b/crates/darkly/src/engine/modifiers/selection.rs
@@ -673,10 +673,11 @@ impl DarklyEngine {
         merged.extend_from_slice(&self.selection_overlay);
         merged.extend_from_slice(&self.tool_overlay);
         if merged.is_empty() {
-            self.compositor.clear_overlay();
+            self.compositor.tool_overlay_mut().clear_primitives();
         } else {
-            self.compositor.set_overlay_primitives(merged);
+            self.compositor.tool_overlay_mut().set_primitives(merged);
         }
+        self.compositor.mark_needs_present();
     }
 
     // --- Tool Overlay ---
@@ -692,16 +693,23 @@ impl DarklyEngine {
     }
 
     pub fn overlay_hit_test(&self, screen_x: f32, screen_y: f32) -> Option<usize> {
-        self.compositor.overlay_hit_test(screen_x, screen_y)
+        self.compositor.tool_overlay().hit_test(screen_x, screen_y)
     }
 
     /// Upload the mask texture sampled by KIND_MASKED_STAMP overlay primitives.
     pub fn set_overlay_mask(&mut self, width: u32, height: u32, rgba: &[u8]) {
-        self.compositor
-            .set_overlay_mask(&self.gpu.device, &self.gpu.queue, width, height, rgba);
+        self.compositor.tool_overlay_mut().set_mask_texture(
+            &self.gpu.device,
+            &self.gpu.queue,
+            width,
+            height,
+            rgba,
+        );
+        self.compositor.mark_needs_present();
     }
 
     pub fn clear_overlay_mask(&mut self) {
-        self.compositor.clear_overlay_mask();
+        self.compositor.tool_overlay_mut().clear_mask_texture();
+        self.compositor.mark_needs_present();
     }
 }

--- a/crates/darkly/src/engine/painting.rs
+++ b/crates/darkly/src/engine/painting.rs
@@ -693,7 +693,7 @@ impl DarklyEngine {
 
         // Refresh the blend-uniform buffer so the composite pass sees the
         // new offset/size on the next render.
-        self.compositor.update_layer_uniforms_full(
+        self.compositor.update_layer_uniforms(
             &self.gpu.queue,
             layer_id,
             opacity,

--- a/crates/darkly/src/engine/rendering.rs
+++ b/crates/darkly/src/engine/rendering.rs
@@ -687,7 +687,7 @@ impl DarklyEngine {
             self.compositor
                 .ensure_layer(&self.gpu.device, &self.gpu.queue, layer);
             let blend = layer.blend();
-            self.compositor.update_layer_uniforms_full(
+            self.compositor.update_layer_uniforms(
                 &self.gpu.queue,
                 layer.id(),
                 blend.opacity,

--- a/crates/darkly/src/gpu/compositor.rs
+++ b/crates/darkly/src/gpu/compositor.rs
@@ -9,7 +9,7 @@ use crate::gpu::params::ParamValue;
 use crate::gpu::veil_chain::VeilChain;
 use crate::gpu::view::{ViewTransform, DEFAULT_WORKSPACE_BG};
 use crate::gpu::void::{Void, VoidRegistry};
-use crate::layer::{Layer, LayerId, LayerNode};
+use crate::layer::{Layer, LayerId, RasterLayer, VoidLayer};
 use smallvec::SmallVec;
 use std::collections::{HashMap, HashSet};
 
@@ -137,24 +137,95 @@ pub(super) struct LayerCache {
     content: LayerContent,
 }
 
+/// Carrier passed to [`LayerNode::compose_into`] so the dispatch hop can
+/// reach the compositor and the per-walk parameters without exploding the
+/// compositor's private surface. Built once per child by `compose_children`
+/// and discarded after the call.
+pub struct CompositionContext<'a> {
+    pub(super) compositor: &'a mut Compositor,
+    pub(super) encoder: &'a mut wgpu::CommandEncoder,
+    pub(super) device: &'a wgpu::Device,
+    pub(super) doc: &'a Document,
+    pub(super) parent_group: LayerId,
+    pub(super) scissor: (u32, u32, u32, u32),
+}
+
+impl<'a> CompositionContext<'a> {
+    /// Dispatch into the compositor's per-variant compose arm. Mirrors the
+    /// [`LayerKindGpu::realize_in`] split — the arm bodies live on
+    /// [`Compositor`] (where they touch its private fields), and the
+    /// dispatch is owned by the variant via [`LayerNode::compose_into`].
+    pub(crate) fn compose_layer(&mut self, layer: &Layer) {
+        self.compositor.compose_layer_arm(
+            self.encoder,
+            self.device,
+            self.doc,
+            self.parent_group,
+            layer,
+            self.scissor,
+        );
+    }
+
+    pub(crate) fn compose_group(&mut self, group: &crate::layer::LayerGroup) {
+        self.compositor.compose_group_arm(
+            self.encoder,
+            self.device,
+            self.doc,
+            self.parent_group,
+            group,
+            self.scissor,
+        );
+    }
+}
+
+/// GPU-side realization protocol for a single content-layer kind.
+///
+/// Each [`Layer`] variant implements this so the compositor's `ensure_layer`
+/// walk doesn't need to match on which kind it's looking at — the variant
+/// knows how to allocate its own per-instance resources. Adding a new layer
+/// kind means implementing this trait once on the new variant; no consumer
+/// edit is required.
+pub trait LayerKindGpu {
+    fn realize_in(&self, compositor: &mut Compositor, device: &wgpu::Device, queue: &wgpu::Queue);
+}
+
+impl LayerKindGpu for Layer {
+    fn realize_in(&self, compositor: &mut Compositor, device: &wgpu::Device, queue: &wgpu::Queue) {
+        match self {
+            Layer::Raster(r) => r.realize_in(compositor, device, queue),
+            Layer::Void(v) => v.realize_in(compositor, device, queue),
+        }
+    }
+}
+
+impl LayerKindGpu for RasterLayer {
+    fn realize_in(&self, compositor: &mut Compositor, device: &wgpu::Device, queue: &wgpu::Queue) {
+        compositor.ensure_raster_layer(device, queue, self.id, self.pixels.bounds);
+    }
+}
+
+impl LayerKindGpu for VoidLayer {
+    fn realize_in(&self, compositor: &mut Compositor, device: &wgpu::Device, queue: &wgpu::Queue) {
+        let void = compositor.create_void_box(device, &self.void_type, &self.params);
+        compositor.ensure_void_layer(device, queue, self.id, void);
+    }
+}
+
 /// How a layer's pixels reach `node_textures[id]`.
 ///
 /// - `Raster`: pixels arrive via paint / paste / fill — `node_textures[id]`
 ///   is authoritative and the compositor doesn't regenerate it.
-/// - `Procedural`: pixels are GPU-regenerable from `(void_type, params)`.
-///   The compositor calls [`Void::encode`] before the next composite when
-///   `dirty` is set (first allocation, param edit, animation tick, …).
+/// - `Procedural`: pixels are GPU-regenerable. The compositor calls
+///   [`Void::encode`] before the next composite when the void's own dirty
+///   flag (owned on the trait object) reports stale.
 enum LayerContent {
     Raster,
     Procedural(ProceduralContent),
 }
 
-/// Per-instance procedural-content state.
-///
-/// `dirty` is the regenerate gate: flipped true when the void is first
-/// allocated, when params change, when external input lands, or when an
-/// animated tick writes a fresh time uniform. The render path clears it
-/// after re-rendering once via [`Compositor::encode_dirty_layer_content`].
+/// Per-instance procedural-content state. The "needs re-encode" flag lives
+/// on the [`Void`] itself ([`Void::take_dirty`]) — the compositor neither
+/// stores nor reconciles it.
 struct ProceduralContent {
     /// The procedural-content trait object. Owned here (one per layer)
     /// because animation mutates its `time` field.
@@ -162,9 +233,6 @@ struct ProceduralContent {
     /// Per-instance GPU resources for the void's own pipeline (uniform
     /// buffer + bind groups built off the registry's shared pipeline).
     cache: EffectCache,
-    /// True when the procedural texture is stale and needs to be
-    /// re-rendered before the next blend.
-    dirty: bool,
 }
 
 /// Uniforms for raster layer compositing. The shader samples the layer
@@ -740,10 +808,22 @@ impl Compositor {
     /// using the kind-specific entry points below; the caller already has
     /// the right inputs in hand.
     pub fn ensure_layer(&mut self, device: &wgpu::Device, queue: &wgpu::Queue, layer: &Layer) {
-        match layer {
-            Layer::Raster(r) => self.ensure_raster_layer(device, queue, r.id, r.pixels.bounds),
-            Layer::Void(v) => self.ensure_void_layer(device, queue, v.id, &v.void_type, &v.params),
-        }
+        layer.realize_in(self, device, queue);
+    }
+
+    /// Construct a `Box<dyn Void>` via the compositor-owned registry without
+    /// exposing the registry itself. Used by [`VoidLayer`]'s
+    /// [`LayerKindGpu::realize_in`] so the registry stays private to the
+    /// compositor.
+    fn create_void_box(
+        &mut self,
+        device: &wgpu::Device,
+        type_id: &str,
+        params: &[ParamValue],
+    ) -> Box<dyn Void> {
+        let format = self.canvas_content_format();
+        self.void_registry
+            .create_void(type_id, params, device, format)
     }
 
     /// Create GPU texture + uniform buffer for a new raster layer.
@@ -1191,7 +1271,6 @@ impl Compositor {
         };
         proc.void
             .restore_persistent_pixels(device, queue, &mut proc.cache, width, height, bytes);
-        proc.dirty = true;
         self.mark_dirty();
     }
 
@@ -1433,6 +1512,14 @@ impl Compositor {
         &mut self.void_registry
     }
 
+    /// Canvas-content texture format used by every content layer (raster +
+    /// void). Exposed so engine paths that need to construct a void via the
+    /// registry before calling [`Self::ensure_void_layer`] can pass the same
+    /// format the compositor would have used internally.
+    pub fn canvas_content_format(&self) -> wgpu::TextureFormat {
+        wgpu::TextureFormat::Rgba8Unorm
+    }
+
     /// Allocate the per-instance GPU state for a new void layer:
     /// procedural texture in [`Self::node_textures`] (canvas-sized
     /// [`wgpu::TextureFormat::Rgba8Unorm`], matching the raster path so the
@@ -1440,13 +1527,17 @@ impl Compositor {
     /// branch) and a [`LayerCache`] holding the blend uniforms plus a
     /// [`LayerContent::Procedural`] sidecar with the trait object and its
     /// `EffectCache`. Idempotent — calling twice for the same id is a no-op.
+    ///
+    /// The caller constructs `void` via the engine's void registry. The
+    /// compositor takes the trait object as-is and stops bookkeeping the
+    /// `(type_id, params)` pair: ownership of those facts already lives on
+    /// the `Void` itself.
     pub fn ensure_void_layer(
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         layer_id: LayerId,
-        void_type: &str,
-        params: &[ParamValue],
+        void: Box<dyn Void>,
     ) {
         if self.layer_cache.contains_key(&layer_id) {
             return;
@@ -1456,12 +1547,6 @@ impl Compositor {
         let bounds = CanvasRect::from_xywh(0, 0, self.canvas_width, self.canvas_height);
         let layer_tex = LayerTexture::with_bounds(device, bounds);
 
-        // Build the per-instance trait object via the registry. The registry
-        // lazy-builds the shared pipeline on the first call for a given type.
-        let format = layer_tex.format();
-        let void = self
-            .void_registry
-            .create_void(void_type, params, device, format);
         let cache = void.create_cache(
             device,
             queue,
@@ -1500,11 +1585,7 @@ impl Compositor {
                 opacity: 1.0,
                 blend_mode: normal,
                 isolated: false,
-                content: LayerContent::Procedural(ProceduralContent {
-                    void,
-                    cache,
-                    dirty: true,
-                }),
+                content: LayerContent::Procedural(ProceduralContent { void, cache }),
             },
         );
         self.mark_dirty();
@@ -1516,25 +1597,16 @@ impl Compositor {
     /// hold stateful pixel data — e.g. the camera void's last received
     /// frame) is preserved untouched. The blend uniforms (opacity / mode
     /// / isolated) are also untouched — only the procedural side changes.
-    ///
-    /// `void_type` is unused here but kept in the signature so the engine
-    /// API matches what callers had to thread through anyway. It used to
-    /// be required when this method rebuilt the void from scratch via the
-    /// registry; that path was abandoned because it dropped the camera
-    /// void's aux texture on every param edit.
     pub fn update_void_layer_params(
         &mut self,
-        _device: &wgpu::Device,
         queue: &wgpu::Queue,
         layer_id: LayerId,
-        _void_type: &str,
         params: &[ParamValue],
     ) {
         let Some(proc) = self.procedural_content_mut(layer_id) else {
             return;
         };
         proc.void.update_params(queue, &proc.cache, params);
-        proc.dirty = true;
         self.mark_dirty();
     }
 
@@ -1559,7 +1631,6 @@ impl Compositor {
         }
         proc.void
             .upload_external_image(device, queue, &mut proc.cache, source);
-        proc.dirty = true;
         self.mark_dirty();
     }
 
@@ -1594,7 +1665,6 @@ impl Compositor {
                 continue;
             }
             proc.void.update_time(queue, &proc.cache, dt);
-            proc.dirty = true;
         }
     }
 
@@ -1603,22 +1673,29 @@ impl Compositor {
     /// `compose_children` samples up-to-date pixels. Raster layers are
     /// inherently "never dirty" — their pixels arrived through paint and
     /// `node_textures[id]` is authoritative.
+    ///
+    /// The dirty bit is the void's own, returned through
+    /// [`Void::take_dirty`]: state-changing methods on the trait
+    /// (`update_params`, `update_time`, `upload_external_image`) mark it,
+    /// and `take_dirty` returns-and-clears so a void encodes at most once
+    /// per state change.
     fn encode_dirty_layer_content(&mut self, encoder: &mut wgpu::CommandEncoder) {
-        // Two-phase: collect ids of dirty procedural layers, then drop the
-        // mutable borrow and re-acquire per-entry. Keeps the loop body
-        // short and avoids borrowing `self.layer_cache` and
-        // `self.node_textures` at the same time. The scratch buffer is
-        // owned by `self` so the per-frame Vec churn vanishes.
+        // Two-phase: collect ids of procedural layers whose void reports
+        // dirty (consuming the flag), then drop the mutable borrow and
+        // re-acquire per-entry. Keeps the loop body short and avoids
+        // borrowing `self.layer_cache` and `self.node_textures` at the same
+        // time. The scratch buffer is owned by `self` so the per-frame Vec
+        // churn vanishes.
         self.dirty_procedural_scratch.clear();
         self.dirty_procedural_scratch
-            .extend(
-                self.layer_cache
-                    .iter()
-                    .filter_map(|(id, c)| match &c.content {
-                        LayerContent::Procedural(p) if p.dirty => Some(*id),
-                        _ => None,
-                    }),
-            );
+            .extend(self.layer_cache.iter_mut().filter_map(|(id, c)| {
+                if let LayerContent::Procedural(p) = &mut c.content {
+                    if p.void.take_dirty() {
+                        return Some(*id);
+                    }
+                }
+                None
+            }));
         // Index-iterate so the loop body can re-borrow `self.layer_cache`
         // mutably; the LayerIds are `Copy`. The scratch retains its
         // capacity across frames so the per-frame `Vec` churn vanishes.
@@ -1645,7 +1722,6 @@ impl Compositor {
                 continue;
             };
             proc.void.encode(encoder, &proc.cache, dst_view);
-            proc.dirty = false;
         }
         // Leave the field empty at exit — capacity is retained but no
         // potentially-stale LayerIds live past dispose.
@@ -1719,11 +1795,11 @@ impl Compositor {
             && self.tool_overlay.needs_animation()
             && self.frame_count.is_multiple_of(overlay_divisor);
 
-        // Voids piggyback on the same master clock as veils and the tool
-        // overlay — using a parallel integer divisor keeps tick alignment so
-        // an animated void never forces a frame the other systems wouldn't
-        // already produce, matching the `docs/lessons-learned/gpu-lessons-learned.md`
-        // master-clock principle.
+        // Each animated subsystem advances on its own integer divisor of
+        // the master rAF clock; integer divisors guarantee no subsystem
+        // forces a frame another subsystem wouldn't already produce. See
+        // `docs/lessons-learned/gpu-lessons-learned.md` master-clock
+        // principle.
         let void_fires = void_divisor > 0
             && self.any_animated_layer(doc)
             && self.frame_count.is_multiple_of(void_divisor);
@@ -2359,6 +2435,11 @@ impl Compositor {
 
     /// Composite a list of children into the parent group's accumulators.
     /// Handles passthrough groups by recursing with the same parent group_id.
+    ///
+    /// Per-child dispatch goes through [`LayerNode::compose_into`] so each
+    /// node variant is responsible for its own compose behaviour — this
+    /// walk only owns the per-child visibility + isolation filters that are
+    /// orthogonal to node kind.
     fn compose_children(
         &mut self,
         encoder: &mut wgpu::CommandEncoder,
@@ -2368,8 +2449,6 @@ impl Compositor {
         children: &[LayerId],
         scissor: (u32, u32, u32, u32),
     ) {
-        let (scissor_x, scissor_y, scissor_w, scissor_h) = scissor;
-
         for &child_id in children {
             let node = match doc.find_node(child_id) {
                 Some(n) => n,
@@ -2385,237 +2464,241 @@ impl Compositor {
             if !self.is_in_isolation_path(doc, child_id) {
                 continue;
             }
-            match node {
-                LayerNode::Layer(layer) => {
-                    // One blend arm for both raster and procedural content.
-                    // The procedural texture lives in `node_textures` keyed
-                    // by layer id (allocated by `ensure_void_layer` and
-                    // refreshed by `encode_dirty_layer_content` before the
-                    // tree walk), and the blend uniforms are the same
-                    // `BlendUniforms` shape in the unified `layer_cache` —
-                    // so neither lookup branches on kind here.
-                    let layer_id = layer.id();
-
-                    // Effective view + uniforms: when this layer is the
-                    // floating target, swap the live texture view for the
-                    // (canvas-aligned) preview view AND swap the live's
-                    // layer-aligned blend uniforms for the preview's
-                    // canvas-aligned ones — both halves must move together
-                    // or the shader maps fragments to the wrong region.
-                    // Voids never become floating targets today, so the
-                    // detour collapses to the live path for them; if voids
-                    // ever do, the same code path will Just Work.
-                    let active_floating = self
-                        .transform_pass
-                        .active
-                        .as_ref()
-                        .filter(|s| s.target_layer == layer_id);
-                    let layer_view = match active_floating {
-                        Some(s) => &s.preview_view,
-                        None => match self.node_textures.get(&layer_id) {
-                            Some(t) => t.view(),
-                            None => continue,
-                        },
-                    };
-                    let uniform_buf_ptr = match active_floating {
-                        Some(s) => &s.preview_blend_uniform_buf,
-                        None => match self.layer_cache.get(&layer_id) {
-                            Some(c) => &c.uniform_buf,
-                            None => continue,
-                        },
-                    };
-
-                    // Ping-pong: read from current accum, write to the other.
-                    let gs = self.group_state.get_mut(&parent_group).unwrap();
-                    let src = gs.current_accum;
-                    let dst = 1 - src;
-                    gs.current_accum = dst;
-
-                    // Floating target swaps the bg/layer view per-frame to the
-                    // (canvas-aligned) preview texture; skip the cache so
-                    // preview-state ephemera never leak in. The non-floating
-                    // path uses stable view+uniform handles so the cache key
-                    // `(parent, child, src)` is sufficient.
-                    let fresh_bind_group: Option<wgpu::BindGroup>;
-                    let cached_bind_group: Option<&wgpu::BindGroup>;
-                    if active_floating.is_some() {
-                        fresh_bind_group = Some(self.create_blend_bind_group(
-                            device,
-                            &self.group_state[&parent_group].accum.views[src],
-                            layer_view,
-                            uniform_buf_ptr,
-                            "blend-layer",
-                        ));
-                        cached_bind_group = None;
-                    } else {
-                        // Split-borrow: pull out the views we need so the
-                        // mutable borrow of `blend_bind_groups` doesn't
-                        // overlap with field reads inside the helper.
-                        let bg_view = &self.group_state[&parent_group].accum.views[src];
-                        let bgl = &self.blend_pipelines.bind_group_layout;
-                        let sampler = &self.sampler;
-                        cached_bind_group = Some(Self::get_or_create_blend_bind_group(
-                            &mut self.blend_bind_groups,
-                            bgl,
-                            sampler,
-                            device,
-                            (parent_group, layer_id, src as u8),
-                            bg_view,
-                            layer_view,
-                            uniform_buf_ptr,
-                            "blend-layer",
-                        ));
-                        fresh_bind_group = None;
-                    }
-                    let bind_group: &wgpu::BindGroup = cached_bind_group
-                        .unwrap_or_else(|| fresh_bind_group.as_ref().expect("one branch sets it"));
-
-                    {
-                        let gs = &self.group_state[&parent_group];
-                        // Effective mask bind group: live mask by default,
-                        // preview-mask bind group when one of this layer's
-                        // modifiers is the floating target. Field-explicit
-                        // form so the cached `bind_group` borrow on
-                        // `self.blend_bind_groups` survives this lookup.
-                        let mask_bg = Self::effective_mask_bind_group_fields(
-                            &self.mask_bind_groups,
-                            &self.default_mask_bind_group,
-                            &self.transform_pass,
-                            doc,
-                            layer_id,
-                        );
-                        let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                            label: Some("blend-layer"),
-                            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                                view: &gs.accum.views[dst],
-                                resolve_target: None,
-                                depth_slice: None,
-                                ops: wgpu::Operations {
-                                    load: wgpu::LoadOp::Load,
-                                    store: wgpu::StoreOp::Store,
-                                },
-                            })],
-                            ..Default::default()
-                        });
-                        rpass.set_scissor_rect(scissor_x, scissor_y, scissor_w, scissor_h);
-                        rpass.set_pipeline(self.blend_pipelines.pipeline());
-                        rpass.set_bind_group(0, bind_group, &[]);
-                        rpass.set_bind_group(1, mask_bg, &[]);
-                        rpass.draw(0..3, 0..1);
-                    }
-                }
-
-                LayerNode::Group(g) => {
-                    let group_id = g.id;
-                    if g.passthrough {
-                        // Structural detection: a passthrough group with a
-                        // visible mask modifier triggers Photoshop-style
-                        // snapshot+lerp; otherwise it's pure passthrough.
-                        let has_active_mask = doc
-                            .mask_modifier(group_id)
-                            .map(|m| m.common.visible)
-                            .unwrap_or(false);
-
-                        if has_active_mask {
-                            self.compose_passthrough_masked(
-                                encoder,
-                                device,
-                                doc,
-                                parent_group,
-                                group_id,
-                                scissor,
-                            );
-                        } else {
-                            // Pure passthrough — inline children into parent.
-                            let inner: ChildIds = ChildIds::from_slice(doc.children_of(group_id));
-                            self.compose_children(
-                                encoder,
-                                device,
-                                doc,
-                                parent_group,
-                                &inner,
-                                scissor,
-                            );
-                        }
-                    } else {
-                        // Normal group: composite into its own isolated buffer,
-                        // then blend the result into the parent.
-                        if !self.group_state.contains_key(&group_id) {
-                            continue;
-                        }
-                        self.compose_group(encoder, device, doc, group_id, scissor);
-
-                        // Blend group's composite cache into parent's accumulators.
-                        let gs_parent = self.group_state.get_mut(&parent_group).unwrap();
-                        let src = gs_parent.current_accum;
-                        let dst = 1 - src;
-                        gs_parent.current_accum = dst;
-
-                        // Split-borrow into the cache: bg/layer views and
-                        // uniform buffer live in distinct fields from
-                        // `blend_bind_groups`, so we can hold the mutable
-                        // borrow of the cache and the immutable borrows of
-                        // the views together. Groups never become floating
-                        // targets themselves, so the cache always applies
-                        // here (a modifier-as-floating-target only swaps
-                        // mask_bg via `effective_mask_bind_group`).
-                        let bg_view = &self.group_state[&parent_group].accum.views[src];
-                        let gs_child = &self.group_state[&group_id];
-                        let child_view = &gs_child.composite_cache_view;
-                        let child_uniform = &gs_child.uniform_buf;
-                        let bgl = &self.blend_pipelines.bind_group_layout;
-                        let sampler = &self.sampler;
-                        let bind_group = Self::get_or_create_blend_bind_group(
-                            &mut self.blend_bind_groups,
-                            bgl,
-                            sampler,
-                            device,
-                            (parent_group, group_id, src as u8),
-                            bg_view,
-                            child_view,
-                            child_uniform,
-                            "blend-group",
-                        );
-
-                        let gs_parent = &self.group_state[&parent_group];
-                        // Same effective-mask routing as the raster path —
-                        // when the floating target is one of this group's
-                        // modifiers, sample the preview-mask bind group
-                        // instead of the live one. Field-explicit form so
-                        // the cached `bind_group` borrow on
-                        // `self.blend_bind_groups` survives this lookup.
-                        let child_mask_bg = Self::effective_mask_bind_group_fields(
-                            &self.mask_bind_groups,
-                            &self.default_mask_bind_group,
-                            &self.transform_pass,
-                            doc,
-                            group_id,
-                        );
-                        {
-                            let mut rpass =
-                                encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                                    label: Some("blend-group"),
-                                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                                        view: &gs_parent.accum.views[dst],
-                                        resolve_target: None,
-                                        depth_slice: None,
-                                        ops: wgpu::Operations {
-                                            load: wgpu::LoadOp::Load,
-                                            store: wgpu::StoreOp::Store,
-                                        },
-                                    })],
-                                    ..Default::default()
-                                });
-                            rpass.set_scissor_rect(scissor_x, scissor_y, scissor_w, scissor_h);
-                            rpass.set_pipeline(self.blend_pipelines.pipeline());
-                            rpass.set_bind_group(0, bind_group, &[]);
-                            rpass.set_bind_group(1, child_mask_bg, &[]);
-                            rpass.draw(0..3, 0..1);
-                        }
-                    }
-                }
-            }
+            let mut ctx = CompositionContext {
+                compositor: self,
+                encoder,
+                device,
+                doc,
+                parent_group,
+                scissor,
+            };
+            node.compose_into(&mut ctx);
         }
+    }
+
+    /// Composite a content layer (raster or void) into its parent group's
+    /// ping-pong accumulators. One blend arm for both raster and procedural
+    /// content — the procedural texture lives in `node_textures` keyed by
+    /// layer id (allocated by `ensure_void_layer` and refreshed by
+    /// `encode_dirty_layer_content` before the tree walk), and the blend
+    /// uniforms are the same `BlendUniforms` shape in the unified
+    /// `layer_cache` — so neither lookup branches on kind here.
+    fn compose_layer_arm(
+        &mut self,
+        encoder: &mut wgpu::CommandEncoder,
+        device: &wgpu::Device,
+        doc: &Document,
+        parent_group: LayerId,
+        layer: &Layer,
+        scissor: (u32, u32, u32, u32),
+    ) {
+        let (scissor_x, scissor_y, scissor_w, scissor_h) = scissor;
+        let layer_id = layer.id();
+
+        // Effective view + uniforms: when this layer is the floating
+        // target, swap the live texture view for the (canvas-aligned)
+        // preview view AND swap the live's layer-aligned blend uniforms
+        // for the preview's canvas-aligned ones — both halves must move
+        // together or the shader maps fragments to the wrong region.
+        // Voids never become floating targets today, so the detour
+        // collapses to the live path for them; if voids ever do, the same
+        // code path will Just Work.
+        let active_floating = self
+            .transform_pass
+            .active
+            .as_ref()
+            .filter(|s| s.target_layer == layer_id);
+        let layer_view = match active_floating {
+            Some(s) => &s.preview_view,
+            None => match self.node_textures.get(&layer_id) {
+                Some(t) => t.view(),
+                None => return,
+            },
+        };
+        let uniform_buf_ptr = match active_floating {
+            Some(s) => &s.preview_blend_uniform_buf,
+            None => match self.layer_cache.get(&layer_id) {
+                Some(c) => &c.uniform_buf,
+                None => return,
+            },
+        };
+
+        // Ping-pong: read from current accum, write to the other.
+        let gs = self.group_state.get_mut(&parent_group).unwrap();
+        let src = gs.current_accum;
+        let dst = 1 - src;
+        gs.current_accum = dst;
+
+        // Floating target swaps the bg/layer view per-frame to the
+        // (canvas-aligned) preview texture; skip the cache so preview-state
+        // ephemera never leak in. The non-floating path uses stable
+        // view+uniform handles so the cache key `(parent, child, src)` is
+        // sufficient.
+        let fresh_bind_group: Option<wgpu::BindGroup>;
+        let cached_bind_group: Option<&wgpu::BindGroup>;
+        if active_floating.is_some() {
+            fresh_bind_group = Some(self.create_blend_bind_group(
+                device,
+                &self.group_state[&parent_group].accum.views[src],
+                layer_view,
+                uniform_buf_ptr,
+                "blend-layer",
+            ));
+            cached_bind_group = None;
+        } else {
+            let bg_view = &self.group_state[&parent_group].accum.views[src];
+            let bgl = &self.blend_pipelines.bind_group_layout;
+            let sampler = &self.sampler;
+            cached_bind_group = Some(Self::get_or_create_blend_bind_group(
+                &mut self.blend_bind_groups,
+                bgl,
+                sampler,
+                device,
+                (parent_group, layer_id, src as u8),
+                bg_view,
+                layer_view,
+                uniform_buf_ptr,
+                "blend-layer",
+            ));
+            fresh_bind_group = None;
+        }
+        let bind_group: &wgpu::BindGroup = cached_bind_group
+            .unwrap_or_else(|| fresh_bind_group.as_ref().expect("one branch sets it"));
+
+        let gs = &self.group_state[&parent_group];
+        let mask_bg = Self::effective_mask_bind_group_fields(
+            &self.mask_bind_groups,
+            &self.default_mask_bind_group,
+            &self.transform_pass,
+            doc,
+            layer_id,
+        );
+        let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("blend-layer"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &gs.accum.views[dst],
+                resolve_target: None,
+                depth_slice: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            ..Default::default()
+        });
+        rpass.set_scissor_rect(scissor_x, scissor_y, scissor_w, scissor_h);
+        rpass.set_pipeline(self.blend_pipelines.pipeline());
+        rpass.set_bind_group(0, bind_group, &[]);
+        rpass.set_bind_group(1, mask_bg, &[]);
+        rpass.draw(0..3, 0..1);
+    }
+
+    /// Composite a child group into its parent's ping-pong accumulators.
+    /// Passthrough groups inline their children into the parent (with the
+    /// Photoshop-style snapshot+lerp detour when a visible mask is
+    /// attached); normal groups composite into their own isolated buffer
+    /// first and then blend the result into the parent.
+    fn compose_group_arm(
+        &mut self,
+        encoder: &mut wgpu::CommandEncoder,
+        device: &wgpu::Device,
+        doc: &Document,
+        parent_group: LayerId,
+        group: &crate::layer::LayerGroup,
+        scissor: (u32, u32, u32, u32),
+    ) {
+        let (scissor_x, scissor_y, scissor_w, scissor_h) = scissor;
+        let group_id = group.id;
+
+        if group.passthrough {
+            // Structural detection: a passthrough group with a visible mask
+            // modifier triggers Photoshop-style snapshot+lerp; otherwise
+            // it's pure passthrough.
+            let has_active_mask = doc
+                .mask_modifier(group_id)
+                .map(|m| m.common.visible)
+                .unwrap_or(false);
+
+            if has_active_mask {
+                self.compose_passthrough_masked(
+                    encoder,
+                    device,
+                    doc,
+                    parent_group,
+                    group_id,
+                    scissor,
+                );
+            } else {
+                // Pure passthrough — inline children into parent.
+                let inner: ChildIds = ChildIds::from_slice(doc.children_of(group_id));
+                self.compose_children(encoder, device, doc, parent_group, &inner, scissor);
+            }
+            return;
+        }
+
+        // Normal group: composite into its own isolated buffer, then blend
+        // the result into the parent.
+        if !self.group_state.contains_key(&group_id) {
+            return;
+        }
+        self.compose_group(encoder, device, doc, group_id, scissor);
+
+        // Blend group's composite cache into parent's accumulators.
+        let gs_parent = self.group_state.get_mut(&parent_group).unwrap();
+        let src = gs_parent.current_accum;
+        let dst = 1 - src;
+        gs_parent.current_accum = dst;
+
+        // Split-borrow into the cache: bg/layer views and uniform buffer
+        // live in distinct fields from `blend_bind_groups`, so we can hold
+        // the mutable borrow of the cache and the immutable borrows of the
+        // views together. Groups never become floating targets themselves,
+        // so the cache always applies here (a modifier-as-floating-target
+        // only swaps mask_bg via `effective_mask_bind_group`).
+        let bg_view = &self.group_state[&parent_group].accum.views[src];
+        let gs_child = &self.group_state[&group_id];
+        let child_view = &gs_child.composite_cache_view;
+        let child_uniform = &gs_child.uniform_buf;
+        let bgl = &self.blend_pipelines.bind_group_layout;
+        let sampler = &self.sampler;
+        let bind_group = Self::get_or_create_blend_bind_group(
+            &mut self.blend_bind_groups,
+            bgl,
+            sampler,
+            device,
+            (parent_group, group_id, src as u8),
+            bg_view,
+            child_view,
+            child_uniform,
+            "blend-group",
+        );
+
+        let gs_parent = &self.group_state[&parent_group];
+        let child_mask_bg = Self::effective_mask_bind_group_fields(
+            &self.mask_bind_groups,
+            &self.default_mask_bind_group,
+            &self.transform_pass,
+            doc,
+            group_id,
+        );
+        let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("blend-group"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &gs_parent.accum.views[dst],
+                resolve_target: None,
+                depth_slice: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            ..Default::default()
+        });
+        rpass.set_scissor_rect(scissor_x, scissor_y, scissor_w, scissor_h);
+        rpass.set_pipeline(self.blend_pipelines.pipeline());
+        rpass.set_bind_group(0, bind_group, &[]);
+        rpass.set_bind_group(1, child_mask_bg, &[]);
+        rpass.draw(0..3, 0..1);
     }
 
     /// Composite a passthrough group whose mask is active.

--- a/crates/darkly/src/gpu/compositor.rs
+++ b/crates/darkly/src/gpu/compositor.rs
@@ -4,7 +4,7 @@ use crate::gpu::atlas::LayerTexture;
 use crate::gpu::blend::BlendPipelines;
 use crate::gpu::content_bounds::ContentBoundsPass;
 use crate::gpu::effect::EffectCache;
-use crate::gpu::overlay::{OverlayPrimitive, ToolOverlay};
+use crate::gpu::overlay::ToolOverlay;
 use crate::gpu::params::ParamValue;
 use crate::gpu::veil_chain::VeilChain;
 use crate::gpu::view::{ViewTransform, DEFAULT_WORKSPACE_BG};
@@ -118,19 +118,19 @@ struct GroupState {
 /// [`LayerContent`]. One pool keyed by [`LayerId`] replaces the previous
 /// `raster_cache` + `void_layers` split, so the compositor's lookup paths
 /// (blend arm, uniforms write, dispose) don't dispatch on layer kind.
-struct LayerCache {
+pub(super) struct LayerCache {
     /// Uniform buffer holding opacity + blend_mode + isolated.
-    uniform_buf: wgpu::Buffer,
+    pub(super) uniform_buf: wgpu::Buffer,
     /// CPU-side cache of the blend properties last written to `uniform_buf`.
     /// Kept here so the floating-preview path can mirror them into its own
     /// canvas-aligned uniform buffer without re-reading the GPU buffer.
-    opacity: f32,
+    pub(super) opacity: f32,
     /// Cached gpu_value for the layer's blend mode. The compositor never
     /// branches on which mode this is — the shader does — so we mirror the
     /// raw shader integer rather than carry a registration pointer through
     /// every per-frame access.
-    blend_mode: u32,
-    isolated: bool,
+    pub(super) blend_mode: u32,
+    pub(super) isolated: bool,
     /// Where this layer's pixels come from. Raster pixels arrive via paint;
     /// procedural pixels are regenerated on demand by a [`Void`] trait
     /// object before each composite.
@@ -173,18 +173,18 @@ struct ProceduralContent {
 /// translates per-pixel from canvas UV to layer UV.
 #[repr(C)]
 #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-struct BlendUniforms {
-    opacity: f32,
-    blend_mode: u32,
-    isolated: u32,
-    _pad1: f32,
+pub(super) struct BlendUniforms {
+    pub(super) opacity: f32,
+    pub(super) blend_mode: u32,
+    pub(super) isolated: u32,
+    pub(super) _pad1: f32,
     /// Layer's (offset_x, offset_y) in canvas coordinates.
-    layer_offset: [f32; 2],
+    pub(super) layer_offset: [f32; 2],
     /// Layer texture dimensions in pixels.
-    layer_size: [f32; 2],
+    pub(super) layer_size: [f32; 2],
     /// Canvas dimensions in pixels.
-    canvas_size: [f32; 2],
-    _pad2: [f32; 2],
+    pub(super) canvas_size: [f32; 2],
+    pub(super) _pad2: [f32; 2],
 }
 
 /// GPU state for a passthrough group that has a mask (Photoshop-style).
@@ -214,7 +214,7 @@ pub struct Compositor {
     /// layer textures (Rgba8Unorm), mask modifier textures (R8Unorm), and
     /// any future pixel-bearing modifier kinds — `LayerTexture.format`
     /// distinguishes them. One lookup per access, no fan-out.
-    node_textures: HashMap<LayerId, LayerTexture>,
+    pub(super) node_textures: HashMap<LayerId, LayerTexture>,
 
     /// Default mask bind group using the 1×1 white texture (pass-through
     /// fallback for hosts without a visible mask modifier).
@@ -239,9 +239,9 @@ pub struct Compositor {
     /// the document's [`LayerId`] — both kinds share the same blend
     /// pipeline path, so collapsing them into one pool means the blend
     /// arm, uniforms write, and dispose all do exactly one lookup.
-    layer_cache: HashMap<LayerId, LayerCache>,
+    pub(super) layer_cache: HashMap<LayerId, LayerCache>,
 
-    blend_pipelines: BlendPipelines,
+    pub(super) blend_pipelines: BlendPipelines,
 
     // --- Passthrough Group Mask (Photoshop-style snapshot-lerp) ---
     mask_lerp_pipeline: wgpu::RenderPipeline,
@@ -257,7 +257,7 @@ pub struct Compositor {
     /// View transform uniform buffer for the present shader.
     view_uniform_buf: wgpu::Buffer,
 
-    sampler: wgpu::Sampler,
+    pub(super) sampler: wgpu::Sampler,
 
     /// Dirty gate — false means nothing changed, skip compositing.
     needs_composite: bool,
@@ -274,8 +274,8 @@ pub struct Compositor {
     /// uniformly.
     dirty_node_pixels: HashSet<LayerId>,
 
-    canvas_width: u32,
-    canvas_height: u32,
+    pub(super) canvas_width: u32,
+    pub(super) canvas_height: u32,
     /// Padded (tile-aligned) render target dimensions — used for shader UV
     /// computations in the transform pass, which must match the actual
     /// accumulator texture size.
@@ -290,7 +290,7 @@ pub struct Compositor {
     void_registry: VoidRegistry,
 
     // --- Floating Content Transform ---
-    transform_pass: crate::gpu::transform::TransformPass,
+    pub(super) transform_pass: crate::gpu::transform::TransformPass,
 
     // --- Isolation (session state) ---
     /// When `Some(id)`, the render walk descends only into nodes on the
@@ -1072,11 +1072,7 @@ impl Compositor {
         queue: &wgpu::Queue,
         node_id: LayerId,
     ) {
-        let Some(tex) = self
-            .node_textures
-            .get(&node_id)
-            .or_else(|| self.node_textures.get(&node_id))
-        else {
+        let Some(tex) = self.node_textures.get(&node_id) else {
             return;
         };
         let r_channel = tex.format() == wgpu::TextureFormat::R8Unorm;
@@ -1806,29 +1802,15 @@ impl Compositor {
     }
 
     /// Update a content layer's uniforms (called when opacity, blend mode,
-    /// or isolated changes). Convenience wrapper that pins `isolated` to
-    /// false — bulk sync paths that compute isolation already use the full
-    /// variant directly.
-    pub fn update_layer_uniforms(
-        &mut self,
-        queue: &wgpu::Queue,
-        layer_id: LayerId,
-        opacity: f32,
-        blend_mode_gpu: u32,
-    ) {
-        self.update_layer_uniforms_full(queue, layer_id, opacity, blend_mode_gpu, false);
-    }
-
-    /// Update a content layer's uniforms including the isolated flag. Works
-    /// uniformly for raster and procedural layers — both store their blend
-    /// state in the same [`LayerCache`] and sample from canvas-positioned
-    /// textures in `node_textures`. Reads the layer's bounds from its
-    /// `LayerTexture` so callers don't need to thread them through;
-    /// bounds-changing operations update the texture's stored offset/size
-    /// directly via `resize_node_texture`.
+    /// or isolated changes). Works uniformly for raster and procedural
+    /// layers — both store their blend state in the same [`LayerCache`]
+    /// and sample from canvas-positioned textures in `node_textures`.
+    /// Reads the layer's bounds from its `LayerTexture` so callers don't
+    /// need to thread them through; bounds-changing operations update the
+    /// texture's stored offset/size directly via `resize_node_texture`.
     ///
     /// `blend_mode_gpu` is the registry-resolved gpu_value.
-    pub fn update_layer_uniforms_full(
+    pub fn update_layer_uniforms(
         &mut self,
         queue: &wgpu::Queue,
         layer_id: LayerId,
@@ -1869,39 +1851,6 @@ impl Compositor {
         self.write_preview_blend_uniforms_if_active(queue, layer_id);
     }
 
-    /// Write the floating preview's canvas-aligned blend uniforms using the
-    /// given layer's cached blend props. No-op when there is no active
-    /// floating, or when the active floating's target is not `layer_id`.
-    /// Called from both `update_layer_uniforms_full` (on prop change) and
-    /// the floating setup paths (to seed the buffer at session start).
-    fn write_preview_blend_uniforms_if_active(&self, queue: &wgpu::Queue, layer_id: LayerId) {
-        let state = match self.transform_pass.active.as_ref() {
-            Some(s) if s.target_layer == layer_id => s,
-            _ => return,
-        };
-        let cache = match self.layer_cache.get(&layer_id) {
-            Some(c) => c,
-            None => return,
-        };
-        let uniforms = BlendUniforms {
-            opacity: cache.opacity,
-            blend_mode: cache.blend_mode,
-            isolated: cache.isolated as u32,
-            _pad1: 0.0,
-            layer_offset: [0.0, 0.0],
-            layer_size: [self.canvas_width as f32, self.canvas_height as f32],
-            canvas_size: [self.canvas_width as f32, self.canvas_height as f32],
-            _pad2: [0.0, 0.0],
-        };
-        queue.write_buffer(
-            &state.preview_blend_uniform_buf,
-            0,
-            bytemuck::bytes_of(&uniforms),
-        );
-    }
-
-    /// Look up the resolved mask bind group for a modifier id, falling back to
-    /// the default (1x1 white = no masking) when no real mask is active.
     /// Get the composited output texture (root group's composite cache).
     /// Used by the color picker for readback.
     pub fn composited_texture(&self) -> &wgpu::Texture {
@@ -1920,54 +1869,16 @@ impl Compositor {
         &mut self.veil_chain
     }
 
-    // --- Tool Overlay ---
-
-    /// Replace the current overlay primitives.
-    pub fn set_overlay_primitives(&mut self, prims: Vec<OverlayPrimitive>) {
-        self.tool_overlay.set_primitives(prims);
-        self.needs_present = true;
+    /// Read-only access to the tool overlay. Callers do their own dispatch;
+    /// the compositor stops being a switchboard.
+    pub fn tool_overlay(&self) -> &ToolOverlay {
+        &self.tool_overlay
     }
 
-    /// Clear all overlay primitives.
-    pub fn clear_overlay(&mut self) {
-        self.tool_overlay.clear_primitives();
-        self.needs_present = true;
-    }
-
-    /// Advance overlay animation time.
-    pub fn update_overlay_time(&mut self, dt: f32) {
-        self.tool_overlay.advance_time(dt);
-    }
-
-    /// Upload a mask texture for KIND_MASKED_STAMP overlay primitives.
-    pub fn set_overlay_mask(
-        &mut self,
-        device: &wgpu::Device,
-        queue: &wgpu::Queue,
-        width: u32,
-        height: u32,
-        rgba: &[u8],
-    ) {
-        self.tool_overlay
-            .set_mask_texture(device, queue, width, height, rgba);
-        self.needs_present = true;
-    }
-
-    /// Drop the uploaded mask (fall back to 1×1 white).
-    pub fn clear_overlay_mask(&mut self) {
-        self.tool_overlay.clear_mask_texture();
-        self.needs_present = true;
-    }
-
-    /// Ensure the overlay's preview-mask texture exists at the given size;
-    /// returns a view for a brush node to render into.
-    pub fn ensure_overlay_preview_mask(
-        &mut self,
-        device: &wgpu::Device,
-        width: u32,
-        height: u32,
-    ) -> &wgpu::TextureView {
-        self.tool_overlay.ensure_preview_mask(device, width, height)
+    /// Mutable access to the tool overlay. Callers that change overlay state
+    /// must follow with `mark_needs_present()` themselves.
+    pub fn tool_overlay_mut(&mut self) -> &mut ToolOverlay {
+        &mut self.tool_overlay
     }
 
     /// Split-borrow accessor for the preview-render hot path: returns
@@ -1984,406 +1895,6 @@ impl Compositor {
         Option<&crate::gpu::selection::SelectionState>,
     ) {
         (&mut self.tool_overlay, self.selection_state.as_ref())
-    }
-
-    /// Route the preview-mask texture as the active overlay mask binding.
-    pub fn use_overlay_preview_mask(&mut self) {
-        self.tool_overlay.use_preview_mask_as_mask();
-        self.needs_present = true;
-    }
-
-    /// Unbind the preview mask (falls back to 1×1 white default).
-    pub fn clear_overlay_preview_mask(&mut self) {
-        self.tool_overlay.clear_preview_mask();
-        self.needs_present = true;
-    }
-
-    /// Borrow the overlay's preview-mask Texture (None if never allocated).
-    pub fn overlay_preview_mask_texture(&self) -> Option<&wgpu::Texture> {
-        self.tool_overlay.preview_mask_texture()
-    }
-
-    /// Immutable access to the tool overlay for test assertions.
-    pub fn tool_overlay_ref(&self) -> &ToolOverlay {
-        &self.tool_overlay
-    }
-
-    /// CPU-side hit test on overlay primitives.
-    pub fn overlay_hit_test(&self, screen_x: f32, screen_y: f32) -> Option<usize> {
-        self.tool_overlay.hit_test(screen_x, screen_y)
-    }
-
-    // --- Floating Content (Transform) ---
-    //
-    // The floating preview is a *derived view* of the target node's texture:
-    // when a transform is active, the compositor maintains a per-target
-    // preview texture rebuilt on every matrix update, holding "what the
-    // target would look like if commit ran right now". The render walk's
-    // `effective_node_view` and `effective_mask_bind_group` accessors swap
-    // the live view / mask bind group for the preview equivalents when the
-    // floating target is encountered, so the host's normal blend pass
-    // renders the preview without any extra render pass — and isolation,
-    // grouping, and other branch-free render concerns compose with it
-    // automatically.
-    //
-    // The compositor exposes primitives (set/clear floating content, update
-    // uniforms + preview, commit to live target). The engine drives them
-    // by calling `update_floating_preview` after each matrix change and on
-    // setup_transform.
-
-    /// Allocate the per-target preview texture (and, when target is R8, a
-    /// mask-shape bind group sampling it) plus the canvas-aligned blend
-    /// uniform buffer the host's blend pass reads when this layer is the
-    /// floating target.
-    ///
-    /// Preview is canvas-sized (not live-sized) so a translate that moves
-    /// content past the live layer's bounding box still has room on the
-    /// preview to write — clipped at canvas bounds, which is all the
-    /// viewport renders anyway. Commit's `grow_node_to_fit` separately
-    /// expands the live layer so off-canvas pixels survive the commit.
-    fn allocate_preview_resources(
-        &self,
-        device: &wgpu::Device,
-        format: wgpu::TextureFormat,
-    ) -> (
-        wgpu::Texture,
-        wgpu::TextureView,
-        Option<wgpu::BindGroup>,
-        wgpu::Buffer,
-    ) {
-        let preview = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("floating-preview"),
-            size: wgpu::Extent3d {
-                width: self.canvas_width.max(1),
-                height: self.canvas_height.max(1),
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format,
-            // COPY_SRC needed because `render_commit` runs
-            // `copy_for_compositing` against the render target before its
-            // shader pass — when the target is the preview texture, that
-            // copy reads from preview.
-            usage: wgpu::TextureUsages::TEXTURE_BINDING
-                | wgpu::TextureUsages::COPY_SRC
-                | wgpu::TextureUsages::COPY_DST
-                | wgpu::TextureUsages::RENDER_ATTACHMENT,
-            view_formats: &[],
-        });
-        let view = preview.create_view(&wgpu::TextureViewDescriptor::default());
-        let mask_bg = if format == wgpu::TextureFormat::R8Unorm {
-            Some(device.create_bind_group(&wgpu::BindGroupDescriptor {
-                label: Some("floating-preview-mask-bg"),
-                layout: &self.blend_pipelines.mask_bind_group_layout,
-                entries: &[wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: wgpu::BindingResource::TextureView(&view),
-                }],
-            }))
-        } else {
-            None
-        };
-        let blend_uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("floating-preview-blend-uniforms"),
-            size: std::mem::size_of::<BlendUniforms>() as u64,
-            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-        (preview, view, mask_bg, blend_uniform_buf)
-    }
-
-    /// Look up the target's format + dimensions. Falls back to canvas-sized
-    /// RGBA8 when the node texture hasn't been allocated yet (paste-as-
-    /// floating creates the layer before its texture).
-    fn target_format_and_dims(&self, target_layer: LayerId) -> (wgpu::TextureFormat, u32, u32) {
-        match self.node_textures.get(&target_layer) {
-            Some(t) => {
-                let ext = t.layer_extent();
-                (t.format(), ext.width, ext.height)
-            }
-            None => (
-                wgpu::TextureFormat::Rgba8Unorm,
-                self.canvas_width,
-                self.canvas_height,
-            ),
-        }
-    }
-
-    /// Set up floating content for GPU preview from straight-alpha RGBA
-    /// pixel data (used by the paste paths). The target's preview texture
-    /// is allocated alongside.
-    pub fn set_floating_content(
-        &mut self,
-        device: &wgpu::Device,
-        queue: &wgpu::Queue,
-        rgba_data: &[u8],
-        _source_origin: (i32, i32),
-        source_width: u32,
-        source_height: u32,
-        target_layer: LayerId,
-    ) {
-        let (target_format, _tw, _th) = self.target_format_and_dims(target_layer);
-        let (preview_texture, preview_view, preview_mask_bg, preview_blend_uniform_buf) =
-            self.allocate_preview_resources(device, target_format);
-        self.transform_pass.set_floating_content(
-            device,
-            queue,
-            &self.sampler,
-            rgba_data,
-            source_width,
-            source_height,
-            target_layer,
-            target_format,
-            preview_texture,
-            preview_view,
-            preview_mask_bg,
-            preview_blend_uniform_buf,
-        );
-        // Seed the preview's blend uniforms from the live layer's cached
-        // props now that the floating session is active.
-        self.write_preview_blend_uniforms_if_active(queue, target_layer);
-        self.mark_dirty();
-    }
-
-    /// Set floating content by copying directly from a node's GPU texture.
-    /// GPU→GPU copy — no CPU tiles involved. Format dispatch (R8 mask vs RGBA
-    /// layer) is driven by the texture's own format from the unified node pool.
-    pub fn set_floating_content_from_gpu(
-        &mut self,
-        device: &wgpu::Device,
-        queue: &wgpu::Queue,
-        encoder: &mut wgpu::CommandEncoder,
-        source_origin: (i32, i32),
-        source_width: u32,
-        source_height: u32,
-        target_layer: LayerId,
-    ) {
-        let layer = match self.node_textures.get(&target_layer) {
-            Some(t) => t,
-            None => return,
-        };
-        let target_format = layer.format();
-        let (preview_texture, preview_view, preview_mask_bg, preview_blend_uniform_buf) =
-            self.allocate_preview_resources(device, target_format);
-        // Re-borrow `layer` after `allocate_preview_resources` — the helper
-        // doesn't take `&mut self`, but rust-analyzer prefers the explicit
-        // re-fetch over keeping the borrow live across the helper call.
-        let layer = self
-            .node_textures
-            .get(&target_layer)
-            .expect("layer present after preview allocation");
-        self.transform_pass.set_floating_content_from_gpu(
-            device,
-            queue,
-            encoder,
-            &self.sampler,
-            layer,
-            source_origin,
-            source_width,
-            source_height,
-            target_layer,
-            target_format,
-            preview_texture,
-            preview_view,
-            preview_mask_bg,
-            preview_blend_uniform_buf,
-        );
-        // Seed the preview's blend uniforms from the live layer's cached
-        // props now that the floating session is active.
-        self.write_preview_blend_uniforms_if_active(queue, target_layer);
-        self.mark_dirty();
-    }
-
-    /// Update the floating preview: write the current matrix uniforms, copy
-    /// live target → preview texture, apply the engine-side `clear_shape`
-    /// (None for paste mode, `Some` for transform mode), then run the
-    /// commit shader into the preview. The resulting preview texture is
-    /// what the host's blend pass reads through `effective_node_view` /
-    /// `effective_mask_bind_group` for the rest of the frame.
-    ///
-    /// Called by the engine on `setup_transform` (initial preview) and
-    /// `update_floating_matrix` (per drag tick).
-    #[allow(clippy::too_many_arguments)]
-    pub fn update_floating_preview(
-        &self,
-        device: &wgpu::Device,
-        queue: &wgpu::Queue,
-        paint_pipelines: &crate::gpu::paint_target::PaintPipelines,
-        matrix: &crate::gpu::transform::Affine2D,
-        source_origin: (i32, i32),
-        source_width: u32,
-        source_height: u32,
-        clear_shape: Option<&crate::gpu::transform::ClearShape>,
-    ) {
-        let Some(state) = self.transform_pass.active.as_ref() else {
-            return;
-        };
-        let live = match self.node_textures.get(&state.target_layer) {
-            Some(t) => t,
-            None => return,
-        };
-
-        // The preview is canvas-aligned: the transform shader writes the
-        // moved source content using target_offset=(0,0), target_size=canvas,
-        // so any pixel that lands within the canvas survives — including
-        // ones that fell outside the live texture's bounding box.
-        self.transform_pass.update_uniforms(
-            queue,
-            matrix,
-            source_origin,
-            source_width,
-            source_height,
-            (0, 0),
-            self.canvas_width,
-            self.canvas_height,
-            self.canvas_width,
-            self.canvas_height,
-        );
-
-        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("floating-preview-build"),
-        });
-
-        // 0. Reset the whole preview to transparent. The copy below only
-        //    repaints the canvas portion live actually covers, and the
-        //    commit shader discards outside the transformed source bounds —
-        //    so canvas pixels outside live's extent would otherwise retain
-        //    previous-frame transform writes (ghost trails).
-        crate::gpu::clear_view_transparent(
-            &mut encoder,
-            &state.preview_view,
-            "floating-preview-clear",
-        );
-
-        // 1. Copy live → preview so non-source-rect pixels are preserved.
-        //    Live texture sits at `(live.offset_x, live.offset_y)` in canvas
-        //    space; clip the copy to the on-canvas portion (the preview is
-        //    canvas-sized at origin 0,0). Off-canvas pixels are not in the
-        //    preview — the viewport never renders them anyway, and commit's
-        //    `grow_node_to_fit` preserves them on the live texture.
-        let canvas_rect =
-            crate::coord::CanvasRect::from_xywh(0, 0, self.canvas_width, self.canvas_height);
-        let live_canvas_extent = live.canvas_extent();
-        if let Some(visible) = live_canvas_extent.intersect(canvas_rect) {
-            // Translate the visible canvas slice into the live texture's
-            // layer-local coordinate frame for the GPU copy origin.
-            let visible_layer = live
-                .canvas_to_layer_rect(visible)
-                .expect("intersect with live's extent yields a layer-local rect");
-            let dst_x = visible.x0() as u32;
-            let dst_y = visible.y0() as u32;
-            encoder.copy_texture_to_texture(
-                wgpu::TexelCopyTextureInfo {
-                    texture: live.texture(),
-                    mip_level: 0,
-                    origin: wgpu::Origin3d {
-                        x: visible_layer.x0(),
-                        y: visible_layer.y0(),
-                        z: 0,
-                    },
-                    aspect: wgpu::TextureAspect::All,
-                },
-                wgpu::TexelCopyTextureInfo {
-                    texture: &state.preview_texture,
-                    mip_level: 0,
-                    origin: wgpu::Origin3d {
-                        x: dst_x,
-                        y: dst_y,
-                        z: 0,
-                    },
-                    aspect: wgpu::TextureAspect::All,
-                },
-                wgpu::Extent3d {
-                    width: visible.width,
-                    height: visible.height,
-                    depth_or_array_layers: 1,
-                },
-            );
-        }
-
-        // 2. Apply the source-rect clear (transform mode only — paste mode
-        //    leaves the preview as a copy of the live target so the commit
-        //    shader composites over the existing pixels). The preview is
-        //    canvas-aligned, so the paint target reports canvas dims/offset.
-        if let Some(cs) = clear_shape {
-            let preview_target = crate::gpu::paint_target::GpuPaintTarget::from_canvas_texture(
-                &state.preview_texture,
-                &state.preview_view,
-                state.target_format,
-                self.canvas_width,
-                self.canvas_height,
-            );
-            match cs {
-                crate::gpu::transform::ClearShape::Rect(rect) => {
-                    preview_target.clear_rect(&mut encoder, paint_pipelines, queue, *rect);
-                }
-                crate::gpu::transform::ClearShape::Selection { mask_bind_group } => {
-                    preview_target.erase_with_selection(
-                        &mut encoder,
-                        paint_pipelines,
-                        queue,
-                        mask_bind_group,
-                    );
-                }
-            }
-        }
-
-        // 3. Run the commit shader into the preview at the current matrix.
-        self.transform_pass.render_commit(
-            device,
-            &mut encoder,
-            &state.preview_texture,
-            &state.preview_view,
-        );
-
-        queue.submit(std::iter::once(encoder.finish()));
-    }
-
-    /// Render the transform directly into the live target texture.
-    /// Used by `commit_floating()` after the engine has applied the
-    /// `clear_shape` to the live target.
-    pub fn commit_floating_to_texture(
-        &mut self,
-        device: &wgpu::Device,
-        encoder: &mut wgpu::CommandEncoder,
-        queue: &wgpu::Queue,
-        matrix: &crate::gpu::transform::Affine2D,
-        source_origin: (i32, i32),
-        source_width: u32,
-        source_height: u32,
-    ) {
-        let Some(state) = self.transform_pass.active.as_ref() else {
-            return;
-        };
-        let live = match self.node_textures.get(&state.target_layer) {
-            Some(t) => t,
-            None => return,
-        };
-
-        let live_extent = live.canvas_extent();
-        self.transform_pass.update_uniforms(
-            queue,
-            matrix,
-            source_origin,
-            source_width,
-            source_height,
-            (live_extent.x0(), live_extent.y0()),
-            live_extent.width,
-            live_extent.height,
-            self.canvas_width,
-            self.canvas_height,
-        );
-
-        self.transform_pass
-            .render_commit(device, encoder, live.texture(), live.view());
-    }
-
-    /// Remove floating content GPU state.
-    pub fn clear_floating_content(&mut self) {
-        self.transform_pass.clear();
-        self.mark_dirty();
     }
 
     /// Effective mask bind group for a host raster/group during compositing
@@ -2429,20 +1940,6 @@ impl Compositor {
             }
         }
         live_or_default
-    }
-
-    /// Get a reference to the transform source texture and its view.
-    /// Returns None if no floating content is active.
-    pub fn transform_source_texture(&self) -> Option<(&wgpu::Texture, &wgpu::TextureView)> {
-        self.transform_pass
-            .active
-            .as_ref()
-            .map(|s| (&s.source_texture, &s.source_view))
-    }
-
-    /// Check if floating content is active.
-    pub fn has_floating_content(&self) -> bool {
-        self.transform_pass.active.is_some()
     }
 
     /// Run the present pass, veil chain, and final blit to surface.
@@ -3253,37 +2750,8 @@ impl Compositor {
         self.veil_chain.clear_needs_present();
     }
 
-    /// Composite layers if needed, then present to an arbitrary texture view.
-    ///
-    /// This is the backend-agnostic rendering entry point. Any frontend
-    /// (WASM surface, native window, CEF hole-punch, headless test) can
-    /// provide a `TextureView` and get the composited + veiled result.
-    pub fn render_to_view(
-        &mut self,
-        device: &wgpu::Device,
-        queue: &wgpu::Queue,
-        target_view: &wgpu::TextureView,
-        doc: &mut Document,
-    ) {
-        if !self.has_pending_work(doc) {
-            return;
-        }
-
-        self.render_offscreen(device, queue, doc);
-
-        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("present-to-view"),
-        });
-        self.present_and_veils(&mut encoder, target_view);
-        queue.submit(std::iter::once(encoder.finish()));
-
-        self.finish_present();
-    }
-
     /// Upload dirty tiles, composite changed layers, present to a surface.
-    ///
-    /// Convenience wrapper around `render_to_view` that handles surface
-    /// acquisition and presentation. Used by the WASM frontend.
+    /// Used by the WASM frontend.
     pub fn render(
         &mut self,
         device: &wgpu::Device,

--- a/crates/darkly/src/gpu/compositor.rs
+++ b/crates/darkly/src/gpu/compositor.rs
@@ -10,7 +10,14 @@ use crate::gpu::veil_chain::VeilChain;
 use crate::gpu::view::{ViewTransform, DEFAULT_WORKSPACE_BG};
 use crate::gpu::void::{Void, VoidRegistry};
 use crate::layer::{Layer, LayerId, LayerNode};
+use smallvec::SmallVec;
 use std::collections::{HashMap, HashSet};
+
+/// Stack-side capacity for the per-frame `children_of(...)` snapshot used by
+/// the composite walk. Typical documents have single-digit children per group;
+/// wider groups (paste-many-layers, stress tests) spill to the heap without
+/// ceremony.
+type ChildIds = SmallVec<[LayerId; 8]>;
 
 /// Convert a `display.pixelFilter` string value to the float code stamped
 /// into `ViewTransform.flags[0]`. Unknown values fall back to auto.
@@ -219,6 +226,15 @@ pub struct Compositor {
     /// loop (which falls back to `default_mask_bind_group` for hidden masks).
     mask_bind_groups: HashMap<LayerId, wgpu::BindGroup>,
 
+    /// Cached blend bind groups for `compose_children`. Key is
+    /// `(parent_group, child_id, src_accum_idx)` — both ping-pong sides
+    /// get their own entry per child because the source accum view flips
+    /// every layer. Entries are invalidated in `dispose_node_texture` and
+    /// `resize_node_texture` against the affected node id (either as
+    /// parent or child); the floating-target case bypasses the cache so
+    /// preview-state ephemera never leak in.
+    blend_bind_groups: HashMap<(LayerId, LayerId, u8), wgpu::BindGroup>,
+
     /// Pre-built GPU objects per content layer (raster + void). Keyed by
     /// the document's [`LayerId`] — both kinds share the same blend
     /// pipeline path, so collapsing them into one pool means the blend
@@ -318,6 +334,12 @@ pub struct Compositor {
     frame_count: u64,
     /// Last wall-clock time for dt computation.
     last_wall_time: f32,
+
+    /// Reused buffer for the "ids of dirty procedural layers" pass in
+    /// `encode_dirty_layer_content`. Cleared at the top of the pass and
+    /// drained before returning, so the only retained allocation is the
+    /// `Vec` capacity itself.
+    dirty_procedural_scratch: Vec<LayerId>,
 }
 
 impl Compositor {
@@ -671,6 +693,7 @@ impl Compositor {
             node_textures: HashMap::new(),
             default_mask_bind_group,
             mask_bind_groups: HashMap::new(),
+            blend_bind_groups: HashMap::new(),
             layer_cache: HashMap::new(),
             blend_pipelines,
             mask_lerp_pipeline,
@@ -700,6 +723,7 @@ impl Compositor {
             pixel_filter: pixel_filter_from_config(),
             frame_count: 0,
             last_wall_time: 0.0,
+            dirty_procedural_scratch: Vec::new(),
         }
     }
 
@@ -849,6 +873,12 @@ impl Compositor {
         );
 
         self.node_textures.insert(node_id, new_tex);
+
+        // Any cached blend bind groups using this node (as parent or child)
+        // reference the now-replaced texture view; drop them so the next
+        // composite re-creates against the fresh handle.
+        self.blend_bind_groups
+            .retain(|(parent, child, _), _| *parent != node_id && *child != node_id);
 
         // If this node has a cached mask bind group, rebuild it against the
         // freshly-allocated view. The blend stage holds no other reference.
@@ -1372,6 +1402,12 @@ impl Compositor {
     pub fn dispose_node_texture(&mut self, node_id: LayerId) {
         self.node_textures.remove(&node_id);
         self.mask_bind_groups.remove(&node_id);
+        // Blend bind groups that name this node as either the parent (a
+        // group whose accum is gone) or the child (a layer or child-group
+        // whose view is gone) point at a freed texture handle. Evict them
+        // so the next composite rebuilds against current state.
+        self.blend_bind_groups
+            .retain(|(parent, child, _), _| *parent != node_id && *child != node_id);
         self.layer_cache.remove(&node_id);
         self.dirty_node_pixels.remove(&node_id);
         self.mark_dirty();
@@ -1575,16 +1611,24 @@ impl Compositor {
         // Two-phase: collect ids of dirty procedural layers, then drop the
         // mutable borrow and re-acquire per-entry. Keeps the loop body
         // short and avoids borrowing `self.layer_cache` and
-        // `self.node_textures` at the same time.
-        let dirty: Vec<LayerId> = self
-            .layer_cache
-            .iter()
-            .filter_map(|(id, c)| match &c.content {
-                LayerContent::Procedural(p) if p.dirty => Some(*id),
-                _ => None,
-            })
-            .collect();
-        for id in dirty {
+        // `self.node_textures` at the same time. The scratch buffer is
+        // owned by `self` so the per-frame Vec churn vanishes.
+        self.dirty_procedural_scratch.clear();
+        self.dirty_procedural_scratch
+            .extend(
+                self.layer_cache
+                    .iter()
+                    .filter_map(|(id, c)| match &c.content {
+                        LayerContent::Procedural(p) if p.dirty => Some(*id),
+                        _ => None,
+                    }),
+            );
+        // Index-iterate so the loop body can re-borrow `self.layer_cache`
+        // mutably; the LayerIds are `Copy`. The scratch retains its
+        // capacity across frames so the per-frame `Vec` churn vanishes.
+        let count = self.dirty_procedural_scratch.len();
+        for i in 0..count {
+            let id = self.dirty_procedural_scratch[i];
             let dst_view = match self.node_textures.get(&id) {
                 Some(t) => t.view(),
                 None => continue,
@@ -1607,6 +1651,9 @@ impl Compositor {
             proc.void.encode(encoder, &proc.cache, dst_view);
             proc.dirty = false;
         }
+        // Leave the field empty at exit — capacity is retained but no
+        // potentially-stale LayerIds live past dispose.
+        self.dirty_procedural_scratch.clear();
     }
 
     /// Total number of node textures (raster layers + mask modifiers)
@@ -1855,12 +1902,6 @@ impl Compositor {
 
     /// Look up the resolved mask bind group for a modifier id, falling back to
     /// the default (1x1 white = no masking) when no real mask is active.
-    fn mask_bind_group(&self, layer_id: LayerId) -> &wgpu::BindGroup {
-        self.mask_bind_groups
-            .get(&layer_id)
-            .unwrap_or(&self.default_mask_bind_group)
-    }
-
     /// Get the composited output texture (root group's composite cache).
     /// Used by the color picker for readback.
     pub fn composited_texture(&self) -> &wgpu::Texture {
@@ -2354,13 +2395,33 @@ impl Compositor {
         doc: &Document,
         host_id: LayerId,
     ) -> &wgpu::BindGroup {
+        Self::effective_mask_bind_group_fields(
+            &self.mask_bind_groups,
+            &self.default_mask_bind_group,
+            &self.transform_pass,
+            doc,
+            host_id,
+        )
+    }
+
+    /// Field-explicit variant of [`Self::effective_mask_bind_group`] so a
+    /// caller can hold a disjoint `&mut self.blend_bind_groups` borrow
+    /// across this lookup. The method-form takes `&self` whole; the
+    /// borrow checker can't split that.
+    fn effective_mask_bind_group_fields<'a>(
+        mask_bind_groups: &'a HashMap<LayerId, wgpu::BindGroup>,
+        default_mask_bind_group: &'a wgpu::BindGroup,
+        transform_pass: &'a crate::gpu::transform::TransformPass,
+        doc: &Document,
+        host_id: LayerId,
+    ) -> &'a wgpu::BindGroup {
         let live_or_default = doc
             .mask_modifier(host_id)
             .filter(|m| m.common.visible)
-            .map(|m| self.mask_bind_group(m.id))
-            .unwrap_or(&self.default_mask_bind_group);
+            .and_then(|m| mask_bind_groups.get(&m.id))
+            .unwrap_or(default_mask_bind_group);
 
-        if let Some(state) = self.transform_pass.active.as_ref() {
+        if let Some(state) = transform_pass.active.as_ref() {
             if doc.parent_of(state.target_layer) == Some(host_id) {
                 if let Some(bg) = state.preview_mask_bind_group.as_ref() {
                     return bg;
@@ -2579,6 +2640,7 @@ impl Compositor {
     ///
     /// Forces an identity 1:1 view transform so screen pixels map to canvas
     /// pixels and the OOB branch is inactive across the whole target.
+    #[cfg(any(test, feature = "testing"))]
     pub fn test_present_to_canvas(
         &mut self,
         device: &wgpu::Device,
@@ -2676,6 +2738,53 @@ impl Compositor {
         })
     }
 
+    /// Cached entry point for `create_blend_bind_group`. The key
+    /// `(parent_group, child, src_accum_idx)` uniquely identifies the bg+layer
+    /// view pair for a given composite — view handles and uniform buffers
+    /// are stable across frames, so caching by key avoids the per-frame
+    /// allocator round-trip. Caller is responsible for bypassing the cache
+    /// when the inputs are not stable (e.g. floating-target preview swap).
+    ///
+    /// Takes the cache field directly rather than `&mut self` so the caller
+    /// can keep other immutable field borrows live across this call. Returns
+    /// a borrow into the cache, valid until the cache is mutated again.
+    fn get_or_create_blend_bind_group<'a>(
+        blend_bind_groups: &'a mut HashMap<(LayerId, LayerId, u8), wgpu::BindGroup>,
+        bgl: &wgpu::BindGroupLayout,
+        sampler: &wgpu::Sampler,
+        device: &wgpu::Device,
+        key: (LayerId, LayerId, u8),
+        bg_view: &wgpu::TextureView,
+        layer_view: &wgpu::TextureView,
+        uniform_buf: &wgpu::Buffer,
+        label: &str,
+    ) -> &'a wgpu::BindGroup {
+        blend_bind_groups.entry(key).or_insert_with(|| {
+            device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some(label),
+                layout: bgl,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(bg_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::TextureView(layer_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: wgpu::BindingResource::Sampler(sampler),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 3,
+                        resource: uniform_buf.as_entire_binding(),
+                    },
+                ],
+            })
+        })
+    }
+
     /// Recursively composite a group's children into its GroupState.
     ///
     /// For passthrough groups, children are inlined into the parent's accum
@@ -2717,8 +2826,9 @@ impl Compositor {
 
         // Inline children into this group's accumulators. Clone the child
         // ids so the borrow on `doc` doesn't outlive the call into
-        // `compose_children`, which itself re-borrows `doc`.
-        let children: Vec<LayerId> = doc.children_of(group_id).to_vec();
+        // `compose_children`, which itself re-borrows `doc`. `SmallVec`
+        // absorbs the typical single-digit-children case on the stack.
+        let children: ChildIds = ChildIds::from_slice(doc.children_of(group_id));
         self.compose_children(encoder, device, doc, group_id, &children, scissor);
 
         // Copy final accum to this group's composite cache.
@@ -2824,20 +2934,59 @@ impl Compositor {
                     let dst = 1 - src;
                     gs.current_accum = dst;
 
-                    let bind_group = self.create_blend_bind_group(
-                        device,
-                        &self.group_state[&parent_group].accum.views[src],
-                        layer_view,
-                        uniform_buf_ptr,
-                        "blend-layer",
-                    );
+                    // Floating target swaps the bg/layer view per-frame to the
+                    // (canvas-aligned) preview texture; skip the cache so
+                    // preview-state ephemera never leak in. The non-floating
+                    // path uses stable view+uniform handles so the cache key
+                    // `(parent, child, src)` is sufficient.
+                    let fresh_bind_group: Option<wgpu::BindGroup>;
+                    let cached_bind_group: Option<&wgpu::BindGroup>;
+                    if active_floating.is_some() {
+                        fresh_bind_group = Some(self.create_blend_bind_group(
+                            device,
+                            &self.group_state[&parent_group].accum.views[src],
+                            layer_view,
+                            uniform_buf_ptr,
+                            "blend-layer",
+                        ));
+                        cached_bind_group = None;
+                    } else {
+                        // Split-borrow: pull out the views we need so the
+                        // mutable borrow of `blend_bind_groups` doesn't
+                        // overlap with field reads inside the helper.
+                        let bg_view = &self.group_state[&parent_group].accum.views[src];
+                        let bgl = &self.blend_pipelines.bind_group_layout;
+                        let sampler = &self.sampler;
+                        cached_bind_group = Some(Self::get_or_create_blend_bind_group(
+                            &mut self.blend_bind_groups,
+                            bgl,
+                            sampler,
+                            device,
+                            (parent_group, layer_id, src as u8),
+                            bg_view,
+                            layer_view,
+                            uniform_buf_ptr,
+                            "blend-layer",
+                        ));
+                        fresh_bind_group = None;
+                    }
+                    let bind_group: &wgpu::BindGroup = cached_bind_group
+                        .unwrap_or_else(|| fresh_bind_group.as_ref().expect("one branch sets it"));
 
                     {
                         let gs = &self.group_state[&parent_group];
                         // Effective mask bind group: live mask by default,
                         // preview-mask bind group when one of this layer's
-                        // modifiers is the floating target.
-                        let mask_bg = self.effective_mask_bind_group(doc, layer_id);
+                        // modifiers is the floating target. Field-explicit
+                        // form so the cached `bind_group` borrow on
+                        // `self.blend_bind_groups` survives this lookup.
+                        let mask_bg = Self::effective_mask_bind_group_fields(
+                            &self.mask_bind_groups,
+                            &self.default_mask_bind_group,
+                            &self.transform_pass,
+                            doc,
+                            layer_id,
+                        );
                         let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                             label: Some("blend-layer"),
                             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
@@ -2853,7 +3002,7 @@ impl Compositor {
                         });
                         rpass.set_scissor_rect(scissor_x, scissor_y, scissor_w, scissor_h);
                         rpass.set_pipeline(self.blend_pipelines.pipeline());
-                        rpass.set_bind_group(0, &bind_group, &[]);
+                        rpass.set_bind_group(0, bind_group, &[]);
                         rpass.set_bind_group(1, mask_bg, &[]);
                         rpass.draw(0..3, 0..1);
                     }
@@ -2881,7 +3030,7 @@ impl Compositor {
                             );
                         } else {
                             // Pure passthrough — inline children into parent.
-                            let inner: Vec<LayerId> = doc.children_of(group_id).to_vec();
+                            let inner: ChildIds = ChildIds::from_slice(doc.children_of(group_id));
                             self.compose_children(
                                 encoder,
                                 device,
@@ -2905,12 +3054,29 @@ impl Compositor {
                         let dst = 1 - src;
                         gs_parent.current_accum = dst;
 
+                        // Split-borrow into the cache: bg/layer views and
+                        // uniform buffer live in distinct fields from
+                        // `blend_bind_groups`, so we can hold the mutable
+                        // borrow of the cache and the immutable borrows of
+                        // the views together. Groups never become floating
+                        // targets themselves, so the cache always applies
+                        // here (a modifier-as-floating-target only swaps
+                        // mask_bg via `effective_mask_bind_group`).
+                        let bg_view = &self.group_state[&parent_group].accum.views[src];
                         let gs_child = &self.group_state[&group_id];
-                        let bind_group = self.create_blend_bind_group(
+                        let child_view = &gs_child.composite_cache_view;
+                        let child_uniform = &gs_child.uniform_buf;
+                        let bgl = &self.blend_pipelines.bind_group_layout;
+                        let sampler = &self.sampler;
+                        let bind_group = Self::get_or_create_blend_bind_group(
+                            &mut self.blend_bind_groups,
+                            bgl,
+                            sampler,
                             device,
-                            &self.group_state[&parent_group].accum.views[src],
-                            &gs_child.composite_cache_view,
-                            &gs_child.uniform_buf,
+                            (parent_group, group_id, src as u8),
+                            bg_view,
+                            child_view,
+                            child_uniform,
                             "blend-group",
                         );
 
@@ -2918,8 +3084,16 @@ impl Compositor {
                         // Same effective-mask routing as the raster path —
                         // when the floating target is one of this group's
                         // modifiers, sample the preview-mask bind group
-                        // instead of the live one.
-                        let child_mask_bg = self.effective_mask_bind_group(doc, group_id);
+                        // instead of the live one. Field-explicit form so
+                        // the cached `bind_group` borrow on
+                        // `self.blend_bind_groups` survives this lookup.
+                        let child_mask_bg = Self::effective_mask_bind_group_fields(
+                            &self.mask_bind_groups,
+                            &self.default_mask_bind_group,
+                            &self.transform_pass,
+                            doc,
+                            group_id,
+                        );
                         {
                             let mut rpass =
                                 encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
@@ -2937,7 +3111,7 @@ impl Compositor {
                                 });
                             rpass.set_scissor_rect(scissor_x, scissor_y, scissor_w, scissor_h);
                             rpass.set_pipeline(self.blend_pipelines.pipeline());
-                            rpass.set_bind_group(0, &bind_group, &[]);
+                            rpass.set_bind_group(0, bind_group, &[]);
                             rpass.set_bind_group(1, child_mask_bg, &[]);
                             rpass.draw(0..3, 0..1);
                         }
@@ -2965,7 +3139,7 @@ impl Compositor {
         // PassthroughMaskState must exist (created when the mask was added).
         if !self.passthrough_mask_state.contains_key(&group_id) {
             // Fallback: just inline children without mask.
-            let inner: Vec<LayerId> = doc.children_of(group_id).to_vec();
+            let inner: ChildIds = ChildIds::from_slice(doc.children_of(group_id));
             self.compose_children(encoder, device, doc, parent_group, &inner, scissor);
             return;
         }
@@ -3004,7 +3178,7 @@ impl Compositor {
         );
 
         // 2. Composite children into parent accumulators (passthrough).
-        let inner: Vec<LayerId> = doc.children_of(group_id).to_vec();
+        let inner: ChildIds = ChildIds::from_slice(doc.children_of(group_id));
         self.compose_children(encoder, device, doc, parent_group, &inner, scissor);
 
         // 3. Lerp pass: mix(snapshot, current_accum, mask).

--- a/crates/darkly/src/gpu/floating_preview.rs
+++ b/crates/darkly/src/gpu/floating_preview.rs
@@ -1,0 +1,421 @@
+//! Floating-content preview methods on [`Compositor`].
+//!
+//! The floating preview is a *derived view* of the target node's texture:
+//! when a transform is active, the compositor maintains a per-target
+//! preview texture rebuilt on every matrix update, holding "what the
+//! target would look like if commit ran right now". The render walk's
+//! `effective_node_view` and `effective_mask_bind_group` accessors swap
+//! the live view / mask bind group for the preview equivalents when the
+//! floating target is encountered, so the host's normal blend pass
+//! renders the preview without any extra render pass — and isolation,
+//! grouping, and other branch-free render concerns compose with it
+//! automatically.
+//!
+//! The compositor exposes primitives (set/clear floating content, update
+//! uniforms + preview, commit to live target). The engine drives them by
+//! calling `update_floating_preview` after each matrix change and on
+//! `setup_transform`.
+
+use crate::gpu::compositor::{BlendUniforms, Compositor};
+use crate::layer::LayerId;
+
+impl Compositor {
+    /// Allocate the per-target preview texture (and, when target is R8, a
+    /// mask-shape bind group sampling it) plus the canvas-aligned blend
+    /// uniform buffer the host's blend pass reads when this layer is the
+    /// floating target.
+    ///
+    /// Preview is canvas-sized (not live-sized) so a translate that moves
+    /// content past the live layer's bounding box still has room on the
+    /// preview to write — clipped at canvas bounds, which is all the
+    /// viewport renders anyway. Commit's `grow_node_to_fit` separately
+    /// expands the live layer so off-canvas pixels survive the commit.
+    fn allocate_preview_resources(
+        &self,
+        device: &wgpu::Device,
+        format: wgpu::TextureFormat,
+    ) -> (
+        wgpu::Texture,
+        wgpu::TextureView,
+        Option<wgpu::BindGroup>,
+        wgpu::Buffer,
+    ) {
+        let preview = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("floating-preview"),
+            size: wgpu::Extent3d {
+                width: self.canvas_width.max(1),
+                height: self.canvas_height.max(1),
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            // COPY_SRC needed because `render_commit` runs
+            // `copy_for_compositing` against the render target before its
+            // shader pass — when the target is the preview texture, that
+            // copy reads from preview.
+            usage: wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_SRC
+                | wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let view = preview.create_view(&wgpu::TextureViewDescriptor::default());
+        let mask_bg = if format == wgpu::TextureFormat::R8Unorm {
+            Some(device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("floating-preview-mask-bg"),
+                layout: &self.blend_pipelines.mask_bind_group_layout,
+                entries: &[wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&view),
+                }],
+            }))
+        } else {
+            None
+        };
+        let blend_uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("floating-preview-blend-uniforms"),
+            size: std::mem::size_of::<BlendUniforms>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        (preview, view, mask_bg, blend_uniform_buf)
+    }
+
+    /// Look up the target's format + dimensions. Falls back to canvas-sized
+    /// RGBA8 when the node texture hasn't been allocated yet (paste-as-
+    /// floating creates the layer before its texture).
+    fn target_format_and_dims(&self, target_layer: LayerId) -> (wgpu::TextureFormat, u32, u32) {
+        match self.node_textures.get(&target_layer) {
+            Some(t) => {
+                let ext = t.layer_extent();
+                (t.format(), ext.width, ext.height)
+            }
+            None => (
+                wgpu::TextureFormat::Rgba8Unorm,
+                self.canvas_width,
+                self.canvas_height,
+            ),
+        }
+    }
+
+    /// Set up floating content for GPU preview from straight-alpha RGBA
+    /// pixel data (used by the paste paths). The target's preview texture
+    /// is allocated alongside.
+    pub fn set_floating_content(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        rgba_data: &[u8],
+        _source_origin: (i32, i32),
+        source_width: u32,
+        source_height: u32,
+        target_layer: LayerId,
+    ) {
+        let (target_format, _tw, _th) = self.target_format_and_dims(target_layer);
+        let (preview_texture, preview_view, preview_mask_bg, preview_blend_uniform_buf) =
+            self.allocate_preview_resources(device, target_format);
+        self.transform_pass.set_floating_content(
+            device,
+            queue,
+            &self.sampler,
+            rgba_data,
+            source_width,
+            source_height,
+            target_layer,
+            target_format,
+            preview_texture,
+            preview_view,
+            preview_mask_bg,
+            preview_blend_uniform_buf,
+        );
+        // Seed the preview's blend uniforms from the live layer's cached
+        // props now that the floating session is active.
+        self.write_preview_blend_uniforms_if_active(queue, target_layer);
+        self.mark_dirty();
+    }
+
+    /// Set floating content by copying directly from a node's GPU texture.
+    /// GPU→GPU copy — no CPU tiles involved. Format dispatch (R8 mask vs RGBA
+    /// layer) is driven by the texture's own format from the unified node pool.
+    pub fn set_floating_content_from_gpu(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+        source_origin: (i32, i32),
+        source_width: u32,
+        source_height: u32,
+        target_layer: LayerId,
+    ) {
+        let layer = match self.node_textures.get(&target_layer) {
+            Some(t) => t,
+            None => return,
+        };
+        let target_format = layer.format();
+        let (preview_texture, preview_view, preview_mask_bg, preview_blend_uniform_buf) =
+            self.allocate_preview_resources(device, target_format);
+        // Re-borrow `layer` after `allocate_preview_resources` — the helper
+        // doesn't take `&mut self`, but rust-analyzer prefers the explicit
+        // re-fetch over keeping the borrow live across the helper call.
+        let layer = self
+            .node_textures
+            .get(&target_layer)
+            .expect("layer present after preview allocation");
+        self.transform_pass.set_floating_content_from_gpu(
+            device,
+            queue,
+            encoder,
+            &self.sampler,
+            layer,
+            source_origin,
+            source_width,
+            source_height,
+            target_layer,
+            target_format,
+            preview_texture,
+            preview_view,
+            preview_mask_bg,
+            preview_blend_uniform_buf,
+        );
+        // Seed the preview's blend uniforms from the live layer's cached
+        // props now that the floating session is active.
+        self.write_preview_blend_uniforms_if_active(queue, target_layer);
+        self.mark_dirty();
+    }
+
+    /// Update the floating preview: write the current matrix uniforms, copy
+    /// live target → preview texture, apply the engine-side `clear_shape`
+    /// (None for paste mode, `Some` for transform mode), then run the
+    /// commit shader into the preview. The resulting preview texture is
+    /// what the host's blend pass reads through `effective_node_view` /
+    /// `effective_mask_bind_group` for the rest of the frame.
+    ///
+    /// Called by the engine on `setup_transform` (initial preview) and
+    /// `update_floating_matrix` (per drag tick).
+    #[allow(clippy::too_many_arguments)]
+    pub fn update_floating_preview(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        paint_pipelines: &crate::gpu::paint_target::PaintPipelines,
+        matrix: &crate::gpu::transform::Affine2D,
+        source_origin: (i32, i32),
+        source_width: u32,
+        source_height: u32,
+        clear_shape: Option<&crate::gpu::transform::ClearShape>,
+    ) {
+        let Some(state) = self.transform_pass.active.as_ref() else {
+            return;
+        };
+        let live = match self.node_textures.get(&state.target_layer) {
+            Some(t) => t,
+            None => return,
+        };
+
+        // The preview is canvas-aligned: the transform shader writes the
+        // moved source content using target_offset=(0,0), target_size=canvas,
+        // so any pixel that lands within the canvas survives — including
+        // ones that fell outside the live texture's bounding box.
+        self.transform_pass.update_uniforms(
+            queue,
+            matrix,
+            source_origin,
+            source_width,
+            source_height,
+            (0, 0),
+            self.canvas_width,
+            self.canvas_height,
+            self.canvas_width,
+            self.canvas_height,
+        );
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("floating-preview-build"),
+        });
+
+        // 0. Reset the whole preview to transparent. The copy below only
+        //    repaints the canvas portion live actually covers, and the
+        //    commit shader discards outside the transformed source bounds —
+        //    so canvas pixels outside live's extent would otherwise retain
+        //    previous-frame transform writes (ghost trails).
+        crate::gpu::clear_view_transparent(
+            &mut encoder,
+            &state.preview_view,
+            "floating-preview-clear",
+        );
+
+        // 1. Copy live → preview so non-source-rect pixels are preserved.
+        //    Live texture sits at `(live.offset_x, live.offset_y)` in canvas
+        //    space; clip the copy to the on-canvas portion (the preview is
+        //    canvas-sized at origin 0,0). Off-canvas pixels are not in the
+        //    preview — the viewport never renders them anyway, and commit's
+        //    `grow_node_to_fit` preserves them on the live texture.
+        let canvas_rect =
+            crate::coord::CanvasRect::from_xywh(0, 0, self.canvas_width, self.canvas_height);
+        let live_canvas_extent = live.canvas_extent();
+        if let Some(visible) = live_canvas_extent.intersect(canvas_rect) {
+            // Translate the visible canvas slice into the live texture's
+            // layer-local coordinate frame for the GPU copy origin.
+            let visible_layer = live
+                .canvas_to_layer_rect(visible)
+                .expect("intersect with live's extent yields a layer-local rect");
+            let dst_x = visible.x0() as u32;
+            let dst_y = visible.y0() as u32;
+            encoder.copy_texture_to_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: live.texture(),
+                    mip_level: 0,
+                    origin: wgpu::Origin3d {
+                        x: visible_layer.x0(),
+                        y: visible_layer.y0(),
+                        z: 0,
+                    },
+                    aspect: wgpu::TextureAspect::All,
+                },
+                wgpu::TexelCopyTextureInfo {
+                    texture: &state.preview_texture,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d {
+                        x: dst_x,
+                        y: dst_y,
+                        z: 0,
+                    },
+                    aspect: wgpu::TextureAspect::All,
+                },
+                wgpu::Extent3d {
+                    width: visible.width,
+                    height: visible.height,
+                    depth_or_array_layers: 1,
+                },
+            );
+        }
+
+        // 2. Apply the source-rect clear (transform mode only — paste mode
+        //    leaves the preview as a copy of the live target so the commit
+        //    shader composites over the existing pixels). The preview is
+        //    canvas-aligned, so the paint target reports canvas dims/offset.
+        if let Some(cs) = clear_shape {
+            let preview_target = crate::gpu::paint_target::GpuPaintTarget::from_canvas_texture(
+                &state.preview_texture,
+                &state.preview_view,
+                state.target_format,
+                self.canvas_width,
+                self.canvas_height,
+            );
+            match cs {
+                crate::gpu::transform::ClearShape::Rect(rect) => {
+                    preview_target.clear_rect(&mut encoder, paint_pipelines, queue, *rect);
+                }
+                crate::gpu::transform::ClearShape::Selection { mask_bind_group } => {
+                    preview_target.erase_with_selection(
+                        &mut encoder,
+                        paint_pipelines,
+                        queue,
+                        mask_bind_group,
+                    );
+                }
+            }
+        }
+
+        // 3. Run the commit shader into the preview at the current matrix.
+        self.transform_pass.render_commit(
+            device,
+            &mut encoder,
+            &state.preview_texture,
+            &state.preview_view,
+        );
+
+        queue.submit(std::iter::once(encoder.finish()));
+    }
+
+    /// Render the transform directly into the live target texture.
+    /// Used by `commit_floating()` after the engine has applied the
+    /// `clear_shape` to the live target.
+    pub fn commit_floating_to_texture(
+        &mut self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        queue: &wgpu::Queue,
+        matrix: &crate::gpu::transform::Affine2D,
+        source_origin: (i32, i32),
+        source_width: u32,
+        source_height: u32,
+    ) {
+        let Some(state) = self.transform_pass.active.as_ref() else {
+            return;
+        };
+        let live = match self.node_textures.get(&state.target_layer) {
+            Some(t) => t,
+            None => return,
+        };
+
+        let live_extent = live.canvas_extent();
+        self.transform_pass.update_uniforms(
+            queue,
+            matrix,
+            source_origin,
+            source_width,
+            source_height,
+            (live_extent.x0(), live_extent.y0()),
+            live_extent.width,
+            live_extent.height,
+            self.canvas_width,
+            self.canvas_height,
+        );
+
+        self.transform_pass
+            .render_commit(device, encoder, live.texture(), live.view());
+    }
+
+    /// Remove floating content GPU state.
+    pub fn clear_floating_content(&mut self) {
+        self.transform_pass.clear();
+        self.mark_dirty();
+    }
+
+    /// Get a reference to the transform source texture and its view.
+    /// Returns None if no floating content is active.
+    pub fn transform_source_texture(&self) -> Option<(&wgpu::Texture, &wgpu::TextureView)> {
+        self.transform_pass
+            .active
+            .as_ref()
+            .map(|s| (&s.source_texture, &s.source_view))
+    }
+
+    /// Write the floating preview's canvas-aligned blend uniforms using the
+    /// given layer's cached blend props. No-op when there is no active
+    /// floating, or when the active floating's target is not `layer_id`.
+    /// Called from both `update_layer_uniforms` (on prop change) and the
+    /// floating setup paths (to seed the buffer at session start).
+    pub(super) fn write_preview_blend_uniforms_if_active(
+        &self,
+        queue: &wgpu::Queue,
+        layer_id: LayerId,
+    ) {
+        let state = match self.transform_pass.active.as_ref() {
+            Some(s) if s.target_layer == layer_id => s,
+            _ => return,
+        };
+        let cache = match self.layer_cache.get(&layer_id) {
+            Some(c) => c,
+            None => return,
+        };
+        let uniforms = BlendUniforms {
+            opacity: cache.opacity,
+            blend_mode: cache.blend_mode,
+            isolated: cache.isolated as u32,
+            _pad1: 0.0,
+            layer_offset: [0.0, 0.0],
+            layer_size: [self.canvas_width as f32, self.canvas_height as f32],
+            canvas_size: [self.canvas_width as f32, self.canvas_height as f32],
+            _pad2: [0.0, 0.0],
+        };
+        queue.write_buffer(
+            &state.preview_blend_uniform_buf,
+            0,
+            bytemuck::bytes_of(&uniforms),
+        );
+    }
+}

--- a/crates/darkly/src/gpu/flood_fill.rs
+++ b/crates/darkly/src/gpu/flood_fill.rs
@@ -33,6 +33,15 @@ use crate::gpu::readback::{self, ReadbackRequest};
 /// Returns an R8 mask (width × height bytes): 255 where the fill should apply, 0 elsewhere.
 /// The algorithm is the same scanline approach used by the tile-based fill, but
 /// operates on contiguous pixel data from a GPU readback.
+///
+/// Algorithm notes (per CLAUDE.md "Performance Principle"): the implementation
+/// is Smith/Heckbert scanline fill — `VecDeque<(y, start, end)>` holds whole
+/// horizontal segments, not per-pixel work. Queue depth is bounded by the
+/// number of distinct segments in the fill region (O(perimeter)), not the
+/// pixel count. The `mask` is a flat `Vec<u8>` indexed directly; no HashMap.
+/// The prior "burned by" lesson was per-pixel HashMap dispatch inside a
+/// tile-based fill — this implementation specifically does not have that
+/// shape, so the scanline+VecDeque pair is the right primitive here.
 pub fn flood_fill_rgba(
     pixels: &[u8],
     width: u32,

--- a/crates/darkly/src/gpu/mod.rs
+++ b/crates/darkly/src/gpu/mod.rs
@@ -39,6 +39,7 @@ pub mod readback;
 pub mod region_store;
 pub mod selection;
 pub mod straight_composite;
+#[cfg(any(test, feature = "testing"))]
 pub mod test_utils;
 pub mod transform;
 pub mod veil;

--- a/crates/darkly/src/gpu/mod.rs
+++ b/crates/darkly/src/gpu/mod.rs
@@ -31,6 +31,7 @@ pub mod content_bounds;
 pub mod context;
 pub mod diff_rect;
 pub mod effect;
+pub mod floating_preview;
 pub mod flood_fill;
 pub mod overlay;
 pub mod paint_target;

--- a/crates/darkly/src/gpu/readback.rs
+++ b/crates/darkly/src/gpu/readback.rs
@@ -146,6 +146,9 @@ impl ReadbackRequest {
     /// On WebGPU/WASM this deadlocks: `recv()` spin-waits (Rust's thread
     /// parker is a no-op on wasm32), blocking the JS event loop, so the
     /// `map_async` Promise can never resolve. See docs/lessons-learned/gpu-lessons-learned.md §5.
+    /// Gated behind the `testing` cargo feature (or `cfg(test)`) so production
+    /// and WASM builds cannot link against it.
+    #[cfg(any(test, feature = "testing"))]
     pub fn blocking_read(&self, device: &wgpu::Device) -> Vec<u8> {
         let slice = self.buffer.slice(..);
 

--- a/crates/darkly/src/gpu/region_store.rs
+++ b/crates/darkly/src/gpu/region_store.rs
@@ -168,22 +168,7 @@ impl RegionScratch {
         }
         let new_w = w.max(self.scratch_width);
         let new_h = h.max(self.scratch_height);
-        self.scratch_rgba = Self::create_scratch(
-            device,
-            new_w,
-            new_h,
-            wgpu::TextureFormat::Rgba8Unorm,
-            "scratch-rgba",
-        );
-        self.scratch_r8 = Self::create_scratch(
-            device,
-            new_w,
-            new_h,
-            wgpu::TextureFormat::R8Unorm,
-            "scratch-r8",
-        );
-        self.scratch_width = new_w;
-        self.scratch_height = new_h;
+        self.realloc_scratch_pair(device, new_w, new_h, None);
     }
 
     /// Reallocate the scratch textures to `(new_w, new_h)` and copy the
@@ -211,76 +196,85 @@ impl RegionScratch {
         {
             return;
         }
+        let target_w = new_w.max(self.scratch_width);
+        let target_h = new_h.max(self.scratch_height);
+        self.realloc_scratch_pair(
+            device,
+            target_w,
+            target_h,
+            Some((encoder, dst_offset_x, dst_offset_y)),
+        );
+    }
+
+    /// Reallocate both scratch textures (RGBA8 + R8) to `(new_w, new_h)`.
+    /// When `copy` is `Some((encoder, dst_x, dst_y))`, the existing
+    /// scratch contents are copied into the new textures at the given
+    /// offset before the old textures are dropped. `(scratch_width,
+    /// scratch_height)` is updated to `(new_w, new_h)` regardless of copy.
+    fn realloc_scratch_pair(
+        &mut self,
+        device: &wgpu::Device,
+        new_w: u32,
+        new_h: u32,
+        copy: Option<(&mut wgpu::CommandEncoder, u32, u32)>,
+    ) {
+        let pairs = [
+            (
+                &mut self.scratch_rgba,
+                wgpu::TextureFormat::Rgba8Unorm,
+                "scratch-rgba",
+            ),
+            (
+                &mut self.scratch_r8,
+                wgpu::TextureFormat::R8Unorm,
+                "scratch-r8",
+            ),
+        ];
         let copy_w = self.scratch_width;
         let copy_h = self.scratch_height;
-        let new_rgba = Self::create_scratch(
-            device,
-            new_w.max(self.scratch_width),
-            new_h.max(self.scratch_height),
-            wgpu::TextureFormat::Rgba8Unorm,
-            "scratch-rgba",
-        );
-        let new_r8 = Self::create_scratch(
-            device,
-            new_w.max(self.scratch_width),
-            new_h.max(self.scratch_height),
-            wgpu::TextureFormat::R8Unorm,
-            "scratch-r8",
-        );
-
-        if copy_w > 0 && copy_h > 0 {
-            encoder.copy_texture_to_texture(
-                wgpu::TexelCopyTextureInfo {
-                    texture: &self.scratch_rgba,
-                    mip_level: 0,
-                    origin: wgpu::Origin3d::ZERO,
-                    aspect: wgpu::TextureAspect::All,
-                },
-                wgpu::TexelCopyTextureInfo {
-                    texture: &new_rgba,
-                    mip_level: 0,
-                    origin: wgpu::Origin3d {
-                        x: dst_offset_x,
-                        y: dst_offset_y,
-                        z: 0,
+        let (encoder_opt, dst_offset_x, dst_offset_y) = match copy {
+            Some((enc, x, y)) => (Some(enc), x, y),
+            None => (None, 0, 0),
+        };
+        let do_copy = encoder_opt.is_some() && copy_w > 0 && copy_h > 0;
+        // The encoder borrow has to be threaded through the loop body; an
+        // `Option<&mut _>` doesn't `Copy`, so reborrow via `as_deref_mut`
+        // each iteration.
+        let mut encoder_opt = encoder_opt;
+        for (field, format, label) in pairs {
+            let new_tex = Self::create_scratch(device, new_w, new_h, format, label);
+            if do_copy {
+                let encoder = encoder_opt
+                    .as_deref_mut()
+                    .expect("do_copy implies encoder present");
+                encoder.copy_texture_to_texture(
+                    wgpu::TexelCopyTextureInfo {
+                        texture: field,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d::ZERO,
+                        aspect: wgpu::TextureAspect::All,
                     },
-                    aspect: wgpu::TextureAspect::All,
-                },
-                wgpu::Extent3d {
-                    width: copy_w,
-                    height: copy_h,
-                    depth_or_array_layers: 1,
-                },
-            );
-            encoder.copy_texture_to_texture(
-                wgpu::TexelCopyTextureInfo {
-                    texture: &self.scratch_r8,
-                    mip_level: 0,
-                    origin: wgpu::Origin3d::ZERO,
-                    aspect: wgpu::TextureAspect::All,
-                },
-                wgpu::TexelCopyTextureInfo {
-                    texture: &new_r8,
-                    mip_level: 0,
-                    origin: wgpu::Origin3d {
-                        x: dst_offset_x,
-                        y: dst_offset_y,
-                        z: 0,
+                    wgpu::TexelCopyTextureInfo {
+                        texture: &new_tex,
+                        mip_level: 0,
+                        origin: wgpu::Origin3d {
+                            x: dst_offset_x,
+                            y: dst_offset_y,
+                            z: 0,
+                        },
+                        aspect: wgpu::TextureAspect::All,
                     },
-                    aspect: wgpu::TextureAspect::All,
-                },
-                wgpu::Extent3d {
-                    width: copy_w,
-                    height: copy_h,
-                    depth_or_array_layers: 1,
-                },
-            );
+                    wgpu::Extent3d {
+                        width: copy_w,
+                        height: copy_h,
+                        depth_or_array_layers: 1,
+                    },
+                );
+            }
+            *field = new_tex;
         }
-
-        self.scratch_rgba = new_rgba;
-        self.scratch_r8 = new_r8;
-        self.scratch_width = new_w.max(self.scratch_width);
-        self.scratch_height = new_h.max(self.scratch_height);
+        self.scratch_width = new_w;
+        self.scratch_height = new_h;
     }
 
     /// Copy a canvas-space rect from a layer/mask texture into the scratch

--- a/crates/darkly/src/gpu/selection.rs
+++ b/crates/darkly/src/gpu/selection.rs
@@ -21,6 +21,20 @@ pub struct SelectionPipelines {
     combine_bgl: wgpu::BindGroupLayout,
     mode_buf: wgpu::Buffer,
     sampler: wgpu::Sampler,
+    /// Recyclable R8 texture used as `combine`'s `shape_tex` binding.
+    /// Sized to exactly the selection's `(width, height)` because the
+    /// combine shader samples with UV in `[0, 1]` over the full texture
+    /// extent — a larger scratch would shift the UV mapping and miss the
+    /// uploaded shape data. Re-allocated only when the selection's
+    /// dimensions change (canvas resize, document load).
+    shape_scratch: Option<ShapeScratch>,
+}
+
+struct ShapeScratch {
+    texture: wgpu::Texture,
+    view: wgpu::TextureView,
+    width: u32,
+    height: u32,
 }
 
 #[repr(C)]
@@ -137,13 +151,49 @@ impl SelectionPipelines {
             combine_bgl,
             mode_buf,
             sampler,
+            shape_scratch: None,
         }
+    }
+
+    /// Ensure `shape_scratch` is exactly `(w, h)` and return its view. The
+    /// combine shader's UV must map `(0, 1)` to the uploaded data, so the
+    /// scratch dimensions cannot be larger than the selection — when the
+    /// selection's dims change we reallocate.
+    fn ensure_shape_scratch(&mut self, device: &wgpu::Device, w: u32, h: u32) -> &ShapeScratch {
+        let needs_alloc = match &self.shape_scratch {
+            Some(s) => s.width != w || s.height != h,
+            None => true,
+        };
+        if needs_alloc {
+            let texture = device.create_texture(&wgpu::TextureDescriptor {
+                label: Some("sel-shape-scratch"),
+                size: wgpu::Extent3d {
+                    width: w,
+                    height: h,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::R8Unorm,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+                view_formats: &[],
+            });
+            let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+            self.shape_scratch = Some(ShapeScratch {
+                texture,
+                view,
+                width: w,
+                height: h,
+            });
+        }
+        self.shape_scratch.as_ref().unwrap()
     }
 
     /// Run the combine shader: reads `state.textures[current]` + shape → writes
     /// to `state.textures[1 - current]`, then swaps and rebuilds bind groups.
     pub fn combine(
-        &self,
+        &mut self,
         encoder: &mut wgpu::CommandEncoder,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
@@ -156,24 +206,11 @@ impl SelectionPipelines {
         let w = state.width;
         let h = state.height;
 
-        // Upload shape to a temp texture.
-        let shape_tex = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("sel-shape-temp"),
-            size: wgpu::Extent3d {
-                width: w,
-                height: h,
-                depth_or_array_layers: 1,
-            },
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::R8Unorm,
-            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
-            view_formats: &[],
-        });
+        self.ensure_shape_scratch(device, w, h);
+        let scratch = self.shape_scratch.as_ref().expect("just ensured");
         queue.write_texture(
             wgpu::TexelCopyTextureInfo {
-                texture: &shape_tex,
+                texture: &scratch.texture,
                 mip_level: 0,
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,
@@ -190,7 +227,7 @@ impl SelectionPipelines {
                 depth_or_array_layers: 1,
             },
         );
-        let shape_view = shape_tex.create_view(&wgpu::TextureViewDescriptor::default());
+        let shape_view = &scratch.view;
 
         queue.write_buffer(
             &self.mode_buf,
@@ -211,7 +248,7 @@ impl SelectionPipelines {
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
-                    resource: wgpu::BindingResource::TextureView(&shape_view),
+                    resource: wgpu::BindingResource::TextureView(shape_view),
                 },
                 wgpu::BindGroupEntry {
                     binding: 2,

--- a/crates/darkly/src/gpu/straight_composite.rs
+++ b/crates/darkly/src/gpu/straight_composite.rs
@@ -2,19 +2,18 @@
 //!
 //! Hardware alpha blending (`SrcAlpha`/`OneMinusSrcAlpha`) produces premultiplied
 //! output, which corrupts straight-alpha layer textures. Any render pass that
-//! composites onto a straight-alpha target must:
-//!
-//! 1. Copy the destination region to a temp texture
-//! 2. Have the shader read both source and dest, compute Porter-Duff manually
-//!    using the `source_over()` function from `shaders/source_over.wgsl`
-//! 3. Output with REPLACE blend (`blend: None`)
+//! composites onto a straight-alpha target must copy the destination region
+//! into a temp texture, sample both source and dest in the shader to compute
+//! Porter-Duff manually via the `source_over()` helper from
+//! `shaders/source_over.wgsl`, and emit with REPLACE blend (`blend: None`).
 //!
 //! The WGSL `source_over()` function is included via `concat!` at shader load:
 //! ```ignore
 //! concat!(include_str!("source_over.wgsl"), "\n", include_str!("my_shader.wgsl"))
 //! ```
 //!
-//! This module provides the Rust-side utilities for step 1.
+//! Provides the bind-group-layout and destination-copy helpers used by any
+//! pass that composites onto a straight-alpha target.
 //! See `docs/lessons-learned/compositing-lessons-learned.md` #4 for the full rationale.
 
 /// Create a bind group layout with a single `texture_2d<f32>` at binding 0.

--- a/crates/darkly/src/gpu/view.rs
+++ b/crates/darkly/src/gpu/view.rs
@@ -2,9 +2,8 @@
 //! Compositing happens in canvas-pixel space. This transform is applied
 //! only in the present shader to map canvas pixels to screen pixels.
 
-/// Fallback workspace color (matches the legacy hardcoded value previously
-/// baked into `present.wgsl`). The frontend pushes the theme-sourced color
-/// via `set_viewport_bg()` once the UI loads.
+/// Fallback workspace color used until the frontend pushes the theme-sourced
+/// color via `set_viewport_bg()`.
 pub const DEFAULT_WORKSPACE_BG: [f32; 4] = [0.11, 0.11, 0.11, 1.0];
 #[repr(C)]
 #[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]

--- a/crates/darkly/src/gpu/void.rs
+++ b/crates/darkly/src/gpu/void.rs
@@ -1,4 +1,4 @@
-//! Void layer effects — the procedural counterpart to [`Veil`].
+//! Void layer effects — procedural per-layer content.
 //!
 //! A void is a GPU effect that *generates* a layer's pixel content from a
 //! shader (noise, screenshare, future portals), rather than storing static
@@ -6,19 +6,15 @@
 //! [`crate::layer::Layer::Void`] variant, participating in normal blending,
 //! masking, and undo.
 //!
-//! The trait shape mirrors [`super::veil::Veil`] but the output contract is
-//! different: a void [`Void::encode`] takes no ping-pong source view, because
-//! a void has no upstream input — it writes the layer's color content into
-//! `dst_view` from scratch. The compositor then composites the void's texture
-//! through the normal raster blend pipeline, so opacity / blend mode / mask
-//! work uniformly with raster layers.
+//! A void [`Void::encode`] writes the layer's color content into `dst_view`
+//! from scratch — there is no upstream input texture. The compositor then
+//! composites the void's texture through the normal raster blend pipeline,
+//! so opacity / blend mode / mask work uniformly with raster layers.
 //!
 //! Adding a new void type is one new file under [`super::voids`]: the
 //! module's `register()` returns a [`VoidRegistration`] with everything the
 //! engine needs — display name, parameter schema, pipeline constructor, and
 //! a factory that builds the trait object from a parameter slice.
-//!
-//! [`Veil`]: super::veil::Veil
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -56,6 +52,37 @@ impl ExternalImageSource {
     }
 }
 
+/// Sticky "needs re-encode" flag every void embeds.
+///
+/// Implementations call [`Self::mark`] from inside the state-changing methods
+/// (`update_params`, `update_time`, `upload_external_image`, …). The
+/// compositor's render pass clears it via [`Self::take`] right before
+/// invoking [`Void::encode`], so a void re-renders exactly once per state
+/// change. Defaulting `true` at construction time means the first
+/// compositor pass after `ensure_void_layer` always produces a fresh
+/// texture, even if no param edits have happened yet.
+#[derive(Debug)]
+pub struct DirtyFlag(bool);
+
+impl DirtyFlag {
+    pub fn new_dirty() -> Self {
+        DirtyFlag(true)
+    }
+    pub fn mark(&mut self) {
+        self.0 = true;
+    }
+    /// Return whether the flag was set and clear it.
+    pub fn take(&mut self) -> bool {
+        std::mem::replace(&mut self.0, false)
+    }
+}
+
+impl Default for DirtyFlag {
+    fn default() -> Self {
+        Self::new_dirty()
+    }
+}
+
 /// Layer-level procedural-content effect ("void"). Renders the layer's
 /// pixels from a shader instead of storing them.
 ///
@@ -72,6 +99,18 @@ pub trait Void: std::fmt::Debug {
     /// Return the current parameter values, in the same order as the
     /// type's [`ParamDef`] array in [`VoidRegistration`].
     fn param_values(&self) -> Vec<ParamValue>;
+
+    /// Return whether the void needs re-encoding into its destination
+    /// texture and clear the flag. The compositor calls this once per
+    /// frame; voids embed a [`DirtyFlag`] and forward to it. Implementations
+    /// must initialise the flag dirty so the first compositor pass after
+    /// `ensure_void_layer` produces a fresh texture.
+    fn take_dirty(&mut self) -> bool;
+
+    /// Re-mark this void as needing a fresh encode. Voids call this from
+    /// their own state-mutating methods (`update_params`, `update_time`,
+    /// `upload_external_image`); rarely needed externally.
+    fn mark_dirty(&mut self);
 
     /// Allocate per-instance GPU resources. The compositor passes the
     /// destination view (the void's own texture) so the void can build
@@ -181,10 +220,11 @@ pub struct VoidRegistration {
     pub from_params: fn(&[ParamValue], Arc<EffectPipeline>) -> Box<dyn Void>,
 }
 
-/// Auto-discovered void registry with lazy pipeline caching. Modeled on
-/// [`super::veil::VeilRegistry`]; the two could in principle share a
-/// generic registry, but keeping them separate avoids stamping out an
-/// extra layer of generics for the modest amount of code involved.
+/// Auto-discovered void registry with lazy pipeline caching. Each void
+/// kind contributes one [`VoidRegistration`] via its module's `register()`;
+/// `build.rs` collects them into [`super::voids::registrations`] and the
+/// registry pulls them in at startup. Pipelines build on first use and are
+/// shared via [`Arc`] across instances of the same kind.
 pub struct VoidRegistry {
     entries: HashMap<&'static str, RegistryEntry>,
 }
@@ -285,5 +325,31 @@ impl VoidRegistry {
             .get_or_insert_with(|| Arc::new((entry.create_pipeline)(device, format)))
             .clone();
         (entry.from_params)(params, pipeline)
+    }
+}
+
+#[cfg(test)]
+mod dirty_flag_tests {
+    use super::DirtyFlag;
+
+    #[test]
+    fn starts_dirty_so_first_encode_fires() {
+        let mut flag = DirtyFlag::new_dirty();
+        assert!(flag.take(), "fresh flag must report dirty on first take");
+    }
+
+    #[test]
+    fn take_clears() {
+        let mut flag = DirtyFlag::new_dirty();
+        assert!(flag.take());
+        assert!(!flag.take(), "take must clear the flag");
+    }
+
+    #[test]
+    fn mark_re_arms() {
+        let mut flag = DirtyFlag::new_dirty();
+        flag.take();
+        flag.mark();
+        assert!(flag.take(), "mark after clear must re-arm");
     }
 }

--- a/crates/darkly/src/gpu/voids/camera.rs
+++ b/crates/darkly/src/gpu/voids/camera.rs
@@ -18,7 +18,9 @@
 //! frame is supplied — which only the browser bridge can do.
 
 use crate::gpu::effect::{EffectCache, EffectPipeline};
-use crate::gpu::void::{ExternalImageSource, ParamDef, ParamValue, Void, VoidRegistration};
+use crate::gpu::void::{
+    DirtyFlag, ExternalImageSource, ParamDef, ParamValue, Void, VoidRegistration,
+};
 use std::cell::Cell;
 use std::sync::Arc;
 
@@ -124,7 +126,7 @@ struct CameraUniforms {
     _pad1: f32,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Camera {
     scale: f32,
     rotation_deg: f32,
@@ -149,6 +151,31 @@ pub struct Camera {
     canvas_w: Cell<u32>,
     canvas_h: Cell<u32>,
     shared: Arc<EffectPipeline>,
+    dirty: DirtyFlag,
+}
+
+impl Clone for Camera {
+    fn clone(&self) -> Self {
+        // `clone_boxed` is called for undo / clone_subtree. The clone gets a
+        // fresh `EffectCache` from `ensure_void_layer` with the 1×1
+        // placeholder aux texture, so start dirty.
+        Camera {
+            scale: self.scale,
+            rotation_deg: self.rotation_deg,
+            pan_x: self.pan_x,
+            pan_y: self.pan_y,
+            mirror_h: self.mirror_h,
+            mirror_v: self.mirror_v,
+            freeze: self.freeze,
+            frame_divisor: self.frame_divisor,
+            webcam_w: self.webcam_w,
+            webcam_h: self.webcam_h,
+            canvas_w: Cell::new(self.canvas_w.get()),
+            canvas_h: Cell::new(self.canvas_h.get()),
+            shared: self.shared.clone(),
+            dirty: DirtyFlag::new_dirty(),
+        }
+    }
 }
 
 impl Camera {
@@ -199,6 +226,7 @@ impl Camera {
             canvas_w: Cell::new(1),
             canvas_h: Cell::new(1),
             shared,
+            dirty: DirtyFlag::new_dirty(),
         }
     }
 
@@ -339,6 +367,14 @@ impl Void for Camera {
         ]
     }
 
+    fn take_dirty(&mut self) -> bool {
+        self.dirty.take()
+    }
+
+    fn mark_dirty(&mut self) {
+        self.dirty.mark();
+    }
+
     fn needs_animation(&self) -> bool {
         // The camera doesn't accumulate time on its own, but the compositor
         // uses `needs_animation()` as the "keep the rAF loop alive" signal.
@@ -393,6 +429,7 @@ impl Void for Camera {
         if let Some(buf) = cache.uniform_bufs.first() {
             queue.write_buffer(buf, 0, bytemuck::bytes_of(&self.uniforms()));
         }
+        self.dirty.mark();
     }
 
     fn wants_external_input(&self) -> bool {
@@ -455,6 +492,7 @@ impl Void for Camera {
             0,
             bytemuck::bytes_of(&self.uniforms()),
         );
+        self.dirty.mark();
     }
 
     fn upload_external_image(
@@ -509,6 +547,7 @@ impl Void for Camera {
                     depth_or_array_layers: 1,
                 },
             );
+            self.dirty.mark();
         }
 
         #[cfg(not(target_arch = "wasm32"))]

--- a/crates/darkly/src/gpu/voids/noise.rs
+++ b/crates/darkly/src/gpu/voids/noise.rs
@@ -12,7 +12,7 @@
 use crate::gpu::effect::{
     create_blit_bind_group, create_blit_pipeline, EffectCache, EffectPipeline,
 };
-use crate::gpu::void::{ParamDef, ParamValue, Void, VoidRegistration};
+use crate::gpu::void::{DirtyFlag, ParamDef, ParamValue, Void, VoidRegistration};
 use std::sync::Arc;
 
 /// Procedural-render downscale factor. The FBM shader runs into an aux
@@ -128,7 +128,7 @@ struct NoiseUniforms {
 /// time is not clobbered when a slider moves.
 const USER_PARAMS_BYTES: usize = 24;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Noise {
     pub seed: i32,
     pub octaves: i32,
@@ -142,6 +142,25 @@ pub struct Noise {
     /// without changing the seed.
     pub time: f32,
     shared: Arc<EffectPipeline>,
+    dirty: DirtyFlag,
+}
+
+impl Clone for Noise {
+    fn clone(&self) -> Self {
+        // Clones come up via `clone_boxed` (used by undo / clone_subtree).
+        // The clone owns a fresh `EffectCache` from `ensure_void_layer`, so
+        // start dirty to force a first encode.
+        Noise {
+            seed: self.seed,
+            octaves: self.octaves,
+            size: self.size,
+            warp: self.warp,
+            darkness: self.darkness,
+            time: self.time,
+            shared: self.shared.clone(),
+            dirty: DirtyFlag::new_dirty(),
+        }
+    }
 }
 
 impl Noise {
@@ -178,6 +197,7 @@ impl Noise {
             darkness,
             time,
             shared,
+            dirty: DirtyFlag::new_dirty(),
         }
     }
 
@@ -215,6 +235,14 @@ impl Void for Noise {
         ]
     }
 
+    fn take_dirty(&mut self) -> bool {
+        self.dirty.take()
+    }
+
+    fn mark_dirty(&mut self) {
+        self.dirty.mark();
+    }
+
     fn update_params(&mut self, queue: &wgpu::Queue, cache: &EffectCache, params: &[ParamValue]) {
         self.seed = match params.first() {
             Some(ParamValue::Int(v)) => *v,
@@ -246,6 +274,7 @@ impl Void for Noise {
             let bytes = &bytemuck::bytes_of(&scratch)[..USER_PARAMS_BYTES];
             queue.write_buffer(buf, 0, bytes);
         }
+        self.dirty.mark();
     }
 
     fn create_cache(

--- a/crates/darkly/src/layer.rs
+++ b/crates/darkly/src/layer.rs
@@ -310,6 +310,19 @@ impl LayerNode {
     pub fn type_id(&self) -> &'static str {
         self.kind().type_id
     }
+
+    /// Composite this node into its parent group's accumulators. The
+    /// variant dispatch is owned by `LayerNode` so the compositor's child
+    /// walk never re-introduces a centralised match on node kind. Each arm
+    /// delegates back through `ctx` into a compositor-private method that
+    /// owns the GPU work — variant *knows itself*, compositor *does the
+    /// work*.
+    pub fn compose_into(&self, ctx: &mut crate::gpu::compositor::CompositionContext<'_>) {
+        match self {
+            LayerNode::Layer(layer) => ctx.compose_layer(layer),
+            LayerNode::Group(group) => ctx.compose_group(group),
+        }
+    }
 }
 
 pub enum Layer {

--- a/crates/darkly/tests/void_layer.rs
+++ b/crates/darkly/tests/void_layer.rs
@@ -297,6 +297,70 @@ fn noise_void_time_scrub_is_continuous() {
     );
 }
 
+/// Regression: the void owns its own "needs re-render" bit. Mutating one
+/// void's params must not cause an unrelated void to re-encode — the
+/// compositor must not flip dirty for every procedural layer on every
+/// param edit. Verified by reading back two voids' textures, mutating
+/// just one, and confirming the *un-mutated* one's pixels are byte-equal.
+#[test]
+fn void_dirty_is_per_instance() {
+    let mut engine = test_engine(64, 64);
+    let mut params_a = noise_defaults(&engine);
+    let mut params_b = noise_defaults(&engine);
+    // Different seeds so the two voids' textures are visibly distinct —
+    // helps catch any accidental aliasing in addition to the dirty-bit
+    // check.
+    set_int_param(&mut params_a, "seed", 100);
+    set_int_param(&mut params_b, "seed", 200);
+
+    let id_a = engine
+        .add_void_layer("noise", params_a.clone(), None)
+        .expect("noise void should be addable");
+    let id_b = engine
+        .add_void_layer("noise", params_b, None)
+        .expect("second noise void should be addable");
+
+    // Force a render so both voids have produced their first frame and
+    // cleared their dirty flags.
+    let _ = engine.test_readback_canvas();
+    let before_a = engine.test_readback_layer(id_a);
+    let before_b = engine.test_readback_layer(id_b);
+    assert_ne!(
+        before_a, before_b,
+        "two different seeds must produce different textures",
+    );
+
+    // Mutate only A. B must not re-encode — its dirty bit was cleared
+    // above and nothing has touched it since.
+    set_float_param(&mut params_a, "time", 5.0);
+    engine.update_void_params(id_a, params_a);
+    let _ = engine.test_readback_canvas();
+    let after_a = engine.test_readback_layer(id_a);
+    let after_b = engine.test_readback_layer(id_b);
+
+    assert_ne!(
+        before_a, after_a,
+        "mutated void should re-encode and change pixels",
+    );
+    assert_eq!(
+        before_b, after_b,
+        "untouched void must not re-encode — its dirty bit is its own state",
+    );
+}
+
+fn set_int_param(params: &mut [ParamValue], name: &str, value: i32) {
+    let engine = test_engine(1, 1);
+    let defs = engine.void_param_defs("noise");
+    let idx = defs
+        .iter()
+        .position(|d| match d {
+            darkly::gpu::params::ParamDef::Int { name: n, .. } => *n == name,
+            _ => false,
+        })
+        .unwrap_or_else(|| panic!("noise void has no int param '{name}'"));
+    params[idx] = ParamValue::Int(value);
+}
+
 /// Look up a noise-void param slot by name. The schema currently exposes
 /// `seed, octaves, size, warp, darkness, time`, but tests index by name
 /// rather than position so new params don't silently shift them.


### PR DESCRIPTION
## Summary

Three-slice cleanup of `crates/darkly/src/gpu/` driven by a fresh `CODECLEANUP gpu` audit. Each slice has a handoff doc, a plan doc, and one commit. Order of execution matches the recommended dependency chain: readback safety & perf first (lowest risk, highest safety win), then compositor decomposition (clears the field), then dispatch & authority (largest architectural shift, benefits from a leaner file).

No behavior changes. All existing tests pass. One user-visible workflow change: `cargo test` and the two bench binaries now require `--features darkly/testing`; CLAUDE.md "Lint / CI Checks" is updated to reflect this.

## Slice 1 — Readback safety & per-frame perf (`gpu subsystem cleanup #1`)

**Why:** `gpu::test_utils`, `readback::blocking_read`, and the engine's `test_readback_*` methods deadlock on WebGPU/WASM (CLAUDE.md "No Blocking GPU Readbacks"). They were plain `pub`, gated only by convention. Also addresses per-frame allocation churn in the composite walk and selection/region scratch paths.

- **Add `testing` cargo feature; gate all blocking-readback APIs behind `#[cfg(any(test, feature = "testing"))]`** (`Cargo.toml`, `gpu/mod.rs`, `gpu/readback.rs`, `gpu/compositor.rs::test_present_to_canvas`, `engine/mod.rs::test_readback_*`). Production / WASM builds can no longer reach these APIs at compile time. The two bench binaries (`stroke_replay_bench`, `stroke_replay_matrix`) declare `required-features = ["testing"]`.
- **Update AGENTS.md "Lint / CI Checks"** — `cargo clippy` and `cargo test` lines now include `--features darkly/testing`. The breaking change is intentional per "No Migrations / No Backwards Compatibility".
- **Blend-bind-group cache** on `Compositor` (`HashMap<(parent_group, child, src_accum_idx), BindGroup>`). Eliminates per-layer-per-frame bind-group allocation in `compose_children`. Invalidated in `dispose_node_texture`, `resize_node_texture`, and bake-subtree teardown — the same dispose contract that already invalidates `mask_bind_groups`. Bypassed when the child is the floating-transform target (the per-frame view swap there would poison the cache).
- **`SmallVec<[LayerId; 8]>` for compose-walk child lists** at the four `children_of(...)` sites in `compose_children` / `compose_group` / `compose_passthrough_masked`. Common shallow-tree case stays stack-allocated; deep documents fall back to a heap `Vec` automatically.
- **`dirty_procedural_scratch: Vec<LayerId>` on `Compositor`** — reused across frames in `encode_dirty_layer_content` (which filters all of `layer_cache`, too large for SmallVec). Cleared on entry; drained on exit so no LayerId pointers survive a `dispose`.
- **`SelectionPipelines::shape_scratch`** — recyclable canvas-sized R8 texture inside `SelectionPipelines`, replacing the per-`combine`-call texture allocation. Lazy-created and regrown on canvas resize. `invert` stays as-is (no shape texture needed).
- **`RegionStore::realloc_scratch_pair` helper** — collapses the duplicated RGBA+R8 reallocation in `ensure_scratch_capacity` and `grow_scratch_preserving` behind one function that handles the optional preserving copy.
- **Flood-fill annotation** — one comment block above `flood_fill_rgba` documenting that scanline + `VecDeque<(y, start, end)>` is intentional (queue depth O(perimeter), not O(pixels)) and references the CLAUDE.md "Performance Principle" tile-HashMap lesson it explicitly avoids.

## Slice 2 — Compositor decomposition & dead-code sweep (`gpu subsystem cleanup #2`)

**Why:** `gpu/compositor.rs` was 3194 LOC holding ~10 distinct responsibilities. Several pure pass-through wrappers existed only to hop through `Compositor` to a self-contained subsystem (`ToolOverlay`). Three methods had zero callers. One method had a tautological `or_else` self-lookup left over from a merged refactor.

- **Extract floating-preview methods to `gpu/floating_preview.rs`** (+421 lines, removed from `compositor.rs`). Implemented as `impl Compositor` blocks in the new file so call sites are unchanged. `BlendUniforms` and the related per-uniform-write helper move with it. `TransformPass` stays on `Compositor` to avoid splitting state CLAUDE.md "Ownership Principle" says belongs together.
- **Inline 10 `ToolOverlay` pass-through wrappers** (`set_overlay_primitives`, `clear_overlay`, `set_overlay_mask`, `clear_overlay_mask`, `ensure_overlay_preview_mask`, `use_overlay_preview_mask`, `clear_overlay_preview_mask`, `overlay_preview_mask_texture`, `tool_overlay_ref`, `overlay_hit_test`). Callers under `engine/brush_graph.rs`, `engine/modifiers/selection.rs`, `engine/mod.rs` now talk to `ToolOverlay` directly via `compositor.tool_overlay_mut()` and set `needs_present` through the existing `mark_needs_present()` helper. Type-owned-dispatch win: the overlay now owns its own surface.
- **Delete `Compositor::render_to_view`** — zero callers, speculative "for any frontend" doc.
- **Delete `Compositor::update_overlay_time`** — zero callers; the frame scheduler already advances overlay time inline.
- **Delete `Compositor::update_layer_uniforms` (the wrapper that forwarded to `_full`)** and rename `update_layer_uniforms_full` → `update_layer_uniforms`. Three engine call sites updated in the same pass.
- **Collapse the tautological `or_else` self-lookup** in `request_content_bounds` — `node_textures.get(&node_id).or_else(|| node_textures.get(&node_id))` was a fossil from a merged dual-pool refactor.
- **Slop-comment cleanup** — `gpu/view.rs` drops the "legacy hardcoded value previously baked into present.wgsl" narrative; `gpu/straight_composite.rs` drops the "Rust-side utilities for step 1" project-management framing.

Decisions explicitly made and *not* implemented (documented in the plan): `OverlayProxy` sub-struct rejected (pure decoration over inlining), `FrameScheduler` extraction rejected (60 cohesive LOC; pulling it apart would scatter state), `GpuContext::new_with_shared_device` kept (verified live via the multi-tab shell at `frontend/src/multi_tab/` + `tests/multi_engine.rs`).

## Slice 3 — Dispatch & effect-state ownership (`gpu subsystem cleanup #3`)

**Why:** `Compositor::ensure_layer` and `Compositor::compose_children` both did consumer-side `match` on `Layer` / `LayerNode` variants — CLAUDE.md "Type-owned dispatch" violation. `ProceduralContent.dirty` was a compositor-side mirror of state the `Void` trait should own. `ensure_void_layer` took `(void_type: &str, params: &[ParamValue])` and constructed the void internally; `update_void_layer_params` carried unused `_device` / `_void_type` parameters left over from an abandoned path.

- **`Void::take_dirty(&mut self)` + `Void::mark_dirty(&mut self)` on the trait**, backed by a shared `DirtyFlag` helper (sticky bit, defaults dirty so first-encode fires). Each void embeds a `DirtyFlag` and overrides the trait methods; state-mutating methods (`update_params`, `update_time`, `upload_external_image`) mark it themselves. The compositor's `ProceduralContent.dirty` field and the manual `dirty = true` writes at four sites are gone. New test in `tests/void_layer.rs` confirms a void controls its own dirty bit.
- **`LayerKindGpu` trait + `Layer::realize_in` / `RasterLayer::realize_in` / `VoidLayer::realize_in`** replaces the `match` arms in `Compositor::ensure_layer`. Adding a third content kind is now purely additive — no consumer edit.
- **`CompositionContext<'a>` carrier + `LayerNode::compose_into`** replaces the `match` in `Compositor::compose_children`. The arm bodies move to compositor-private `compose_layer` / `compose_group` methods reached through the context; `LayerNode` owns the dispatch.
- **Collapse `Compositor::ensure_void_layer` signature** to `(layer_id, void: Box<dyn Void>)`. The engine (`engine/layers.rs::add_void_layer`) now constructs the void via the registry and hands the trait object in. `update_void_layer_params` loses its unused `_device` / `_void_type` parameters.
- **Drop apologetic parallel-structure comments** in `gpu/void.rs` ("trait shape mirrors `Veil`", `VoidRegistry` "modeled on `VeilRegistry`") and `gpu/compositor.rs` ("voids piggyback on the same master clock as veils … parallel integer divisor"). The per-frame contracts genuinely differ (voids are sourceless, veils consume ping-pong source views); the parallels are deliberate, the apologies were not.

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --exclude darkly-wasm --features darkly/testing -- -D warnings`
- [ ] `RUSTFLAGS="-D warnings" cargo clippy -p darkly-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings`
- [ ] `cargo test --workspace --exclude darkly-wasm --features darkly/testing -- --test-threads=1` — gates every behavior-preserving change. `tests/void_layer.rs` carries the new trait-owned-dirty test
- [ ] `(cd frontend/wasm && wasm-pack build --release --target web --out-dir pkg)` — confirms no blocking-readback API leaked through the WASM bridge
- [ ] `(cd frontend && npx tsc --noEmit && npm run build && npm test)` — no JSON command shapes changed; expected to pass without modification
- [ ] Manual smoke: a stroke on a void layer (procedural content path), a transform on a floating selection (bind-group cache bypass), and a Merge Down across a group (bake-subtree teardown invalidation)

## Audit & plan trail

- `CODECLEANUP.md` — invocation
- `handoff-gpu-cleanup-readback-and-perf.md` + `plan-gpu-cleanup-readback-and-perf.md` — slice 1 brief & plan
- `handoff-gpu-cleanup-compositor-decompose.md` + `plan-gpu-cleanup-compositor-decompose.md` — slice 2 brief & plan
- `handoff-gpu-cleanup-dispatch-and-authority.md` + `plan-gpu-cleanup-dispatch-and-authority.md` — slice 3 brief & plan
