### PR TITLE
Layer frontend features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,10 @@ shared/styles/          @darkly/styles — tokens + themes (UI + website)
 website/                Astro + Starlight site (splash, docs, /demo/)
 ```
 
+### Hotkey & Config Presets
+
+Darkly's settings use a three-layer resolution order: `user → overlay (krita/ps/gimp) → defaults`. Placement rule is documented in [`crates/darkly/presets/defaults.yaml`](crates/darkly/presets/defaults.yaml)'s header; host-editor reference hotkeys live in [`docs/*-default-hotkeys.md`](docs/).
+
 ## Modularity Principle
 
 **Default to modular.** When you design anything with more than one variant — or that will plausibly grow one — the first question is "what's the unit, and how does the rest of the code stay ignorant of which one it's looking at?" That mindset applies at every scale: from a small enum where one method per variant beats a `match` at the call site, up to full subsystems with traits, registries, and per-variant files. The cost of designing modularly up front is almost always small; the cost of retrofitting after centralized branching has spread across the codebase is large. Hand-written dispatch should feel like an exception that needs justifying, not the default shape.
@@ -177,10 +181,6 @@ Darkly is in pre-release / alpha. Until the first public release, breaking on-di
 ## PR Descriptions
 
 When you finish implementing a plan, emit a concise PR description in a fenced markdown code block as part of your reply. The description must cover the *entire* feature branch (everything since it diverged from its parent), not just the latest change — the user pastes it as the full PR body. On follow-up work, re-emit the complete, updated description as a single block that wholly replaces the previous one; never emit a delta or a partial revision.
-
-## Hotkey & Config Presets
-
-Three-layer resolution: `user → overlay[active editor] → defaults`. Placement rule is documented in [`crates/darkly/presets/defaults.yaml`](crates/darkly/presets/defaults.yaml)'s header; host-editor reference hotkeys live in [`docs/*-default-hotkeys.md`](docs/).
 
 ## Lint / CI Checks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,10 @@ Darkly is in pre-release / alpha. Until the first public release, breaking on-di
 
 When you finish implementing a plan, emit a concise PR description in a fenced markdown code block as part of your reply. The description must cover the *entire* feature branch (everything since it diverged from its parent), not just the latest change — the user pastes it as the full PR body. On follow-up work, re-emit the complete, updated description as a single block that wholly replaces the previous one; never emit a delta or a partial revision.
 
+## Hotkey & Config Presets
+
+Three-layer resolution: `user → overlay[active editor] → defaults`. Placement rule is documented in [`crates/darkly/presets/defaults.yaml`](crates/darkly/presets/defaults.yaml)'s header; host-editor reference hotkeys live in [`docs/*-default-hotkeys.md`](docs/).
+
 ## Lint / CI Checks
 
 Run at commit time only — not during iterative debugging. Use `cargo check` for mid-iteration build sanity. All must pass:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 > [!IMPORTANT]
 > **Darkly is in beta**! Features are being [added daily](#feature-roadmap). Please [report bugs](https://github.com/darkly-art/darkly/issues/new) so we can squash them.
 
-[Darkly](https://darkly.art) is a GPU-native editor written in Rust and geared towards digital painters. It aims to have everything you expect from a paint program, plus some special **[dark arts](#unique-darkly-features)** to help you rage against the machine.
+[Darkly](https://darkly.art) is a GPU-native editor written in Rust and geared towards digital painters. It aims to have everything you expect from a paint program, plus some special **[dark arts](#dark-arts)** to help you rage against the machine.
 
 ### Darkly pledges to:
 
@@ -33,7 +33,27 @@ Do you suffer from the **oppressive sanity** of rulers, guides, and nondestructi
 
 We're gearing up for a Kickstarter! Vote in the [discord](https://discord.gg/kFz2FGhbpu) for which features you want most. Help us make Darkly feature-complete, so we can rescue our friends and colleagues from the grip of corporate software!
 
-## Unique Darkly Features
+## Features
+
+### Node-Based Brush Engine
+
+![brush-engine-screenshot](https://github.com/user-attachments/assets/28baa4dc-9cf1-4d9f-b1e3-4ccbe5943171)
+
+Darkly features a unified node-based brush system. Every brush type -- clone, liquify, watercolor, etc. -- all live in a single engine. This enables infinite customizability, mixing and matching of brush features, and on-the-fly creation of custom brushes.
+
+### Familiar Hotkeys
+
+<img src="https://github.com/user-attachments/assets/63544586-f006-4616-b378-97dd54e321d3" width="400"/>
+
+On first launch, Darkly will ask you which editor preset you want.  Currently we support GIMP, Krita, and Photoshop. I come from Krita, so that one's gotten the most TLC. We want them all to feel natural to new users. If you find any gaps, please let us know!
+
+### Hotkey Cheatsheet
+
+<img src="https://github.com/user-attachments/assets/2bb1737b-169b-4ca2-9687-2c54fbc07a6b" width="500"/>
+
+Darkly also comes with a searchable hotkey cheatsheet, which opens in a separate window, handy for printing or putting on a second screen.
+
+## Dark Arts
 
 ### Veils
 
@@ -59,12 +79,6 @@ Voids are a special type of layer that specializes in pulling inspiration from o
 You can use the `Noise` void to inject entropy, or `Screenshare` to stream another app (3D software, movie, or video game) directly into a layer. This is great for hybrid workflows, and situations where you want to try out different lighting or camera angles, without having to pose, render and paste over and over.
 
 Voids can live anywhere in your layer stack -- over or underneath any other layer. They support masks and blend modes. They are the natural compliment to veils, and a natural integration point for other art programs like Blender, which may have dedicated voids in the future 🧡
-
-### Node-Based Brush Engine
-
-![brush-engine-screenshot](https://github.com/user-attachments/assets/28baa4dc-9cf1-4d9f-b1e3-4ccbe5943171)
-
-Darkly features a unified node-based brush system. Every brush type -- clone, liquify, watercolor, etc. -- all live in a single engine. This enables infinite customizability, mixing and matching of brush features, and on-the-fly creation of custom brushes.
 
 ## Feature Roadmap
 

--- a/crates/darkly/presets/defaults.yaml
+++ b/crates/darkly/presets/defaults.yaml
@@ -34,6 +34,29 @@ hotkeys:
   mirrorViewH: KeyM
   # Darkly-original (brush builder).
   addBrushNode: Shift+KeyA
+  # PS + Krita both bind Quick Group to Ctrl+G. GIMP has no default
+  # (the Layer menu's group commands aren't bound). With layers
+  # selected, the action handler wraps them in the new group; with
+  # nothing selected, creates an empty group.
+  newGroup: $mod+KeyG
+  # PS + Krita both bind Merge Down to Ctrl+E. GIMP's only layer-merge
+  # default is Ctrl+M for "Merge Visible Layers" — semantically
+  # different. The `mergeDown` action handler is selection-aware:
+  # with ≥2 selected it bakes the selection via merge_layers, with 1
+  # it does the classic single-layer merge-down. One hotkey, two ops.
+  mergeDown: $mod+KeyE
+  # `flatten` and `addMask` are intentionally left unbound here:
+  #   - addMask: no reference editor has a default key (PS, Krita,
+  #     and GIMP all expose mask creation through a button click).
+  #     Inventing a Darkly-only binding would surprise users with no
+  #     prior-art expectation, and commit a key slot we'd later have
+  #     to fight if we register e.g. GIMP's Ctrl+M "Merge Visible".
+  #   - flatten: Krita binds Ctrl+Shift+E to "Flatten image" (the
+  #     whole-canvas composite, which is Darkly's `flatten_image`
+  #     engine op — not yet a registered action). Borrowing that key
+  #     for Darkly's single-layer flatten (apply-mask / flatten-group)
+  #     would mislead Krita users. If someone registers `flattenImage`
+  #     as an action, that's where Ctrl+Shift+E belongs.
 
 mouse_clicks:
   # Photoshop and Krita both use Alt+click on a layer/mask thumbnail to

--- a/crates/darkly/presets/gimp.yaml
+++ b/crates/darkly/presets/gimp.yaml
@@ -46,6 +46,8 @@ hotkeys:
   deleteLayer: layerPanel:Delete
   # GIMP binds Layer > Duplicate Layer(s) to Ctrl+Shift+D.
   duplicateLayer: $mod+Shift+KeyD
+  # GIMP's "New Layer…" is bound to Ctrl+Shift+N (host docs line 298).
+  newLayer: $mod+Shift+KeyN
   # Selection.
   clearSelection: $mod+Shift+KeyA
   invertSelection: $mod+KeyI

--- a/crates/darkly/presets/krita.yaml
+++ b/crates/darkly/presets/krita.yaml
@@ -40,7 +40,10 @@ hotkeys:
   isolateLayer: KeyI
   deleteLayer: Shift+Delete
   duplicateLayer: $mod+KeyJ
-  mergeDown: $mod+KeyE
+  # Krita's "Add Paint Layer" is bound to Insert (host docs line 187).
+  newLayer: Insert
+  # mergeDown lives in defaults.yaml at the same key — all 2/3-consensus
+  # bindings consolidate there per the placement rule. No override needed.
   # Selection.
   clearSelection: $mod+Shift+KeyA
   invertSelection: $mod+Shift+KeyI

--- a/crates/darkly/presets/photoshop.yaml
+++ b/crates/darkly/presets/photoshop.yaml
@@ -39,7 +39,10 @@ hotkeys:
   # binding (clearSelectionContents) coexists via the binding-site scope.
   deleteLayer: layerPanel:Delete
   duplicateLayer: $mod+KeyJ
-  mergeDown: $mod+KeyE
+  # Photoshop's "New Layer" is Ctrl+Shift+N.
+  newLayer: $mod+Shift+KeyN
+  # mergeDown lives in defaults.yaml at the same key — all 2/3-consensus
+  # bindings consolidate there per the placement rule. No override needed.
   # Selection.
   clearSelection: $mod+KeyD
   invertSelection: $mod+Shift+KeyI

--- a/crates/darkly/src/document/mod.rs
+++ b/crates/darkly/src/document/mod.rs
@@ -22,6 +22,7 @@ pub enum SelectionMode {
     Intersect,
 }
 
+#[derive(Clone, Copy)]
 pub enum MoveTarget {
     Before(LayerId),
     After(LayerId),
@@ -268,6 +269,21 @@ impl Document {
         self.parent.get(id).copied()
     }
 
+    /// True iff `ancestor` appears on the parent chain above `descendant`.
+    /// A node is not its own ancestor. Detached or orphaned nodes have no
+    /// ancestors. Used by batch ops to dedupe a selection that contains
+    /// both a group and one of its descendants.
+    pub fn is_ancestor_of(&self, ancestor: LayerId, descendant: LayerId) -> bool {
+        let mut cur = self.parent_of(descendant);
+        while let Some(p) = cur {
+            if p == ancestor {
+                return true;
+            }
+            cur = self.parent_of(p);
+        }
+        false
+    }
+
     /// True iff this node and every ancestor up to the root are individually
     /// `visible`. The compositor's `compose_children` walk already short-
     /// circuits invisible subtrees ([`crate::gpu::compositor::Compositor`]
@@ -493,6 +509,35 @@ impl Document {
 
     pub fn flat_layer_index(&self, id: LayerId) -> Option<usize> {
         self.flat_layers().iter().position(|l| l.id() == id)
+    }
+
+    /// All tree-node ids (layers + groups) in display order (DFS over the
+    /// full tree, descending into every group regardless of visibility or
+    /// collapsed-state). Excludes the implicit root and modifiers. Used by
+    /// batch ops that need a stable total order across a selection that
+    /// mixes layers and groups, including cross-parent selections.
+    ///
+    /// Iteration is bottom-of-stack first within each parent's
+    /// `children` Vec — so for a panel that displays "top of stack first,"
+    /// the last entry in this Vec for a given selection is the
+    /// **panel-topmost** member. `merge_layers` uses this to locate the
+    /// topmost selected layer across arbitrary parents.
+    pub fn all_node_ids_in_order(&self) -> Vec<LayerId> {
+        let mut out = Vec::new();
+        self.collect_node_ids(self.root, &mut out);
+        out
+    }
+
+    fn collect_node_ids(&self, group_id: LayerId, out: &mut Vec<LayerId>) {
+        let Some(LayerNode::Group(g)) = self.find_node(group_id) else {
+            return;
+        };
+        for &child_id in &g.children {
+            out.push(child_id);
+            if matches!(self.find_node(child_id), Some(LayerNode::Group(_))) {
+                self.collect_node_ids(child_id, out);
+            }
+        }
     }
 
     // ---------------------------------------------------------------

--- a/crates/darkly/src/engine/duplicate.rs
+++ b/crates/darkly/src/engine/duplicate.rs
@@ -7,37 +7,88 @@
 use super::DarklyEngine;
 use crate::document::MoveTarget;
 use crate::layer::{Layer, LayerId, LayerNode};
-use crate::undo::DuplicateAction;
+use crate::undo::{CompoundAction, DuplicateAction, UndoAction};
 
 impl DarklyEngine {
     /// Duplicate `source_id` and place the copy directly above it in the
     /// same parent. Returns the id of the new top-level node (the duplicated
     /// raster or group). Returns `None` if the source isn't a layer / group.
     pub fn duplicate_node(&mut self, source_id: LayerId) -> Option<LayerId> {
+        let (new_id, action) = self.duplicate_node_inner(source_id)?;
+        self.compositor.mark_dirty();
+        self.push_undo(action);
+        Some(new_id)
+    }
+
+    /// Duplicate every id in `ids` in document order and return their new
+    /// counterparts as a single undo step. Ids whose ancestor is already in
+    /// `ids` are skipped — duplicating the ancestor takes the descendant
+    /// with it, so a second pass would produce a redundant copy. Cross-
+    /// parent selections are supported: each duplicate lands above its own
+    /// source, no matter which parent group that source lives in.
+    pub fn duplicate_nodes(&mut self, ids: Vec<LayerId>) -> Vec<LayerId> {
+        let mut filtered: Vec<LayerId> = ids
+            .iter()
+            .copied()
+            .filter(|&id| self.doc.find_node(id).is_some())
+            .filter(|&id| {
+                !ids.iter()
+                    .any(|&other| other != id && self.doc.is_ancestor_of(other, id))
+            })
+            .collect();
+        let order = self.doc.all_node_ids_in_order();
+        let order_idx = |id: LayerId| order.iter().position(|&x| x == id).unwrap_or(usize::MAX);
+        filtered.sort_by_key(|&id| order_idx(id));
+
+        let mut new_ids = Vec::with_capacity(filtered.len());
+        let mut actions: Vec<Box<dyn UndoAction>> = Vec::with_capacity(filtered.len());
+        for id in filtered {
+            if let Some((new_id, action)) = self.duplicate_node_inner(id) {
+                new_ids.push(new_id);
+                actions.push(action);
+            }
+        }
+        if !actions.is_empty() {
+            self.compositor.mark_dirty();
+            self.push_undo(Box::new(CompoundAction::new(actions)));
+        }
+        new_ids
+    }
+
+    /// Duplicate a single node and return both the new id and the matching
+    /// undo action without pushing it. Shared between [`Self::duplicate_node`]
+    /// and [`Self::duplicate_nodes`].
+    fn duplicate_node_inner(
+        &mut self,
+        source_id: LayerId,
+    ) -> Option<(LayerId, Box<dyn UndoAction>)> {
         self.doc.find_node(source_id)?;
-
         let root_new_id = self.clone_subtree(source_id, None, /* is_root: */ true)?;
-
-        // Anchor the duplicate directly above the source. `add_raster_layer`
-        // / `add_group` insert with `anchor=source_id` at the time of
-        // creation (see clone_subtree); a second move is unnecessary except
-        // when we created via `add_group` on root (which lands at the top).
-        // The "anchor above source" placement is built into the document's
-        // add methods.
-
+        // `clone_subtree(..., None, ...)` lands the new node at the top of
+        // root via `add_*(None) → IntoGroupTop(root)`. Move it next to the
+        // source so each duplicate sits directly above its own original —
+        // critical for multi-duplicate, where N "tops" would otherwise
+        // stack all duplicates together at the top of the panel.
+        //
+        // `MoveTarget::After(source)` lands the new node at source's
+        // position + 1 in source's parent regardless of whether source is
+        // a Layer or a Group. Anchoring `add_*` directly on source would
+        // land the duplicate INSIDE the source when source is a Group
+        // (the `IntoGroupTop` semantic on group anchors).
+        self.doc
+            .move_layer(root_new_id, MoveTarget::After(source_id));
         let parent = self.doc.parent_of(root_new_id);
         let position = self.doc.position_in_parent(root_new_id).unwrap_or(0);
         let tombstones = self.collect_pixel_node_ids(root_new_id);
-
-        self.compositor.mark_dirty();
-        self.push_undo(Box::new(DuplicateAction::new(
+        Some((
             root_new_id,
-            parent,
-            position,
-            tombstones,
-        )));
-
-        Some(root_new_id)
+            Box::new(DuplicateAction::new(
+                root_new_id,
+                parent,
+                position,
+                tombstones,
+            )),
+        ))
     }
 
     /// Recursive subtree clone. `anchor` is the position the new node should

--- a/crates/darkly/src/engine/layers.rs
+++ b/crates/darkly/src/engine/layers.rs
@@ -38,6 +38,118 @@ impl DarklyEngine {
         id
     }
 
+    /// Create a new group and move every id in `ids` into it, preserving
+    /// their relative panel order. The group ends up at the panel-topmost
+    /// selected layer's slot — its parent, its position — so the act
+    /// "wraps" the selection in place. Cross-parent selections are
+    /// supported; sources from other groups get pulled into the new group.
+    ///
+    /// Locked layers and any id whose ancestor is also in `ids` are
+    /// skipped; the new group is created only if at least one editable
+    /// source remains. The whole op is one [`CompoundAction`], so a
+    /// single undo restores the original tree.
+    pub fn group_layers(&mut self, ids: Vec<LayerId>) -> Result<LayerId, String> {
+        if ids.is_empty() {
+            return Err("Need at least one layer to group".into());
+        }
+
+        let mut editable: Vec<LayerId> = Vec::with_capacity(ids.len());
+        for &id in &ids {
+            if self.doc.find_node(id).is_none() {
+                continue;
+            }
+            if !self.doc.is_node_editable(id) {
+                continue;
+            }
+            // Drop any id whose ancestor is also in the batch — moving
+            // the ancestor brings the descendant along; processing both
+            // would yank the descendant out of its group.
+            if ids
+                .iter()
+                .any(|&other| other != id && self.doc.is_ancestor_of(other, id))
+            {
+                continue;
+            }
+            editable.push(id);
+        }
+        if editable.is_empty() {
+            return Err("No editable layers to group".into());
+        }
+
+        // Sort by panel order so the last entry is the panel-topmost
+        // editable source — its slot is where the new group will live.
+        let order = self.doc.all_node_ids_in_order();
+        let order_idx = |id: LayerId| order.iter().position(|&x| x == id).unwrap_or(usize::MAX);
+        editable.sort_by_key(|&id| order_idx(id));
+        let topmost = *editable.last().expect("non-empty");
+        let topmost_parent = self.doc.parent_of(topmost);
+        let topmost_pos = self.doc.position_in_parent(topmost).unwrap_or(0);
+
+        // Create the group at the top of root — a stable spot that
+        // can't accidentally land it inside one of the sources (which
+        // would happen if we anchored on a Group-typed `topmost`, since
+        // `add_group(Some(group))` resolves to `IntoGroupTop(group)`).
+        // We'll move the group to the topmost's slot at the end.
+        let group_id = self.doc.add_group(None);
+        let group_initial_parent = self.doc.parent_of(group_id);
+        let group_initial_pos = self.doc.position_in_parent(group_id).unwrap_or(0);
+
+        let mut actions: Vec<Box<dyn UndoAction>> = Vec::with_capacity(editable.len() + 2);
+        actions.push(Box::new(LayerAddAction::new(
+            group_id,
+            group_initial_parent,
+            group_initial_pos,
+        )));
+
+        // Move sources into the group, preserving bottom-first ordering
+        // (so panel order top-first reads as the original layout). The
+        // first source goes to IntoGroupBottom; subsequent sources chain
+        // `After(prev)` so they land contiguously in the same relative
+        // order they had before.
+        let mut prev: Option<LayerId> = None;
+        for id in editable {
+            let target = match prev {
+                None => MoveTarget::IntoGroupBottom(group_id),
+                Some(p) => MoveTarget::After(p),
+            };
+            if let Some(a) = self.move_layer_inner(id, target) {
+                actions.push(a);
+                prev = Some(id);
+            }
+        }
+
+        // Reposition the group at the topmost's original slot. The
+        // topmost has already been detached (it was the last source
+        // moved into the group), so its parent's children Vec is short
+        // one entry — `topmost_pos` now points at whatever was just
+        // above topmost in panel order. Inserting the group there
+        // lands it exactly where topmost used to be.
+        let group_pre_move_parent = self.doc.parent_of(group_id);
+        let group_pre_move_pos = self.doc.position_in_parent(group_id).unwrap_or(0);
+        self.doc.detach_for_undo(group_id);
+        let clamped_pos = topmost_pos.min(match topmost_parent {
+            Some(p) => self.doc.children_of(p).len(),
+            None => self.doc.children_of(self.doc.root_id()).len(),
+        });
+        self.doc
+            .reinsert_node(group_id, topmost_parent, clamped_pos);
+        let group_final_parent = self.doc.parent_of(group_id);
+        let group_final_pos = self.doc.position_in_parent(group_id).unwrap_or(0);
+        if (group_pre_move_parent, group_pre_move_pos) != (group_final_parent, group_final_pos) {
+            actions.push(Box::new(LayerMoveAction::new(
+                group_id,
+                group_pre_move_parent,
+                group_pre_move_pos,
+                group_final_parent,
+                group_final_pos,
+            )));
+        }
+
+        self.push_undo(Box::new(CompoundAction::new(actions)));
+        self.compositor.mark_dirty();
+        Ok(group_id)
+    }
+
     /// Add a new void (procedural) layer. `params` is matched against the
     /// void type's `ParamDef` schema by index — callers that don't have a
     /// hand-rolled slice should use the type's defaults via
@@ -216,47 +328,164 @@ impl DarklyEngine {
             return Err("Cannot delete the last layer".into());
         }
 
-        let parent = self.doc.parent_of(layer_id);
-        let pos = self.doc.position_in_parent(layer_id).unwrap_or(0);
-
-        // Collect tombstones before detaching — `detach_for_undo` severs
-        // the parent links `collect_pixel_node_ids` walks to enumerate the
-        // subtree.
-        let tombstones = self.collect_pixel_node_ids(layer_id);
-
-        if self.doc.detach_for_undo(layer_id).is_some() {
-            // GPU textures stay alive in the compositor's pool until the
-            // owning undo entry is evicted (LayerRemoveAction::on_evict),
-            // so an undo of the removal restores the pixels intact.
-            self.push_undo(Box::new(LayerRemoveAction::new(
-                layer_id, parent, pos, tombstones,
-            )));
+        if let Some(action) = self.detach_layer_for_remove(layer_id) {
+            self.push_undo(action);
         }
-
         self.compositor.mark_dirty();
         Ok(())
     }
 
+    /// Detach a single layer for removal and return the matching undo
+    /// action without pushing it. Returns `None` if `layer_id` isn't in
+    /// the tree. The caller is responsible for any editability or
+    /// "last layer" checks; this is the raw mutation half shared between
+    /// [`Self::remove_layer`] and [`Self::remove_layers`].
+    fn detach_layer_for_remove(&mut self, layer_id: LayerId) -> Option<Box<dyn UndoAction>> {
+        let parent = self.doc.parent_of(layer_id);
+        let pos = self.doc.position_in_parent(layer_id).unwrap_or(0);
+        // Collect tombstones before detaching — `detach_for_undo` severs
+        // the parent links `collect_pixel_node_ids` walks to enumerate
+        // the subtree.
+        let tombstones = self.collect_pixel_node_ids(layer_id);
+        self.doc.detach_for_undo(layer_id)?;
+        Some(Box::new(LayerRemoveAction::new(
+            layer_id, parent, pos, tombstones,
+        )))
+    }
+
+    /// Remove every id in `ids` in a single undo step. Locked layers and
+    /// any id whose ancestor is also in `ids` are silently skipped; the
+    /// return value is the count of locked layers that were ignored so the
+    /// UI can surface a "N locked layers skipped" toast. Errors only when
+    /// removing the editable set would leave zero layers in the document.
+    pub fn remove_layers(&mut self, ids: Vec<LayerId>) -> Result<usize, String> {
+        let mut editable = Vec::with_capacity(ids.len());
+        let mut skipped_locked = 0usize;
+        for &id in &ids {
+            if self.doc.find_node(id).is_none() {
+                continue;
+            }
+            if !self.doc.is_node_editable(id) {
+                skipped_locked += 1;
+                continue;
+            }
+            // Drop any id that's a descendant of another id already in
+            // the batch — removing the ancestor takes the subtree with it.
+            if ids
+                .iter()
+                .any(|&other| other != id && self.doc.is_ancestor_of(other, id))
+            {
+                continue;
+            }
+            editable.push(id);
+        }
+        if editable.is_empty() {
+            self.compositor.mark_dirty();
+            return Ok(skipped_locked);
+        }
+        if self.doc.node_count().saturating_sub(editable.len()) == 0 {
+            return Err("Cannot delete the last layer".into());
+        }
+
+        self.batched_undo(&editable, |engine, id| engine.detach_layer_for_remove(id));
+        self.compositor.mark_dirty();
+        Ok(skipped_locked)
+    }
+
     pub fn move_layer(&mut self, layer_id: LayerId, target: MoveTarget) {
+        if let Some(action) = self.move_layer_inner(layer_id, target) {
+            self.push_undo(action);
+        }
+        self.compositor.mark_dirty();
+    }
+
+    /// Move a single layer and return the matching undo action without
+    /// pushing it. Returns `None` if `layer_id` is locked or not in the
+    /// tree. Shared between [`Self::move_layer`] and
+    /// [`Self::move_layers`].
+    fn move_layer_inner(
+        &mut self,
+        layer_id: LayerId,
+        target: MoveTarget,
+    ) -> Option<Box<dyn UndoAction>> {
         if !self.doc.is_node_editable(layer_id) {
-            return;
+            return None;
         }
         let old_parent = self.doc.parent_of(layer_id);
-        let old_pos = match self.doc.position_in_parent(layer_id) {
-            Some(p) => p,
-            None => return,
-        };
-
+        let old_pos = self.doc.position_in_parent(layer_id)?;
         self.doc.move_layer(layer_id, target);
-
         let new_parent = self.doc.parent_of(layer_id);
         let new_pos = self.doc.position_in_parent(layer_id).unwrap_or(0);
-
-        self.compositor.mark_dirty();
-
-        self.push_undo(Box::new(LayerMoveAction::new(
+        Some(Box::new(LayerMoveAction::new(
             layer_id, old_parent, old_pos, new_parent, new_pos,
-        )));
+        )))
+    }
+
+    /// Move every id in `ids` to land contiguously at `target`, preserving
+    /// their current relative tree order. Locked layers and any id whose
+    /// ancestor is also in `ids` are silently skipped; returns the count
+    /// of locked-layer skips so the UI can toast. Errors when `target`
+    /// references an id in `ids` or a descendant of one (the drop is
+    /// self-referential).
+    pub fn move_layers(&mut self, ids: Vec<LayerId>, target: MoveTarget) -> Result<usize, String> {
+        let target_id = match target {
+            MoveTarget::Before(t)
+            | MoveTarget::After(t)
+            | MoveTarget::IntoGroupTop(t)
+            | MoveTarget::IntoGroupBottom(t) => t,
+        };
+        for &id in &ids {
+            if id == target_id || self.doc.is_ancestor_of(id, target_id) {
+                return Err("Cannot move a layer into itself".into());
+            }
+        }
+
+        let mut editable: Vec<LayerId> = Vec::with_capacity(ids.len());
+        let mut skipped_locked = 0usize;
+        for &id in &ids {
+            if self.doc.find_node(id).is_none() {
+                continue;
+            }
+            if !self.doc.is_node_editable(id) {
+                skipped_locked += 1;
+                continue;
+            }
+            if ids
+                .iter()
+                .any(|&other| other != id && self.doc.is_ancestor_of(other, id))
+            {
+                continue;
+            }
+            editable.push(id);
+        }
+        if editable.is_empty() {
+            return Ok(skipped_locked);
+        }
+
+        // Sort by document DFS order so subsequent `After(prev)` chaining
+        // preserves the user's original top-to-bottom layout at the
+        // destination.
+        let order = self.doc.all_node_ids_in_order();
+        let order_idx = |id: LayerId| order.iter().position(|&x| x == id).unwrap_or(usize::MAX);
+        editable.sort_by_key(|&id| order_idx(id));
+
+        let mut actions: Vec<Box<dyn UndoAction>> = Vec::with_capacity(editable.len());
+        let mut prev: Option<LayerId> = None;
+        for id in editable {
+            let step_target = match prev {
+                None => target,
+                Some(p) => MoveTarget::After(p),
+            };
+            if let Some(a) = self.move_layer_inner(id, step_target) {
+                actions.push(a);
+                prev = Some(id);
+            }
+        }
+        if !actions.is_empty() {
+            self.push_undo(Box::new(CompoundAction::new(actions)));
+        }
+        self.compositor.mark_dirty();
+        Ok(skipped_locked)
     }
 
     // --- Layer properties ---

--- a/crates/darkly/src/engine/merge.rs
+++ b/crates/darkly/src/engine/merge.rs
@@ -147,4 +147,139 @@ impl DarklyEngine {
         };
         pos > 0
     }
+
+    /// Bake every layer in `ids` (≥2, any parent) into one raster placed at
+    /// the panel-topmost selected layer's slot. The result inherits the
+    /// topmost's name / blend mode / opacity / visibility; sources from
+    /// other parents are detached and tombstoned. Groups in the selection
+    /// are flattened during the bake. Returns the id of the result.
+    ///
+    /// Errors when fewer than two distinct sources are provided, when any
+    /// source is locked (a partial bake is destructive), or when a source
+    /// id isn't in the tree.
+    pub fn merge_layers(&mut self, ids: Vec<LayerId>) -> Result<LayerId, String> {
+        // De-dup while preserving caller order — important for the error
+        // path that names the input set in messages.
+        let mut unique: Vec<LayerId> = Vec::with_capacity(ids.len());
+        for id in ids {
+            if !unique.contains(&id) {
+                unique.push(id);
+            }
+        }
+        if unique.len() < 2 {
+            return Err("Merge needs at least two layers".into());
+        }
+        for &id in &unique {
+            if self.doc.find_node(id).is_none() {
+                return Err("Layer not in tree".into());
+            }
+            if !self.doc.is_node_editable(id) {
+                return Err("A selected layer is locked".into());
+            }
+        }
+
+        // Sort by panel display order so the bake walks bottom-to-top and
+        // the LAST entry is the topmost selected layer in the panel — that
+        // one anchors the result's slot and provides the inherited props.
+        let order = self.doc.all_node_ids_in_order();
+        let order_idx = |id: LayerId| order.iter().position(|&x| x == id).unwrap_or(usize::MAX);
+        unique.sort_by_key(|&id| order_idx(id));
+        let topmost_id = *unique.last().expect("len >= 2");
+
+        // Snapshot the topmost's properties + slot now, before any detach.
+        let (top_name, top_visible, top_locked, top_opacity, top_blend_mode) = {
+            let t = self
+                .doc
+                .find_node(topmost_id)
+                .ok_or("Topmost source missing")?;
+            (
+                t.common().name.clone(),
+                t.common().visible,
+                t.common().locked,
+                t.blend().opacity,
+                t.blend().blend_mode,
+            )
+        };
+        let topmost_parent = self.doc.parent_of(topmost_id);
+        let topmost_pos = self
+            .doc
+            .position_in_parent(topmost_id)
+            .ok_or("Topmost source not in tree")?;
+
+        // Record each source's prior (parent, position) for undo reinsert.
+        // Captured BEFORE any detach so positions reflect the live tree.
+        let sources: Vec<BakeSourceSlot> = unique
+            .iter()
+            .map(|&id| BakeSourceSlot {
+                id,
+                parent: self.doc.parent_of(id),
+                position: self.doc.position_in_parent(id).unwrap_or(0),
+            })
+            .collect();
+
+        // Allocate the result raster, anchored at the topmost so it sits
+        // in the right parent group; we'll reposition exactly after the
+        // sources detach.
+        let canvas_bounds = CanvasRect::from_xywh(0, 0, self.doc.width, self.doc.height);
+        let result_id = self.doc.add_raster_layer(Some(topmost_id));
+        if let Some(LayerNode::Layer(Layer::Raster(r))) = self.doc.find_node_mut(result_id) {
+            r.pixels.bounds = canvas_bounds;
+            r.common.name = top_name;
+            r.common.visible = top_visible;
+            r.common.locked = top_locked;
+            r.blend.opacity = top_opacity;
+            r.blend.blend_mode = top_blend_mode;
+        }
+        self.compositor.ensure_raster_layer(
+            &self.gpu.device,
+            &self.gpu.queue,
+            result_id,
+            canvas_bounds,
+        );
+        self.refresh_blend_uniforms(result_id);
+
+        // Bake sources bottom-to-top (the `unique` order after sorting)
+        // so blend modes stack correctly when composited into the result.
+        self.compositor.bake_subtree_to_layer(
+            &self.gpu.device,
+            &self.gpu.queue,
+            &mut self.doc,
+            &unique,
+            result_id,
+        );
+
+        // Collect tombstones from every source BEFORE detach so the walk
+        // can reach the subtrees.
+        let mut source_tombstones: Vec<LayerId> = Vec::new();
+        for &id in &unique {
+            source_tombstones.extend(self.collect_pixel_node_ids(id));
+        }
+
+        // Detach every source. Their textures stay alive in node_textures
+        // as tombstones owned by the BakeLayersAction.
+        for &id in &unique {
+            self.doc.detach_for_undo(id);
+        }
+
+        // Reposition the result at the topmost's original slot. Detach +
+        // reinsert is the simplest exact-slot landing.
+        self.doc.detach_for_undo(result_id);
+        self.doc
+            .reinsert_node(result_id, topmost_parent, topmost_pos);
+
+        let result_parent = self.doc.parent_of(result_id);
+        let result_position = self.doc.position_in_parent(result_id).unwrap_or(0);
+
+        self.compositor.mark_dirty();
+        self.push_undo(Box::new(BakeLayersAction::new(
+            sources,
+            source_tombstones,
+            result_id,
+            result_parent,
+            result_position,
+            vec![result_id],
+        )));
+
+        Ok(result_id)
+    }
 }

--- a/crates/darkly/src/engine/undo_dispatch.rs
+++ b/crates/darkly/src/engine/undo_dispatch.rs
@@ -7,7 +7,8 @@
 //! own.
 
 use super::DarklyEngine;
-use crate::undo::{PropertyAction, UndoAction};
+use crate::layer::LayerId;
+use crate::undo::{CompoundAction, PropertyAction, UndoAction};
 
 impl DarklyEngine {
     /// Push a completed undo action. Runs `on_evict` on every action that
@@ -33,6 +34,30 @@ impl DarklyEngine {
         let evicted = self.undo_stack.coalesce_property(&mut self.doc, action);
         for mut e in evicted {
             e.on_evict(&mut self.compositor);
+        }
+    }
+
+    /// Run `op` for each id, collecting any returned undo actions into one
+    /// [`CompoundAction`] and pushing the bundle as a single undo step. The
+    /// closure does the per-id mutation directly (so per-id state can be
+    /// snapshotted between iterations — e.g. `position_in_parent` after a
+    /// prior id was detached) and returns `Some(action)` if the op produced
+    /// any reversible work, `None` if it skipped that id.
+    ///
+    /// No undo entry is pushed when every id was skipped — keeps the stack
+    /// clean when, say, every requested removal hit a locked layer.
+    pub(crate) fn batched_undo<F>(&mut self, ids: &[LayerId], mut op: F)
+    where
+        F: FnMut(&mut Self, LayerId) -> Option<Box<dyn UndoAction>>,
+    {
+        let mut actions = Vec::with_capacity(ids.len());
+        for &id in ids {
+            if let Some(a) = op(self, id) {
+                actions.push(a);
+            }
+        }
+        if !actions.is_empty() {
+            self.push_undo(Box::new(CompoundAction::new(actions)));
         }
     }
 

--- a/crates/darkly/tests/engine.rs
+++ b/crates/darkly/tests/engine.rs
@@ -4300,3 +4300,476 @@ fn copy_with_aa_rect_selection_has_no_transparent_border() {
         }
     }
 }
+
+// ============================================================================
+// Multi-layer structural operations
+// ============================================================================
+
+/// Three layers deleted in one batch produce a single undo step that
+/// restores them all with pixels intact.
+#[test]
+fn multi_delete_undo_redo_round_trip() {
+    let mut engine = test_engine(64, 64);
+    let l1 = engine.add_raster_layer(None);
+    let l2 = engine.add_raster_layer(None);
+    let l3 = engine.add_raster_layer(None);
+    let _keep = engine.add_raster_layer(None);
+
+    paint_at(&mut engine, l1, 8.0, 8.0, 1.0, 0.0, 0.0);
+    paint_at(&mut engine, l2, 16.0, 16.0, 0.0, 1.0, 0.0);
+    paint_at(&mut engine, l3, 24.0, 24.0, 0.0, 0.0, 1.0);
+    let pix1 = engine.test_readback_layer(l1);
+    let pix2 = engine.test_readback_layer(l2);
+    let pix3 = engine.test_readback_layer(l3);
+
+    let skipped = engine.remove_layers(vec![l1, l2, l3]).expect("remove ok");
+    assert_eq!(skipped, 0);
+    assert!(!engine.has_layer(l1));
+    assert!(!engine.has_layer(l2));
+    assert!(!engine.has_layer(l3));
+
+    engine.undo();
+    engine.render(0.0);
+    assert!(engine.has_layer(l1), "one undo must restore all three");
+    assert!(engine.has_layer(l2));
+    assert!(engine.has_layer(l3));
+
+    assert_eq!(engine.test_readback_layer(l1), pix1);
+    assert_eq!(engine.test_readback_layer(l2), pix2);
+    assert_eq!(engine.test_readback_layer(l3), pix3);
+}
+
+/// `remove_layers` skips locked layers silently and reports the skip
+/// count so the UI can toast. Unlocked layers in the same batch are
+/// still removed.
+#[test]
+fn delete_skips_locked_layers() {
+    let mut engine = test_engine(64, 64);
+    let l1 = engine.add_raster_layer(None);
+    let l2 = engine.add_raster_layer(None);
+    let _keep = engine.add_raster_layer(None);
+    engine.set_node_locked(l1, true);
+
+    let skipped = engine.remove_layers(vec![l1, l2]).expect("remove ok");
+    assert_eq!(skipped, 1, "the locked layer should be reported as skipped");
+    assert!(engine.has_layer(l1), "locked layer must remain in the tree");
+    assert!(!engine.has_layer(l2), "unlocked layer should be removed");
+}
+
+/// Refuse a batch that would leave zero layers — same invariant the
+/// single-layer `remove_layer` enforces, scaled to batch.
+#[test]
+fn delete_refuses_to_empty_document() {
+    let mut engine = test_engine(64, 64);
+    let l1 = engine.add_raster_layer(None);
+    let l2 = engine.add_raster_layer(None);
+
+    let result = engine.remove_layers(vec![l1, l2]);
+    assert!(result.is_err(), "must refuse leaving an empty document");
+    assert!(engine.has_layer(l1));
+    assert!(engine.has_layer(l2));
+}
+
+/// Selecting a group AND one of its descendants and deleting both must
+/// dedupe — the descendant comes out with its ancestor, so issuing a
+/// second `LayerRemoveAction` would corrupt the undo stack.
+#[test]
+fn delete_dedupes_ancestor_descendant() {
+    use darkly::document::MoveTarget;
+    use darkly::engine::types::LayerInfo;
+    let mut engine = test_engine(64, 64);
+    let _keep = engine.add_raster_layer(None);
+    let group = engine.add_group(None);
+    let child = engine.add_raster_layer(None);
+    engine.move_layer(child, MoveTarget::IntoGroupTop(group));
+
+    let group_in_root = |e: &DarklyEngine| -> bool {
+        e.layer_tree().iter().any(|n| {
+            matches!(
+                n,
+                LayerInfo::Group { id, .. } if *id == group.to_ffi() as f64
+            )
+        })
+    };
+
+    let skipped = engine.remove_layers(vec![group, child]).expect("remove ok");
+    assert_eq!(skipped, 0);
+    assert!(
+        !group_in_root(&engine),
+        "group should be detached from tree"
+    );
+    assert!(!engine.has_layer(group));
+
+    // One undo must restore the group, with its child still attached.
+    // If the dedupe failed, the stack would carry two actions and a
+    // single undo would only restore one of them.
+    engine.undo();
+    engine.render(0.0);
+    assert!(group_in_root(&engine), "one undo restores the group");
+    assert!(
+        engine.has_layer(child),
+        "child must come back with the group"
+    );
+}
+
+/// Moving a non-contiguous selection into a new container preserves
+/// its panel-display order at the destination.
+#[test]
+fn multi_move_preserves_relative_order() {
+    use darkly::document::MoveTarget;
+    use darkly::engine::types::LayerInfo;
+    let mut engine = test_engine(32, 32);
+    let l1 = engine.add_raster_layer(None);
+    let _l2 = engine.add_raster_layer(None);
+    let l3 = engine.add_raster_layer(None);
+    let _keep = engine.add_raster_layer(None);
+    let g = engine.add_group(None);
+
+    engine
+        .move_layers(vec![l1, l3], MoveTarget::IntoGroupTop(g))
+        .expect("move ok");
+
+    // Pull the group out of the published tree and inspect its
+    // children. Published children are panel-order (top first); the
+    // expected post-move order inside the group has l3 above l1
+    // (matching their original relative panel order, where l3 sat
+    // above l1).
+    let tree = engine.layer_tree();
+    let group_info = tree
+        .iter()
+        .find(|n| {
+            matches!(
+                n, LayerInfo::Group { id, .. } if *id == g.to_ffi() as f64
+            )
+        })
+        .expect("group still in tree");
+    let children = match group_info {
+        LayerInfo::Group { children, .. } => children,
+        _ => panic!(),
+    };
+    let child_ids: Vec<f64> = children
+        .iter()
+        .map(|c| match c {
+            LayerInfo::Raster { id, .. } => *id,
+            LayerInfo::Void { id, .. } => *id,
+            LayerInfo::Group { id, .. } => *id,
+        })
+        .collect();
+    assert_eq!(
+        child_ids,
+        vec![l3.to_ffi() as f64, l1.to_ffi() as f64],
+        "group's panel-order children should be [l3, l1] — preserving the \
+         original relative panel order"
+    );
+}
+
+/// `move_layers` refuses a target that's one of the moved ids, or a
+/// descendant of one — the operation would be self-referential.
+#[test]
+fn move_refuses_self_target() {
+    use darkly::document::MoveTarget;
+    let mut engine = test_engine(32, 32);
+    let _keep = engine.add_raster_layer(None);
+    let group = engine.add_group(None);
+    let child = engine.add_raster_layer(None);
+    engine.move_layer(child, MoveTarget::IntoGroupTop(group));
+
+    let result = engine.move_layers(vec![group], MoveTarget::Before(child));
+    assert!(
+        result.is_err(),
+        "moving a group into its own child is nonsense"
+    );
+
+    let result = engine.move_layers(vec![child, group], MoveTarget::Before(group));
+    assert!(
+        result.is_err(),
+        "moving a selection onto a member of itself is nonsense"
+    );
+}
+
+/// `group_layers` wraps the selection in a new group at the panel-
+/// topmost selected layer's slot. The group's children should appear in
+/// the original relative panel order.
+#[test]
+fn group_layers_wraps_selection_at_topmost_slot() {
+    use darkly::engine::types::LayerInfo;
+    let mut engine = test_engine(32, 32);
+    let _keep_bottom = engine.add_raster_layer(None);
+    let l1 = engine.add_raster_layer(None);
+    let l2 = engine.add_raster_layer(None);
+    let l3 = engine.add_raster_layer(None); // panel-topmost of the selection
+    let _keep_top = engine.add_raster_layer(None);
+
+    let group_id = engine.group_layers(vec![l1, l2, l3]).expect("group ok");
+
+    let tree = engine.layer_tree();
+    let group_f = group_id.to_ffi() as f64;
+    let group_info = tree
+        .iter()
+        .find(|n| matches!(n, LayerInfo::Group { id, .. } if *id == group_f))
+        .expect("group in tree");
+
+    // Group's panel-order children are [l3, l2, l1] — preserving the
+    // original top-to-bottom order they had at root.
+    let children = match group_info {
+        LayerInfo::Group { children, .. } => children,
+        _ => panic!(),
+    };
+    let child_ids: Vec<f64> = children
+        .iter()
+        .map(|c| match c {
+            LayerInfo::Raster { id, .. } => *id,
+            LayerInfo::Void { id, .. } => *id,
+            LayerInfo::Group { id, .. } => *id,
+        })
+        .collect();
+    assert_eq!(
+        child_ids,
+        vec![l3.to_ffi() as f64, l2.to_ffi() as f64, l1.to_ffi() as f64,],
+        "group children in panel order should preserve original relative order"
+    );
+}
+
+/// Grouping a cross-parent selection pulls each source out of its
+/// current parent and into the new group. Source groups can end up
+/// empty — that's fine; users can delete them if they want.
+#[test]
+fn group_layers_cross_parent() {
+    use darkly::document::MoveTarget;
+    use darkly::engine::types::LayerInfo;
+    let mut engine = test_engine(32, 32);
+    let _keep = engine.add_raster_layer(None);
+    let outer = engine.add_group(None);
+    let inside = engine.add_raster_layer(None);
+    engine.move_layer(inside, MoveTarget::IntoGroupTop(outer));
+    let root_top = engine.add_raster_layer(None);
+
+    let group_id = engine
+        .group_layers(vec![inside, root_top])
+        .expect("cross-parent group ok");
+
+    let tree = engine.layer_tree();
+    let new_group = tree
+        .iter()
+        .find(|n| matches!(n, LayerInfo::Group { id, .. } if *id == group_id.to_ffi() as f64))
+        .expect("new group at root");
+    let children = match new_group {
+        LayerInfo::Group { children, .. } => children,
+        _ => panic!(),
+    };
+    let child_ids: Vec<f64> = children
+        .iter()
+        .map(|c| match c {
+            LayerInfo::Raster { id, .. } => *id,
+            LayerInfo::Void { id, .. } => *id,
+            LayerInfo::Group { id, .. } => *id,
+        })
+        .collect();
+    assert_eq!(child_ids.len(), 2);
+    assert!(child_ids.contains(&(inside.to_ffi() as f64)));
+    assert!(child_ids.contains(&(root_top.to_ffi() as f64)));
+
+    // The original outer group should still exist but be empty.
+    let outer_info = tree
+        .iter()
+        .find(|n| matches!(n, LayerInfo::Group { id, .. } if *id == outer.to_ffi() as f64))
+        .expect("outer group still in tree");
+    let outer_children = match outer_info {
+        LayerInfo::Group { children, .. } => children,
+        _ => panic!(),
+    };
+    assert!(
+        outer_children.is_empty(),
+        "outer group emptied as source moved out"
+    );
+}
+
+/// Selecting a group AND one of its descendants and then grouping must
+/// dedupe — moving both would yank the descendant out of its parent.
+/// Moving just the ancestor keeps the descendant with it.
+#[test]
+fn group_layers_dedupes_ancestor_descendant() {
+    use darkly::document::MoveTarget;
+    use darkly::engine::types::LayerInfo;
+    let mut engine = test_engine(32, 32);
+    let _keep = engine.add_raster_layer(None);
+    let outer = engine.add_group(None);
+    let inside = engine.add_raster_layer(None);
+    engine.move_layer(inside, MoveTarget::IntoGroupTop(outer));
+
+    let new_group = engine.group_layers(vec![outer, inside]).expect("group ok");
+
+    let tree = engine.layer_tree();
+    let new_info = tree
+        .iter()
+        .find(|n| matches!(n, LayerInfo::Group { id, .. } if *id == new_group.to_ffi() as f64))
+        .expect("new group in tree");
+    let direct_children = match new_info {
+        LayerInfo::Group { children, .. } => children,
+        _ => panic!(),
+    };
+    assert_eq!(direct_children.len(), 1, "ancestor dedup keeps only outer");
+    match &direct_children[0] {
+        LayerInfo::Group { id, children, .. } => {
+            assert_eq!(*id, outer.to_ffi() as f64);
+            assert_eq!(children.len(), 1, "outer still contains inside");
+        }
+        _ => panic!("expected Group as direct child"),
+    }
+}
+
+/// One undo step restores the entire original tree — `add_group` plus
+/// every move are bundled into one `CompoundAction`.
+#[test]
+fn group_layers_one_undo_step_restores_tree() {
+    use darkly::engine::types::LayerInfo;
+    let mut engine = test_engine(32, 32);
+    let _keep = engine.add_raster_layer(None);
+    let l1 = engine.add_raster_layer(None);
+    let l2 = engine.add_raster_layer(None);
+
+    let group_id = engine.group_layers(vec![l1, l2]).expect("group ok");
+
+    let group_in_tree = |e: &DarklyEngine| -> bool {
+        e.layer_tree().iter().any(|n| {
+            matches!(
+                n,
+                LayerInfo::Group { id, .. } if *id == group_id.to_ffi() as f64
+            )
+        })
+    };
+    let layer_at_root = |e: &DarklyEngine, id: LayerId| -> bool {
+        e.layer_tree().iter().any(|n| match n {
+            LayerInfo::Raster { id: x, .. } => *x == id.to_ffi() as f64,
+            _ => false,
+        })
+    };
+
+    assert!(group_in_tree(&engine), "group at root after creation");
+    assert!(!layer_at_root(&engine, l1), "l1 moved into group");
+    assert!(!layer_at_root(&engine, l2), "l2 moved into group");
+
+    engine.undo();
+    engine.render(0.0);
+
+    assert!(!group_in_tree(&engine), "group removed by single undo");
+    assert!(layer_at_root(&engine, l1), "l1 back at root");
+    assert!(layer_at_root(&engine, l2), "l2 back at root");
+}
+
+/// Locked layers in the selection are silently skipped — they stay
+/// where they are, and the unlocked layers go into the new group.
+#[test]
+fn group_layers_skips_locked() {
+    let mut engine = test_engine(32, 32);
+    let _keep = engine.add_raster_layer(None);
+    let l1 = engine.add_raster_layer(None);
+    let l2 = engine.add_raster_layer(None);
+    engine.set_node_locked(l1, true);
+
+    let group_id = engine
+        .group_layers(vec![l1, l2])
+        .expect("group ok with one editable");
+
+    use darkly::engine::types::LayerInfo;
+    let tree = engine.layer_tree();
+    // l1 stays at root (still locked, untouched).
+    let l1_at_root = tree.iter().any(|n| match n {
+        LayerInfo::Raster { id, .. } => *id == l1.to_ffi() as f64,
+        _ => false,
+    });
+    assert!(l1_at_root, "locked layer stayed put at root");
+    // The new group contains only l2.
+    let new_info = tree
+        .iter()
+        .find(|n| matches!(n, LayerInfo::Group { id, .. } if *id == group_id.to_ffi() as f64))
+        .expect("new group in tree");
+    let direct = match new_info {
+        LayerInfo::Group { children, .. } => children,
+        _ => panic!(),
+    };
+    assert_eq!(direct.len(), 1);
+}
+
+/// If every source is locked, error out — there's nothing to group.
+#[test]
+fn group_layers_errors_when_all_locked() {
+    let mut engine = test_engine(32, 32);
+    let _keep = engine.add_raster_layer(None);
+    let l1 = engine.add_raster_layer(None);
+    engine.set_node_locked(l1, true);
+
+    let result = engine.group_layers(vec![l1]);
+    assert!(result.is_err(), "all-locked selection must error");
+}
+
+/// Regression: each duplicate must land directly above its own
+/// source, NOT all stacked at the top of root. With sources [A, B, C]
+/// the final children order is [A, A_dup, B, B_dup, C, C_dup].
+#[test]
+fn multi_duplicate_each_lands_above_its_source() {
+    use darkly::engine::types::LayerInfo;
+    let mut engine = test_engine(32, 32);
+    let _keep_bottom = engine.add_raster_layer(None);
+    let a = engine.add_raster_layer(None);
+    let b = engine.add_raster_layer(None);
+    let c = engine.add_raster_layer(None);
+    engine.set_layer_name(a, "A");
+    engine.set_layer_name(b, "B");
+    engine.set_layer_name(c, "C");
+
+    let news = engine.duplicate_nodes(vec![a, b, c]);
+    assert_eq!(news.len(), 3);
+
+    // Pull the panel-order ids from the published tree. layer_tree() is
+    // top-of-stack first; reverse to read bottom-first for the children
+    // sequence we want to assert on.
+    let mut tree_ids: Vec<f64> = engine
+        .layer_tree()
+        .iter()
+        .map(|n| match n {
+            LayerInfo::Raster { id, .. } => *id,
+            LayerInfo::Void { id, .. } => *id,
+            LayerInfo::Group { id, .. } => *id,
+        })
+        .collect();
+    tree_ids.reverse();
+
+    let pos = |id: darkly::layer::LayerId| {
+        tree_ids
+            .iter()
+            .position(|&x| x == id.to_ffi() as f64)
+            .expect("in tree")
+    };
+    let (pa, pb, pc) = (pos(a), pos(b), pos(c));
+    let (pad, pbd, pcd) = (pos(news[0]), pos(news[1]), pos(news[2]));
+
+    // Each duplicate sits immediately above its own source.
+    assert_eq!(pad, pa + 1, "A_dup should be at A+1, not at the top");
+    assert_eq!(pbd, pb + 1, "B_dup should be at B+1");
+    assert_eq!(pcd, pc + 1, "C_dup should be at C+1");
+}
+
+/// Duplicating a batch returns one new id per source in matching
+/// order, and a single undo step removes them all.
+#[test]
+fn multi_duplicate_returns_new_ids_one_undo() {
+    let mut engine = test_engine(64, 64);
+    let l1 = engine.add_raster_layer(None);
+    let l2 = engine.add_raster_layer(None);
+
+    let news = engine.duplicate_nodes(vec![l1, l2]);
+    assert_eq!(news.len(), 2);
+    for new in &news {
+        assert!(engine.has_layer(*new));
+    }
+
+    engine.undo();
+    engine.render(0.0);
+    for new in news {
+        assert!(
+            !engine.has_layer(new),
+            "one undo must remove every duplicate"
+        );
+    }
+}

--- a/crates/darkly/tests/layer_bake.rs
+++ b/crates/darkly/tests/layer_bake.rs
@@ -419,3 +419,166 @@ fn flatten_group_with_masks_undo_restores_tree_and_pixels() {
         "group mask pixels survive flatten+undo byte-for-byte"
     );
 }
+
+// ============================================================================
+// merge_layers — multi-source bake, same-parent and cross-parent
+// ============================================================================
+
+/// Merging a same-parent selection lands the result at the panel-topmost
+/// selected sibling's slot and inherits that sibling's name / blend /
+/// opacity / visibility.
+#[test]
+fn merge_layers_same_parent_inherits_topmost_props() {
+    use darkly::engine::types::LayerInfo;
+    let mut engine = test_engine(32, 32);
+    let _keep = engine.add_raster_layer(None);
+    let lower = engine.add_raster_layer(None);
+    let upper = engine.add_raster_layer(None);
+    // Rename the topmost so we can confirm the result inherits its name.
+    engine.set_layer_name(upper, "topmost");
+    engine.set_opacity(upper, 0.5);
+
+    paint_dot(&mut engine, lower, 8.0, 8.0, [1.0, 0.0, 0.0]);
+    paint_dot(&mut engine, upper, 16.0, 16.0, [0.0, 1.0, 0.0]);
+
+    let result = engine.merge_layers(vec![lower, upper]).expect("merge ok");
+
+    // Source layers should be detached from the tree.
+    assert!(!engine.has_layer(lower));
+    assert!(!engine.has_layer(upper));
+    assert!(engine.has_layer(result));
+
+    // Result inherits the topmost's name + opacity.
+    let info = engine
+        .layer_tree()
+        .into_iter()
+        .find(|n| match n {
+            LayerInfo::Raster { id, .. } => *id == result.to_ffi() as f64,
+            _ => false,
+        })
+        .expect("result in tree");
+    let (name, opacity) = match info {
+        LayerInfo::Raster { name, opacity, .. } => (name, opacity),
+        _ => panic!(),
+    };
+    assert_eq!(name, "topmost");
+    assert!((opacity - 0.5).abs() < 1e-3, "opacity inherited: {opacity}");
+}
+
+/// A cross-parent selection (one layer at root, one inside a group)
+/// merges successfully: result lands at the topmost selected layer's
+/// slot, and all sources are detached.
+#[test]
+fn merge_layers_cross_parent_lands_at_topmost() {
+    use darkly::document::MoveTarget;
+    use darkly::engine::types::LayerInfo;
+    let mut engine = test_engine(32, 32);
+    let _keep = engine.add_raster_layer(None);
+    // Build [keep, in_group_via_group, group(inner), root_top].
+    let group = engine.add_group(None);
+    let inner = engine.add_raster_layer(None);
+    engine.move_layer(inner, MoveTarget::IntoGroupTop(group));
+    let root_top = engine.add_raster_layer(None);
+    engine.set_layer_name(root_top, "expected-topmost");
+
+    paint_dot(&mut engine, inner, 8.0, 8.0, [1.0, 0.0, 0.0]);
+    paint_dot(&mut engine, root_top, 16.0, 16.0, [0.0, 0.0, 1.0]);
+
+    let result = engine
+        .merge_layers(vec![inner, root_top])
+        .expect("cross-parent merge ok");
+
+    assert!(!engine.has_layer(inner), "inner source detached");
+    assert!(!engine.has_layer(root_top), "root_top source detached");
+    assert!(engine.has_layer(result));
+
+    // Result inherits root_top's name (root_top is the panel-topmost of
+    // the selection: it's the LAST entry of all_node_ids_in_order that
+    // matches an id in the selection).
+    let info = engine
+        .layer_tree()
+        .into_iter()
+        .find(|n| match n {
+            LayerInfo::Raster { id, .. } => *id == result.to_ffi() as f64,
+            _ => false,
+        })
+        .expect("result in tree");
+    let name = match info {
+        LayerInfo::Raster { name, .. } => name,
+        _ => panic!(),
+    };
+    assert_eq!(name, "expected-topmost");
+}
+
+/// A single undo step restores all merged sources, even when they
+/// straddle different parent groups.
+#[test]
+fn merge_layers_undo_restores_all_sources() {
+    use darkly::document::MoveTarget;
+    let mut engine = test_engine(32, 32);
+    let _keep = engine.add_raster_layer(None);
+    let group = engine.add_group(None);
+    let inner = engine.add_raster_layer(None);
+    engine.move_layer(inner, MoveTarget::IntoGroupTop(group));
+    let root_top = engine.add_raster_layer(None);
+
+    paint_dot(&mut engine, inner, 8.0, 8.0, [1.0, 0.0, 0.0]);
+    paint_dot(&mut engine, root_top, 16.0, 16.0, [0.0, 0.0, 1.0]);
+
+    let inner_before = engine.test_readback_layer(inner);
+    let root_top_before = engine.test_readback_layer(root_top);
+
+    let result = engine
+        .merge_layers(vec![inner, root_top])
+        .expect("merge ok");
+    assert!(engine.has_layer(result));
+    assert!(!engine.has_layer(inner));
+    assert!(!engine.has_layer(root_top));
+
+    engine.undo();
+    engine.render(0.0);
+
+    assert!(engine.has_layer(inner), "inner source restored");
+    assert!(engine.has_layer(root_top), "root_top source restored");
+    assert!(!engine.has_layer(result), "result removed by undo");
+    assert_eq!(
+        engine.test_readback_layer(inner),
+        inner_before,
+        "inner pixels restored byte-for-byte"
+    );
+    assert_eq!(
+        engine.test_readback_layer(root_top),
+        root_top_before,
+        "root_top pixels restored byte-for-byte"
+    );
+}
+
+/// `merge_layers` aborts if any source is locked — a partial bake
+/// would destroy the user's data.
+#[test]
+fn merge_layers_rejects_locked() {
+    let mut engine = test_engine(32, 32);
+    let _keep = engine.add_raster_layer(None);
+    let l1 = engine.add_raster_layer(None);
+    let l2 = engine.add_raster_layer(None);
+    engine.set_node_locked(l1, true);
+
+    let result = engine.merge_layers(vec![l1, l2]);
+    assert!(result.is_err(), "locked source must reject the merge");
+    assert!(engine.has_layer(l1));
+    assert!(engine.has_layer(l2));
+}
+
+/// `merge_layers` needs at least two distinct sources.
+#[test]
+fn merge_layers_needs_two_sources() {
+    let mut engine = test_engine(32, 32);
+    let _keep = engine.add_raster_layer(None);
+    let l1 = engine.add_raster_layer(None);
+
+    let r1 = engine.merge_layers(vec![l1]);
+    assert!(r1.is_err(), "single-id merge must error");
+
+    let r2 = engine.merge_layers(vec![l1, l1]);
+    assert!(r2.is_err(), "duplicate-id merge must error (dedupes to 1)");
+}

--- a/frontend/src/actions/index.ts
+++ b/frontend/src/actions/index.ts
@@ -18,6 +18,20 @@ import { detectKind, isImageKind, type FileKind } from '../storage/detectKind';
 import { saveDocument } from '../storage/saveDocument';
 import { shell } from '../multi_tab/shell.svelte';
 
+/** Walk the layer tree to find a node by id. The layer tree is the
+ *  JSON shape produced by `app.refreshLayerTree`, with `children` on
+ *  groups and `modifiers` on hosts. */
+function findNodeInTree(nodes: any[], id: number): any | null {
+    for (const n of nodes) {
+        if (n.id === id) return n;
+        if (n.children) {
+            const found = findNodeInTree(n.children, id);
+            if (found) return found;
+        }
+    }
+    return null;
+}
+
 /** Strip the file extension from a picker-supplied name so we can use
  *  it as a tab title. Matches the basename-only convention already used
  *  by Save As (which seeds `set_document_name` from the chosen filename
@@ -680,6 +694,28 @@ export function registerActions() {
             } catch (e: any) {
                 toast.show('error', e.message ?? String(e));
             }
+        },
+    });
+
+    actions.register({
+        id: 'addMask',
+        displayName: 'Add Mask',
+        category: 'layers',
+        description: 'Add a mask modifier to the active layer or group and activate it for painting.',
+        accepts: ['layerId'],
+        handler: (ctx) => {
+            if (!app.handle) return;
+            const hostId = ctx.layerId ?? app.activeLayerId;
+            if (hostId == null) return;
+            app.handle.add_mask(hostId);
+            // `add_mask` doesn't return the new modifier id, and we want
+            // the mask to be the active paint target after creation —
+            // refresh the tree, then locate the freshly-added mask
+            // modifier on the host and select it.
+            app.refreshLayerTree();
+            const layer = findNodeInTree(app.layerTree, hostId);
+            const mask = layer?.modifiers?.find((m: any) => m.kind === 'mask');
+            if (mask) app.selectLayer(mask.id);
         },
     });
 

--- a/frontend/src/actions/index.ts
+++ b/frontend/src/actions/index.ts
@@ -566,6 +566,43 @@ export function registerActions() {
 
     // -- Layers --
     actions.register({
+        id: 'newLayer',
+        displayName: 'New Layer',
+        category: 'layers',
+        description: 'Add a new layer above the active one.',
+        handler: () => {
+            if (!app.handle) return;
+            const id = app.handle.add_raster_layer(app.activeLayerId ?? -1);
+            app.selectLayer(id);
+            app.refreshLayerTree();
+        },
+    });
+
+    actions.register({
+        id: 'newGroup',
+        displayName: 'New Group',
+        category: 'layers',
+        description: 'Group the selected layers together, or add an empty group if nothing is selected.',
+        handler: () => {
+            if (!app.handle) return;
+            if (app.selectedLayerIds.size > 0) {
+                try {
+                    const groupId = app.handle.group_layers(
+                        Float64Array.from([...app.selectedLayerIds]),
+                    );
+                    if (groupId) app.selectLayer(groupId);
+                } catch (e: any) {
+                    toast.show('error', e.message ?? String(e));
+                }
+            } else {
+                const id = app.handle.add_group(app.activeLayerId ?? -1);
+                app.selectLayer(id);
+            }
+            app.refreshLayerTree();
+        },
+    });
+
+    actions.register({
         id: 'toggleVisibility',
         displayName: 'Toggle Layer Visibility',
         category: 'layers',
@@ -659,7 +696,7 @@ export function registerActions() {
         id: 'duplicateLayer',
         displayName: 'Duplicate Layer',
         category: 'layers',
-        description: 'Duplicate the selected layers; each copy lands directly above its original.',
+        description: 'Make a copy of each selected layer.',
         handler: () => {
             if (!app.handle) return;
             const targets = app.selectedLayerIds.size > 0
@@ -684,34 +721,25 @@ export function registerActions() {
         id: 'mergeDown',
         displayName: 'Merge Down',
         category: 'layers',
-        description: 'Merge the active layer or group into the layer below it.',
+        description: 'Merge the active layer into the one below it, or combine multiple selected layers into a single layer.',
         handler: () => {
             if (!app.handle) return;
-            // Single-layer merge_down: merges with the sibling below. The
-            // menu item routes here only when the selection size is 1.
+            if (app.selectedLayerIds.size >= 2) {
+                try {
+                    const newId = app.handle.merge_layers(
+                        Float64Array.from([...app.selectedLayerIds]),
+                    );
+                    app.refreshLayerTree();
+                    if (newId) app.selectLayer(newId);
+                } catch (e: any) {
+                    toast.show('error', e.message ?? String(e));
+                }
+                return;
+            }
             const sourceId = app.activeLayerId;
             if (sourceId == null) return;
             try {
                 const newId = app.handle.merge_down(sourceId);
-                app.refreshLayerTree();
-                if (newId) app.selectLayer(newId);
-            } catch (e: any) {
-                toast.show('error', e.message ?? String(e));
-            }
-        },
-    });
-
-    actions.register({
-        id: 'mergeSelected',
-        displayName: 'Merge Selected Layers',
-        category: 'layers',
-        description: 'Bake every selected layer into a single raster at the panel-topmost selection slot. Cross-parent selections are supported.',
-        handler: () => {
-            if (!app.handle) return;
-            const targets = [...app.selectedLayerIds];
-            if (targets.length < 2) return;
-            try {
-                const newId = app.handle.merge_layers(Float64Array.from(targets));
                 app.refreshLayerTree();
                 if (newId) app.selectLayer(newId);
             } catch (e: any) {

--- a/frontend/src/actions/index.ts
+++ b/frontend/src/actions/index.ts
@@ -612,9 +612,8 @@ export function registerActions() {
         id: 'deleteLayer',
         displayName: 'Delete Layer',
         category: 'layers',
-        description: 'Delete the active layer (or remove the active veil).',
-        accepts: ['layerId'],
-        handler: (ctx) => {
+        description: 'Delete the selected layers (or remove the active veil).',
+        handler: () => {
             if (!app.handle) return;
             // Veil takes priority: the trash button on the layer panel
             // doubles as veil-remove when a veil is active, so the
@@ -623,16 +622,32 @@ export function registerActions() {
                 app.removeVeil(app.activeVeilIndex);
                 return;
             }
-            const layerId = ctx.layerId ?? app.activeLayerId;
-            if (layerId == null) return;
+            // Structural rule: operate on the current selection. The
+            // right-click handler ensures the clicked row is in the
+            // selection BEFORE the menu opens, so reading from
+            // `app.selectedLayerIds` here picks up exactly what the user
+            // expects. We do NOT accept a `ctx.layerId` override — the
+            // v1 attempt did, and that's what made "Delete N Layers" act
+            // on just one layer.
+            const targets = app.selectedLayerIds.size > 0
+                ? [...app.selectedLayerIds]
+                : app.activeLayerId !== null ? [app.activeLayerId] : [];
+            if (targets.length === 0) return;
             try {
-                // Stop any associated camera MediaStream before the layer is
-                // gone. `refreshLayerTree` does the same reaping as a safety
-                // net (covers undo), but stopping eagerly turns off the
-                // browser's camera-in-use indicator immediately.
-                app.stopCameraVoid(layerId);
-                app.handle.remove_layer(layerId);
-                app.clearSelection();
+                // Stop any associated camera MediaStreams before the
+                // layers go away. `refreshLayerTree` reaps as a safety
+                // net, but stopping eagerly turns off the OS camera
+                // indicator immediately.
+                for (const id of targets) app.stopCameraVoid(id);
+                if (targets.length === 1) {
+                    app.handle.remove_layer(targets[0]);
+                    app.clearSelection();
+                } else {
+                    const skipped = app.handle.remove_layers(Float64Array.from(targets));
+                    if (skipped > 0) {
+                        toast.show('info', `${skipped} locked layer${skipped === 1 ? '' : 's'} skipped`);
+                    }
+                }
                 app.refreshLayerTree();
             } catch (e: any) {
                 toast.show('error', e.message ?? String(e));
@@ -644,15 +659,24 @@ export function registerActions() {
         id: 'duplicateLayer',
         displayName: 'Duplicate Layer',
         category: 'layers',
-        description: 'Make a copy of the active layer or group directly above it.',
-        accepts: ['layerId'],
-        handler: (ctx) => {
+        description: 'Duplicate the selected layers; each copy lands directly above its original.',
+        handler: () => {
             if (!app.handle) return;
-            const sourceId = ctx.layerId ?? app.activeLayerId;
-            if (sourceId == null) return;
-            const newId = app.handle.duplicate_node(sourceId);
-            app.refreshLayerTree();
-            if (newId) app.selectLayer(newId);
+            const targets = app.selectedLayerIds.size > 0
+                ? [...app.selectedLayerIds]
+                : app.activeLayerId !== null ? [app.activeLayerId] : [];
+            if (targets.length === 0) return;
+            if (targets.length === 1) {
+                const newId = app.handle.duplicate_node(targets[0]);
+                app.refreshLayerTree();
+                if (newId) app.selectLayer(newId);
+            } else {
+                const newIds = Array.from(
+                    app.handle.duplicate_nodes(Float64Array.from(targets)),
+                );
+                app.refreshLayerTree();
+                if (newIds.length > 0) app.selectLayers(newIds);
+            }
         },
     });
 
@@ -661,13 +685,33 @@ export function registerActions() {
         displayName: 'Merge Down',
         category: 'layers',
         description: 'Merge the active layer or group into the layer below it.',
-        accepts: ['layerId'],
-        handler: (ctx) => {
+        handler: () => {
             if (!app.handle) return;
-            const sourceId = ctx.layerId ?? app.activeLayerId;
+            // Single-layer merge_down: merges with the sibling below. The
+            // menu item routes here only when the selection size is 1.
+            const sourceId = app.activeLayerId;
             if (sourceId == null) return;
             try {
                 const newId = app.handle.merge_down(sourceId);
+                app.refreshLayerTree();
+                if (newId) app.selectLayer(newId);
+            } catch (e: any) {
+                toast.show('error', e.message ?? String(e));
+            }
+        },
+    });
+
+    actions.register({
+        id: 'mergeSelected',
+        displayName: 'Merge Selected Layers',
+        category: 'layers',
+        description: 'Bake every selected layer into a single raster at the panel-topmost selection slot. Cross-parent selections are supported.',
+        handler: () => {
+            if (!app.handle) return;
+            const targets = [...app.selectedLayerIds];
+            if (targets.length < 2) return;
+            try {
+                const newId = app.handle.merge_layers(Float64Array.from(targets));
                 app.refreshLayerTree();
                 if (newId) app.selectLayer(newId);
             } catch (e: any) {

--- a/frontend/src/editor.ts
+++ b/frontend/src/editor.ts
@@ -103,7 +103,7 @@ export async function createInstance(
     if (options.seedBackground) {
         const bg = handle.add_raster_layer(-1);
         handle.fill_background(bg);
-        instance.activeLayerId = bg;
+        instance.selectLayer(bg);
     }
 
     instance.canvasEl = canvas;

--- a/frontend/src/state/__tests__/selection.test.ts
+++ b/frontend/src/state/__tests__/selection.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DarklyInstance } from '../app.svelte';
+
+// Build a 3-level tree the selection methods will walk:
+//   root
+//     groupA (collapsed=false)
+//       l1
+//       l2
+//     l3
+//     groupB (collapsed=true)
+//       l4    ← hidden from flattenedVisibleIds
+function buildTree() {
+    return [
+        {
+            type: 'group', id: 100, name: 'A', visible: true, collapsed: false,
+            children: [
+                { type: 'raster', id: 1, name: 'l1', visible: true, modifiers: [] },
+                { type: 'raster', id: 2, name: 'l2', visible: true, modifiers: [] },
+            ],
+            modifiers: [],
+        },
+        { type: 'raster', id: 3, name: 'l3', visible: true, modifiers: [] },
+        {
+            type: 'group', id: 200, name: 'B', visible: true, collapsed: true,
+            children: [
+                { type: 'raster', id: 4, name: 'l4', visible: true, modifiers: [] },
+            ],
+            modifiers: [],
+        },
+    ];
+}
+
+let inst: DarklyInstance;
+beforeEach(() => {
+    inst = new DarklyInstance();
+    inst.layerTree = buildTree();
+});
+
+describe('plain selectLayer', () => {
+    it('replaces the selection set with one id', () => {
+        inst.selectLayer(1);
+        expect(inst.activeLayerId).toBe(1);
+        expect([...inst.selectedLayerIds]).toEqual([1]);
+
+        inst.selectLayer(3);
+        expect(inst.activeLayerId).toBe(3);
+        expect([...inst.selectedLayerIds]).toEqual([3]);
+    });
+
+    it('clears selection when id is null', () => {
+        inst.selectLayer(1);
+        inst.selectLayer(null);
+        expect(inst.activeLayerId).toBeNull();
+        expect(inst.selectedLayerIds.size).toBe(0);
+    });
+});
+
+describe('ctrl-click (toggleLayer)', () => {
+    it('adds an id and makes it active', () => {
+        inst.selectLayer(1);
+        inst.toggleLayer(3);
+        expect(inst.activeLayerId).toBe(3);
+        expect([...inst.selectedLayerIds].sort()).toEqual([1, 3]);
+    });
+
+    it('removes an id; non-active removal keeps the active id', () => {
+        inst.selectLayer(1);
+        inst.toggleLayer(3);
+        // now selected={1,3}, active=3
+        inst.toggleLayer(1);
+        // removed non-active id (1)
+        expect(inst.activeLayerId).toBe(3);
+        expect([...inst.selectedLayerIds]).toEqual([3]);
+    });
+
+    it('removing the active id demotes to the next selected in tree order', () => {
+        inst.selectLayer(1);
+        inst.toggleLayer(2);
+        inst.toggleLayer(3);
+        // selected={1,2,3}, active=3
+        inst.toggleLayer(3);
+        // active was 3; should demote to one of {1,2}. Tree order visits 1
+        // before 2, so the replacement is 1.
+        expect([...inst.selectedLayerIds].sort()).toEqual([1, 2]);
+        expect(inst.activeLayerId).toBe(1);
+    });
+
+    it('removing the only selected id clears active to null', () => {
+        inst.selectLayer(1);
+        inst.toggleLayer(1);
+        expect(inst.activeLayerId).toBeNull();
+        expect(inst.selectedLayerIds.size).toBe(0);
+    });
+
+    it('adds to an empty set as a plain select', () => {
+        inst.toggleLayer(2);
+        expect(inst.activeLayerId).toBe(2);
+        expect([...inst.selectedLayerIds]).toEqual([2]);
+    });
+});
+
+describe('shift-click (extendSelectionTo)', () => {
+    it('degenerates to plain select when there is no anchor', () => {
+        // No active layer → no anchor → behaves like selectLayer
+        inst.extendSelectionTo(2);
+        expect(inst.activeLayerId).toBe(2);
+        expect([...inst.selectedLayerIds]).toEqual([2]);
+    });
+
+    it('selects the inclusive range from anchor to target in tree order', () => {
+        inst.selectLayer(1);
+        inst.extendSelectionTo(3);
+        // Tree-visible order: [100, 1, 2, 3, 200] (collapsed B hides l4).
+        // anchor=1 (idx 1), target=3 (idx 3) → range = [1, 2, 3].
+        expect([...inst.selectedLayerIds].sort((a, b) => a - b)).toEqual([1, 2, 3]);
+        expect(inst.activeLayerId).toBe(3);
+    });
+
+    it('handles the reverse direction (target above anchor)', () => {
+        inst.selectLayer(3);
+        inst.extendSelectionTo(1);
+        // Range from 3 down to 1 in tree order — same set, just clicked backwards.
+        expect([...inst.selectedLayerIds].sort((a, b) => a - b)).toEqual([1, 2, 3]);
+        expect(inst.activeLayerId).toBe(1);
+    });
+
+    it('skips children of collapsed groups', () => {
+        inst.selectLayer(1);
+        // Try extending to l4, which lives inside the collapsed group B.
+        // l4 is not in flattenedVisibleIds, so the range falls back to
+        // selectLayer(4). The selection becomes just {4}.
+        inst.extendSelectionTo(4);
+        expect([...inst.selectedLayerIds]).toEqual([4]);
+        expect(inst.activeLayerId).toBe(4);
+    });
+});
+
+describe('isSelected', () => {
+    it('returns membership in the selection set', () => {
+        inst.selectLayer(1);
+        inst.toggleLayer(3);
+        expect(inst.isSelected(1)).toBe(true);
+        expect(inst.isSelected(3)).toBe(true);
+        expect(inst.isSelected(2)).toBe(false);
+    });
+});
+
+describe('handleLayerRowClick router', () => {
+    it('plain click → selectLayer', () => {
+        const e = { shiftKey: false, ctrlKey: false, metaKey: false } as MouseEvent;
+        inst.handleLayerRowClick(2, e);
+        expect([...inst.selectedLayerIds]).toEqual([2]);
+        expect(inst.activeLayerId).toBe(2);
+    });
+
+    it('ctrl-click → toggleLayer', () => {
+        inst.selectLayer(1);
+        const e = { shiftKey: false, ctrlKey: true, metaKey: false } as MouseEvent;
+        inst.handleLayerRowClick(3, e);
+        expect([...inst.selectedLayerIds].sort()).toEqual([1, 3]);
+        expect(inst.activeLayerId).toBe(3);
+    });
+
+    it('shift-click → extendSelectionTo', () => {
+        inst.selectLayer(1);
+        const e = { shiftKey: true, ctrlKey: false, metaKey: false } as MouseEvent;
+        inst.handleLayerRowClick(3, e);
+        expect([...inst.selectedLayerIds].sort((a, b) => a - b)).toEqual([1, 2, 3]);
+    });
+});
+
+describe('selectLayers (replace with N)', () => {
+    it('sets the selection to the given ids and makes the last one active', () => {
+        inst.selectLayers([1, 2, 3]);
+        expect([...inst.selectedLayerIds].sort((a, b) => a - b)).toEqual([1, 2, 3]);
+        expect(inst.activeLayerId).toBe(3);
+    });
+
+    it('empty input clears selection', () => {
+        inst.selectLayer(1);
+        inst.selectLayers([]);
+        expect(inst.selectedLayerIds.size).toBe(0);
+        expect(inst.activeLayerId).toBeNull();
+    });
+});

--- a/frontend/src/state/app.svelte.ts
+++ b/frontend/src/state/app.svelte.ts
@@ -149,8 +149,16 @@ export class DarklyInstance {
         this.requestFrame();
     }
 
-    // Active layer
+    // Active layer — the "primary" layer within the selection. Drives the
+    // properties panel, paint target, shift-click anchor, and per-row
+    // emphasis. Always a member of `selectedLayerIds` when that set is
+    // non-empty; null iff the set is empty.
     activeLayerId = $state<number | null>(null);
+
+    // Multi-selection set. Membership is mutated only via `selectLayer`,
+    // `toggleLayer`, `extendSelectionTo`, `selectLayers`, and
+    // `clearSelection` so the invariant with `activeLayerId` holds.
+    selectedLayerIds = $state<Set<number>>(new Set());
 
     // Active veil. Mutually exclusive with activeLayerId — the right
     // sidebar's properties pane shows the props of whichever is non-null.
@@ -213,16 +221,175 @@ export class DarklyInstance {
             this.requestFrame();
         }
         this.activeLayerId = id;
+        this.selectedLayerIds = id === null ? new Set() : new Set([id]);
         this.activeVeilIndex = null;
+    }
+
+    /** Ctrl/Cmd-click router. Adds `id` if absent, removes if present.
+     *  When removing the active id, demotes `activeLayerId` to the next
+     *  remaining selected id in panel order (or null when empty). */
+    toggleLayer(id: number) {
+        const next = new Set(this.selectedLayerIds);
+        if (next.has(id)) {
+            next.delete(id);
+            if (this.activeLayerId === id) {
+                this.activeLayerId = this.firstInTreeOrder(next);
+            }
+            this.selectedLayerIds = next;
+        } else {
+            next.add(id);
+            this.selectedLayerIds = next;
+            this.activeLayerId = id;
+        }
+        this.activeVeilIndex = null;
+    }
+
+    /** Shift-click router. Selects the inclusive range from the current
+     *  active layer (anchor) to `id` in panel order. With no anchor,
+     *  degenerates to a plain select. */
+    extendSelectionTo(id: number) {
+        if (this.activeLayerId === null) {
+            this.selectLayer(id);
+            return;
+        }
+        const order = this.flattenedVisibleIds();
+        const anchorIdx = order.indexOf(this.activeLayerId);
+        const targetIdx = order.indexOf(id);
+        if (anchorIdx < 0 || targetIdx < 0) {
+            this.selectLayer(id);
+            return;
+        }
+        const [lo, hi] = anchorIdx <= targetIdx
+            ? [anchorIdx, targetIdx]
+            : [targetIdx, anchorIdx];
+        this.selectedLayerIds = new Set(order.slice(lo, hi + 1));
+        // Active follows the click so subsequent shift-clicks extend from
+        // where the user is currently pointing — standard Photoshop.
+        this.activeLayerId = id;
+        this.activeVeilIndex = null;
+    }
+
+    /** Replace the multi-selection with `ids`. The last id becomes
+     *  active (matches plain-click semantics: focus follows the most
+     *  recent touch). Used by batch ops like duplicate that want the
+     *  user to land on the freshly-created layers. */
+    selectLayers(ids: number[]) {
+        if (ids.length === 0) {
+            this.clearSelection();
+            return;
+        }
+        if (this.isolatedNodeId !== null) {
+            this.handle?.set_isolated_node(0);
+            this.isolatedNodeId = null;
+            this.requestFrame();
+        }
+        this.selectedLayerIds = new Set(ids);
+        this.activeLayerId = ids[ids.length - 1];
+        this.activeVeilIndex = null;
+    }
+
+    /** True iff `id` is in the multi-selection. */
+    isSelected(id: number): boolean {
+        return this.selectedLayerIds.has(id);
+    }
+
+    /** Layer-panel row click router. Plain → select, ctrl/cmd → toggle,
+     *  shift → extend range. Both LayerItem and LayerGroup call this so
+     *  the modifier handling stays in one place. */
+    handleLayerRowClick(id: number, e: MouseEvent) {
+        if (e.shiftKey) this.extendSelectionTo(id);
+        else if (e.ctrlKey || e.metaKey) this.toggleLayer(id);
+        else this.selectLayer(id);
+    }
+
+    /** Walk the visible tree depth-first, returning every clickable node
+     *  id in panel-top-to-panel-bottom order. Children of collapsed
+     *  groups are skipped (the user can't see them, so shift-click
+     *  shouldn't reach them). */
+    private flattenedVisibleIds(): number[] {
+        const out: number[] = [];
+        const walk = (nodes: any[]) => {
+            for (const n of nodes) {
+                if (n?.id === undefined) continue;
+                out.push(n.id);
+                if (n.type === 'group' && !n.collapsed && Array.isArray(n.children)) {
+                    walk(n.children);
+                }
+            }
+        };
+        walk(this.layerTree);
+        return out;
+    }
+
+    /** Pick the first id in `set` that appears in panel order. Returns
+     *  null when the set is empty or none of its ids are still in the
+     *  tree. Caller is the active-layer demotion path for ctrl-click. */
+    private firstInTreeOrder(set: Set<number>): number | null {
+        if (set.size === 0) return null;
+        for (const id of this.flattenedVisibleIds()) {
+            if (set.has(id)) return id;
+        }
+        return null;
+    }
+
+    /** Reconcile `selectedLayerIds` and `activeLayerId` against the latest
+     *  layer tree. Ids that no longer exist (deleted, undone, replaced by a
+     *  bake result, etc.) drop out; if the active id disappeared, demote
+     *  to the next remaining selected id in panel order or null. Called
+     *  from `refreshLayerTree` so batch-delete / undo / cross-tab swap
+     *  fallout is handled in one place.
+     *
+     *  Takes the tree as a parameter (rather than reading `this.layerTree`)
+     *  so this code path stays write-only on `layerTree` — reading it here
+     *  would tie the LayerPanel's `$effect` to the very state the method
+     *  just wrote, looping Svelte's update guard. Same pattern as
+     *  `reconcileCameraSources(next)`. */
+    private pruneSelectionAgainstTree(tree: any[]) {
+        const alive = new Set<number>();
+        const visibleOrder: number[] = [];
+        const walk = (nodes: any[]) => {
+            for (const n of nodes) {
+                if (n?.id === undefined) continue;
+                alive.add(n.id);
+                visibleOrder.push(n.id);
+                if (Array.isArray(n.modifiers)) {
+                    for (const m of n.modifiers) {
+                        if (m?.id !== undefined) alive.add(m.id);
+                    }
+                }
+                if (n.type === 'group' && !n.collapsed && Array.isArray(n.children)) {
+                    walk(n.children);
+                }
+            }
+        };
+        walk(tree);
+
+        let mutated = false;
+        const nextSelected = new Set<number>();
+        for (const id of this.selectedLayerIds) {
+            if (alive.has(id)) nextSelected.add(id);
+            else mutated = true;
+        }
+        if (mutated) this.selectedLayerIds = nextSelected;
+
+        if (this.activeLayerId !== null && !alive.has(this.activeLayerId)) {
+            let replacement: number | null = null;
+            for (const id of visibleOrder) {
+                if (nextSelected.has(id)) { replacement = id; break; }
+            }
+            this.activeLayerId = replacement;
+        }
     }
 
     selectVeil(index: number | null) {
         this.activeVeilIndex = index;
         this.activeLayerId = null;
+        this.selectedLayerIds = new Set();
     }
 
     clearSelection() {
         this.activeLayerId = null;
+        this.selectedLayerIds = new Set();
         this.activeVeilIndex = null;
     }
 
@@ -446,6 +613,7 @@ export class DarklyInstance {
             // enclosing effect's dependency set — otherwise the write loops
             // back through the effect.
             this.reconcileCameraSources(next);
+            this.pruneSelectionAgainstTree(next);
             this.layerTree = next;
             // Schedule a render frame: callers invoke this after layer
             // mutations (undo/redo, add/remove, drag/drop, etc.), and

--- a/frontend/src/ui/NewDocumentModal.svelte
+++ b/frontend/src/ui/NewDocumentModal.svelte
@@ -91,7 +91,7 @@
         inst.onHandleReady = (handle) => {
             const bg = handle.add_raster_layer(-1);
             handle.fill_background_color(bg, new Uint8Array(rgba));
-            inst.activeLayerId = bg;
+            inst.selectLayer(bg);
             app.refreshLayerTree();
             app.requestFrame();
         };
@@ -114,7 +114,7 @@
             const inst = shell.open(undefined, { width: w, height: h });
             inst.onHandleReady = (handle) => {
                 const bg = handle.paste_image(w, h, clip.rgba, 0, 0, -1);
-                inst.activeLayerId = bg;
+                inst.selectLayer(bg);
                 app.refreshLayerTree();
                 app.requestFrame();
             };

--- a/frontend/src/ui/layers/LayerFooter.svelte
+++ b/frontend/src/ui/layers/LayerFooter.svelte
@@ -70,17 +70,9 @@
     });
 
     function addMask() {
-        if (!app.handle || app.activeLayerId === null) return;
         if (!canAddMask) return;
-        const hostId = app.activeLayerId;
-        app.handle.add_mask(hostId);
-        // After add_mask the host gains a mask modifier; refresh tree, then
-        // activate the modifier id (the new paint target) so strokes land
-        // on the mask without a session redirect.
+        actions.dispatch('addMask');
         onupdate();
-        const layer = findNode(app.layerTree, hostId);
-        const mask = layer?.modifiers?.find((m: any) => m.kind === 'mask');
-        if (mask) app.selectLayer(mask.id);
     }
 
     let canDelete = $derived(

--- a/frontend/src/ui/layers/LayerFooter.svelte
+++ b/frontend/src/ui/layers/LayerFooter.svelte
@@ -5,7 +5,6 @@
     import VoidPickerModal from '../voids/VoidPickerModal.svelte';
     import { actions } from '../../actions/registry';
     import { tooltipForAction } from '../../config/store.svelte';
-    import { toast } from '../../state/toast.svelte';
 
     let { onupdate }: { onupdate: () => void } = $props();
 
@@ -25,33 +24,17 @@
     }
 
 
+    // The new-layer / new-group footer buttons route through the action
+    // registry so their tooltips can surface the bound hotkey (resolved
+    // via `tooltipForAction`). The selection-aware "wrap or empty group"
+    // logic lives on the action handler in actions/index.ts.
     function addNormalLayer() {
-        if (!app.handle) return;
-        const id = app.handle.add_raster_layer(app.activeLayerId ?? -1);
-        app.selectLayer(id);
+        actions.dispatch('newLayer');
         onupdate();
     }
 
     function addGroup() {
-        if (!app.handle) return;
-        // With layers selected, wrap them in a new group at the panel-
-        // topmost selected layer's slot. With nothing selected, fall
-        // back to the legacy "empty group at the active layer's anchor"
-        // behavior so the gesture still works in an empty / unfocused
-        // panel.
-        if (app.selectedLayerIds.size > 0) {
-            try {
-                const groupId = app.handle.group_layers(
-                    Float64Array.from([...app.selectedLayerIds]),
-                );
-                if (groupId) app.selectLayer(groupId);
-            } catch (e: any) {
-                toast.show('error', e.message ?? String(e));
-            }
-        } else {
-            const id = app.handle.add_group(app.activeLayerId ?? -1);
-            app.selectLayer(id);
-        }
+        actions.dispatch('newGroup');
         onupdate();
     }
 

--- a/frontend/src/ui/layers/LayerFooter.svelte
+++ b/frontend/src/ui/layers/LayerFooter.svelte
@@ -5,6 +5,7 @@
     import VoidPickerModal from '../voids/VoidPickerModal.svelte';
     import { actions } from '../../actions/registry';
     import { tooltipForAction } from '../../config/store.svelte';
+    import { toast } from '../../state/toast.svelte';
 
     let { onupdate }: { onupdate: () => void } = $props();
 
@@ -33,8 +34,24 @@
 
     function addGroup() {
         if (!app.handle) return;
-        const id = app.handle.add_group(app.activeLayerId ?? -1);
-        app.selectLayer(id);
+        // With layers selected, wrap them in a new group at the panel-
+        // topmost selected layer's slot. With nothing selected, fall
+        // back to the legacy "empty group at the active layer's anchor"
+        // behavior so the gesture still works in an empty / unfocused
+        // panel.
+        if (app.selectedLayerIds.size > 0) {
+            try {
+                const groupId = app.handle.group_layers(
+                    Float64Array.from([...app.selectedLayerIds]),
+                );
+                if (groupId) app.selectLayer(groupId);
+            } catch (e: any) {
+                toast.show('error', e.message ?? String(e));
+            }
+        } else {
+            const id = app.handle.add_group(app.activeLayerId ?? -1);
+            app.selectLayer(id);
+        }
         onupdate();
     }
 
@@ -83,6 +100,22 @@
     let canDuplicate = $derived(
         app.activeLayerId !== null
             && findNode(app.layerTree, app.activeLayerId) !== null,
+    );
+
+    // Show the multi-selection count in the footer button tooltips so
+    // the user has a heads-up that the trash/duplicate buttons will
+    // operate on the whole selection, not just the active layer.
+    let selectionSize = $derived(app.selectedLayerIds.size);
+    let isMulti = $derived(selectionSize > 1);
+    let deleteTooltip = $derived(
+        isMulti
+            ? `Delete (${selectionSize})`
+            : tooltipForAction('Delete', 'deleteLayer'),
+    );
+    let duplicateTooltip = $derived(
+        isMulti
+            ? `Duplicate (${selectionSize})`
+            : tooltipForAction('Duplicate', 'duplicateLayer'),
     );
 
     function remove() {
@@ -136,7 +169,7 @@
         class="footer-btn"
         onclick={duplicate}
         disabled={!canDuplicate}
-        title={tooltipForAction('Duplicate', 'duplicateLayer')}
+        title={duplicateTooltip}
     >
         <i class="fa-solid fa-clone"></i>
     </button>
@@ -145,7 +178,7 @@
         class="footer-btn danger"
         onclick={remove}
         disabled={!canDelete || (app.activeVeilIndex === null && !activeEditable)}
-        title={tooltipForAction('Delete', 'deleteLayer')}
+        title={deleteTooltip}
     >
         <i class="fa-solid fa-trash"></i>
     </button>

--- a/frontend/src/ui/layers/LayerGroup.svelte
+++ b/frontend/src/ui/layers/LayerGroup.svelte
@@ -74,6 +74,8 @@
         return siblingBelowExists(app.layerTree, group.id);
     });
 
+    let canAddMask = $derived(!hasMask && editable);
+
     // Chord dispatch is owned by `use:bindingSite` on each preview element
     // below — `bindingSite` intercepts modifier+click in capture phase
     // and dispatches against its named site. These onclick handlers are
@@ -160,6 +162,18 @@
 
     function menuFlatten() {
         actions.dispatch('flatten', { layerId: group.id });
+        onupdate();
+    }
+
+    function menuAddMask() {
+        if (!canAddMask) return;
+        actions.dispatch('addMask', { layerId: group.id });
+        onupdate();
+    }
+
+    function menuDelete() {
+        if (!editable) return;
+        actions.dispatch('deleteLayer', { layerId: group.id });
         onupdate();
     }
 
@@ -332,10 +346,17 @@
     <div class="layer-menu" style:left="{layerMenuX}px" style:top="{layerMenuY}px">
         <!-- Duplicate doesn't mutate the locked node — allowed. -->
         <button onclick={menuDuplicate}>Duplicate group</button>
+        <button onclick={menuAddMask} disabled={!canAddMask}>
+            Add mask
+        </button>
         <button onclick={menuMergeDown} disabled={!canMergeDownForThis || !editable}>
             Merge down
         </button>
         <button onclick={menuFlatten} disabled={!editable}>Flatten</button>
+        <div class="layer-menu-sep"></div>
+        <button onclick={menuDelete} disabled={!editable}>
+            Delete group
+        </button>
     </div>
 {/if}
 
@@ -547,5 +568,11 @@
     .layer-menu button:disabled {
         color: var(--text-dim);
         cursor: default;
+    }
+
+    .layer-menu-sep {
+        height: 1px;
+        background: var(--bg-hover);
+        margin: 4px 0;
     }
 </style>

--- a/frontend/src/ui/layers/LayerGroup.svelte
+++ b/frontend/src/ui/layers/LayerGroup.svelte
@@ -4,6 +4,7 @@
     import { actions } from '../../actions/registry';
     import { bindingSite } from '../../actions/binding_site';
     import { tooltipForAction } from '../../config/store.svelte';
+    import { toast } from '../../state/toast.svelte';
     import LayerItem from './LayerItem.svelte';
     import LayerGroup from './LayerGroup.svelte';
 
@@ -38,6 +39,12 @@
     );
 
     let isActive = $derived(app.activeLayerId === group.id);
+    let isSelected = $derived(app.isSelected(group.id));
+    let selectionSize = $derived(app.selectedLayerIds.size);
+    let isMulti = $derived(selectionSize > 1);
+    let deleteLabel = $derived(isMulti ? `Delete ${selectionSize} Layers` : 'Delete Group');
+    let dupLabel = $derived(isMulti ? `Duplicate ${selectionSize} Layers` : 'Duplicate Group');
+    let mergeLabel = $derived(isMulti ? `Merge ${selectionSize} Layers` : 'Merge Down');
     let isEditingMask = $derived(
         maskModifier !== null && app.activeLayerId === maskModifier.id,
     );
@@ -100,10 +107,11 @@
         }
     }
 
-    function onLayerClick() {
+    function onLayerClick(e: MouseEvent) {
         // The group-header body has no bindings — modifier+click is
-        // reserved for the previews. Plain click selects.
-        app.selectLayer(group.id);
+        // reserved for the previews. Plain / ctrl / shift dispatch is
+        // shared with LayerItem via app.handleLayerRowClick.
+        app.handleLayerRowClick(group.id, e);
     }
 
     function startRename() {
@@ -141,7 +149,12 @@
     function onLayerContextMenu(e: MouseEvent) {
         e.preventDefault();
         e.stopPropagation();
-        app.selectLayer(group.id);
+        // Mirror LayerItem: only replace the selection if the right-
+        // clicked row isn't already part of it. Otherwise the menu
+        // operates on the whole selected set.
+        if (!app.isSelected(group.id)) {
+            app.selectLayer(group.id);
+        }
         layerMenuX = e.clientX;
         layerMenuY = e.clientY;
         showLayerMenu = true;
@@ -149,31 +162,39 @@
         requestAnimationFrame(() => document.addEventListener('click', close));
     }
 
+    // Structural menu items dispatch WITHOUT `ctx.layerId` — the action
+    // handler reads `app.selectedLayerIds` directly. See LayerItem.svelte
+    // for the same pattern and the rationale.
+
     function menuDuplicate() {
-        actions.dispatch('duplicateLayer', { layerId: group.id });
+        actions.dispatch('duplicateLayer');
         onupdate();
     }
 
-    function menuMergeDown() {
-        if (!canMergeDownForThis) return;
-        actions.dispatch('mergeDown', { layerId: group.id });
+    function menuMerge() {
+        if (isMulti) {
+            actions.dispatch('mergeSelected');
+        } else {
+            if (!canMergeDownForThis) return;
+            actions.dispatch('mergeDown');
+        }
         onupdate();
     }
 
     function menuFlatten() {
-        actions.dispatch('flatten', { layerId: group.id });
+        actions.dispatch('flatten');
         onupdate();
     }
 
     function menuAddMask() {
         if (!canAddMask) return;
-        actions.dispatch('addMask', { layerId: group.id });
+        actions.dispatch('addMask');
         onupdate();
     }
 
     function menuDelete() {
-        if (!editable) return;
-        actions.dispatch('deleteLayer', { layerId: group.id });
+        if (!editable && !isMulti) return;
+        actions.dispatch('deleteLayer');
         onupdate();
     }
 
@@ -201,7 +222,16 @@
     }
 
     function onDragStart(e: DragEvent) {
-        e.dataTransfer?.setData('text/plain', String(group.id));
+        const ids = app.isSelected(group.id)
+            ? [...app.selectedLayerIds]
+            : [group.id];
+        if (!app.isSelected(group.id)) {
+            app.selectLayer(group.id);
+        }
+        e.dataTransfer?.setData(
+            'application/x-darkly-layers',
+            JSON.stringify(ids),
+        );
         if (e.dataTransfer) e.dataTransfer.effectAllowed = 'move';
     }
 
@@ -234,17 +264,26 @@
         e.stopPropagation();
         const pos = dropPos;
         dropPos = 'none';
-        const draggedId = e.dataTransfer?.getData('text/plain');
-        if (!draggedId || !app.handle) return;
-        const id = Number(draggedId);
-        if (id === group.id) return;
+        const payload = e.dataTransfer?.getData('application/x-darkly-layers');
+        if (!payload || !app.handle) return;
+        let ids: number[];
+        try { ids = JSON.parse(payload) as number[]; } catch { return; }
+        if (!Array.isArray(ids) || ids.length === 0) return;
+        if (ids.includes(group.id)) return;
 
-        if (pos === 'above') {
-            app.handle.move_layer(id, 'after', group.id);
-        } else if (pos === 'below') {
-            app.handle.move_layer(id, 'before', group.id);
-        } else {
-            app.handle.move_layer(id, 'into_top', group.id);
+        const where = pos === 'above' ? 'after'
+            : pos === 'below' ? 'before'
+            : 'into_top';
+
+        try {
+            const skipped = app.handle.move_layers(
+                Float64Array.from(ids), where, group.id,
+            );
+            if (skipped > 0) {
+                toast.show('info', `${skipped} locked layer${skipped === 1 ? '' : 's'} skipped`);
+            }
+        } catch (e: any) {
+            toast.show('error', e.message ?? String(e));
         }
         onupdate();
     }
@@ -255,6 +294,7 @@
     <div
         class="group-header"
         class:active={isActive}
+        class:selected={isSelected}
         class:drop-above={dropPos === 'above'}
         class:drop-below={dropPos === 'below'}
         class:drop-into={dropPos === 'into'}
@@ -345,17 +385,21 @@
 {#if showLayerMenu}
     <div class="layer-menu" style:left="{layerMenuX}px" style:top="{layerMenuY}px">
         <!-- Duplicate doesn't mutate the locked node — allowed. -->
-        <button onclick={menuDuplicate}>Duplicate group</button>
-        <button onclick={menuAddMask} disabled={!canAddMask}>
-            Add mask
+        <button onclick={menuDuplicate}>{dupLabel}</button>
+        {#if !isMulti}
+            <button onclick={menuAddMask} disabled={!canAddMask}>
+                Add mask
+            </button>
+        {/if}
+        <button onclick={menuMerge} disabled={!isMulti && (!canMergeDownForThis || !editable)}>
+            {mergeLabel}
         </button>
-        <button onclick={menuMergeDown} disabled={!canMergeDownForThis || !editable}>
-            Merge down
-        </button>
-        <button onclick={menuFlatten} disabled={!editable}>Flatten</button>
+        {#if !isMulti}
+            <button onclick={menuFlatten} disabled={!editable}>Flatten</button>
+        {/if}
         <div class="layer-menu-sep"></div>
-        <button onclick={menuDelete} disabled={!editable}>
-            Delete group
+        <button onclick={menuDelete} disabled={!isMulti && !editable}>
+            {deleteLabel}
         </button>
     </div>
 {/if}
@@ -392,6 +436,10 @@
     }
 
     .group-header:hover {
+        background: var(--bg-hover);
+    }
+
+    .group-header.selected {
         background: var(--bg-hover);
     }
 

--- a/frontend/src/ui/layers/LayerGroup.svelte
+++ b/frontend/src/ui/layers/LayerGroup.svelte
@@ -172,12 +172,9 @@
     }
 
     function menuMerge() {
-        if (isMulti) {
-            actions.dispatch('mergeSelected');
-        } else {
-            if (!canMergeDownForThis) return;
-            actions.dispatch('mergeDown');
-        }
+        // `mergeDown` is selection-aware (see LayerItem.svelte's menuMerge).
+        if (!isMulti && !canMergeDownForThis) return;
+        actions.dispatch('mergeDown');
         onupdate();
     }
 

--- a/frontend/src/ui/layers/LayerItem.svelte
+++ b/frontend/src/ui/layers/LayerItem.svelte
@@ -79,6 +79,12 @@
         return siblingBelowExists(app.layerTree, layer.id);
     });
 
+    let canAddMask = $derived(
+        (layer.type === 'raster' || layer.type === 'void')
+            && !hasMask
+            && editable,
+    );
+
     // Chord dispatch is owned by `use:bindingSite` on each preview
     // element below — `bindingSite` intercepts modifier+click in capture
     // phase and dispatches against its named site. These onclick handlers
@@ -154,6 +160,18 @@
     function menuFlatten() {
         if (!hasMask) return;
         actions.dispatch('flatten', { layerId: layer.id });
+        onupdate();
+    }
+
+    function menuAddMask() {
+        if (!canAddMask) return;
+        actions.dispatch('addMask', { layerId: layer.id });
+        onupdate();
+    }
+
+    function menuDelete() {
+        if (!editable) return;
+        actions.dispatch('deleteLayer', { layerId: layer.id });
         onupdate();
     }
 
@@ -367,12 +385,19 @@
         <button onclick={menuDuplicate}>
             Duplicate layer
         </button>
+        <button onclick={menuAddMask} disabled={!canAddMask}>
+            Add mask
+        </button>
         <button onclick={menuMergeDown} disabled={!canMergeDownForThis || !editable}>
             Merge down
         </button>
         {#if hasMask}
             <button onclick={menuFlatten} disabled={!editable}>Flatten</button>
         {/if}
+        <div class="layer-menu-sep"></div>
+        <button onclick={menuDelete} disabled={!editable}>
+            Delete layer
+        </button>
     </div>
 {/if}
 

--- a/frontend/src/ui/layers/LayerItem.svelte
+++ b/frontend/src/ui/layers/LayerItem.svelte
@@ -172,15 +172,12 @@
     }
 
     function menuMerge() {
-        // With 1 selected, route to the existing single-layer merge_down
-        // op (merges with the sibling below). With ≥2, route to the
-        // new merge_layers op (bakes the selection into one raster).
-        if (isMulti) {
-            actions.dispatch('mergeSelected');
-        } else {
-            if (!canMergeDownForThis) return;
-            actions.dispatch('mergeDown');
-        }
+        // `mergeDown` is selection-aware: with ≥2 selected it bakes the
+        // selection via merge_layers; with 1, it does the classic
+        // single-layer merge-down. Guard only the single-layer case
+        // where there's no sibling below.
+        if (!isMulti && !canMergeDownForThis) return;
+        actions.dispatch('mergeDown');
         onupdate();
     }
 

--- a/frontend/src/ui/layers/LayerItem.svelte
+++ b/frontend/src/ui/layers/LayerItem.svelte
@@ -4,6 +4,7 @@
     import { bindingSite } from '../../actions/binding_site';
     import { actions } from '../../actions/registry';
     import { tooltipForAction } from '../../config/store.svelte';
+    import { toast } from '../../state/toast.svelte';
 
     interface Modifier {
         id: number; kind: string; name: string; visible: boolean; locked: boolean;
@@ -38,6 +39,12 @@
     );
 
     let isActive = $derived(app.activeLayerId === layer.id);
+    let isSelected = $derived(app.isSelected(layer.id));
+    let selectionSize = $derived(app.selectedLayerIds.size);
+    let isMulti = $derived(selectionSize > 1);
+    let deleteLabel = $derived(isMulti ? `Delete ${selectionSize} Layers` : 'Delete Layer');
+    let dupLabel = $derived(isMulti ? `Duplicate ${selectionSize} Layers` : 'Duplicate Layer');
+    let mergeLabel = $derived(isMulti ? `Merge ${selectionSize} Layers` : 'Merge Down');
     // The mask is the active edit target whenever the active node id IS the
     // mask modifier id — no session redirect.
     let isEditingMask = $derived(
@@ -101,10 +108,11 @@
         onupdate();
     }
 
-    function onLayerClick() {
+    function onLayerClick(e: MouseEvent) {
         // The layer-item body has no chord bindings — modifier+click is
-        // reserved for the previews. Plain click selects.
-        app.selectLayer(layer.id);
+        // reserved for the previews. Plain / ctrl / shift dispatch is
+        // shared with LayerGroup via app.handleLayerRowClick.
+        app.handleLayerRowClick(layer.id, e);
     }
 
     function clickLayerThumb(e: MouseEvent) {
@@ -134,10 +142,15 @@
     function onLayerContextMenu(e: MouseEvent) {
         e.preventDefault();
         e.stopPropagation();
-        // Select the right-clicked layer so subsequent dispatched actions
-        // that fall back to `app.activeLayerId` (e.g. when ctx.layerId
-        // isn't honoured by a particular handler) still target this layer.
-        app.selectLayer(layer.id);
+        // If the right-clicked row is already in the multi-selection,
+        // keep the selection intact — the menu acts on the whole set.
+        // If it's not in the selection, replace the selection with just
+        // this row (Photoshop / GIMP behavior). This way the menu and
+        // every action it dispatches operate on a selection that
+        // **always includes the right-clicked row**.
+        if (!app.isSelected(layer.id)) {
+            app.selectLayer(layer.id);
+        }
         layerMenuX = e.clientX;
         layerMenuY = e.clientY;
         showLayerMenu = true;
@@ -146,32 +159,46 @@
         requestAnimationFrame(() => document.addEventListener('click', close));
     }
 
+    // Structural menu items dispatch WITHOUT `ctx.layerId` — the action
+    // handler reads `app.selectedLayerIds` (the right-click handler above
+    // guarantees the clicked row is in the selection). This is what
+    // makes "Delete 3 Layers" actually delete 3 layers; the v1 attempt
+    // passed `{ layerId: layer.id }` and silently demoted every action
+    // to single-layer.
+
     function menuDuplicate() {
-        actions.dispatch('duplicateLayer', { layerId: layer.id });
+        actions.dispatch('duplicateLayer');
         onupdate();
     }
 
-    function menuMergeDown() {
-        if (!canMergeDownForThis) return;
-        actions.dispatch('mergeDown', { layerId: layer.id });
+    function menuMerge() {
+        // With 1 selected, route to the existing single-layer merge_down
+        // op (merges with the sibling below). With ≥2, route to the
+        // new merge_layers op (bakes the selection into one raster).
+        if (isMulti) {
+            actions.dispatch('mergeSelected');
+        } else {
+            if (!canMergeDownForThis) return;
+            actions.dispatch('mergeDown');
+        }
         onupdate();
     }
 
     function menuFlatten() {
         if (!hasMask) return;
-        actions.dispatch('flatten', { layerId: layer.id });
+        actions.dispatch('flatten');
         onupdate();
     }
 
     function menuAddMask() {
         if (!canAddMask) return;
-        actions.dispatch('addMask', { layerId: layer.id });
+        actions.dispatch('addMask');
         onupdate();
     }
 
     function menuDelete() {
-        if (!editable) return;
-        actions.dispatch('deleteLayer', { layerId: layer.id });
+        if (!editable && !isMulti) return;
+        actions.dispatch('deleteLayer');
         onupdate();
     }
 
@@ -223,7 +250,19 @@
     let draggable = $state(true);
 
     function onDragStart(e: DragEvent) {
-        e.dataTransfer?.setData('text/plain', String(layer.id));
+        // Grabbed row IS in selection → drag the whole set. Grabbed row
+        // is NOT in selection → drag only it, and replace the selection
+        // with just it (focus commits to what the user grabbed).
+        const ids = app.isSelected(layer.id)
+            ? [...app.selectedLayerIds]
+            : [layer.id];
+        if (!app.isSelected(layer.id)) {
+            app.selectLayer(layer.id);
+        }
+        e.dataTransfer?.setData(
+            'application/x-darkly-layers',
+            JSON.stringify(ids),
+        );
         if (e.dataTransfer) e.dataTransfer.effectAllowed = 'move';
     }
 
@@ -249,18 +288,28 @@
         e.preventDefault();
         e.stopPropagation();
         dropPos = 'none';
-        const draggedId = e.dataTransfer?.getData('text/plain');
-        if (!draggedId || !app.handle) return;
-        const id = Number(draggedId);
-        if (id === layer.id) return;
+        const payload = e.dataTransfer?.getData('application/x-darkly-layers');
+        if (!payload || !app.handle) return;
+        let ids: number[];
+        try { ids = JSON.parse(payload) as number[]; } catch { return; }
+        if (!Array.isArray(ids) || ids.length === 0) return;
+        // Dropping the dragged set onto one of its own members is a no-op
+        // — the engine would reject it as self-referential anyway.
+        if (ids.includes(layer.id)) return;
 
         const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
         const ratio = (e.clientY - rect.top) / rect.height;
+        const where = ratio < 0.5 ? 'after' : 'before';
 
-        if (ratio < 0.5) {
-            app.handle.move_layer(id, 'after', layer.id);
-        } else {
-            app.handle.move_layer(id, 'before', layer.id);
+        try {
+            const skipped = app.handle.move_layers(
+                Float64Array.from(ids), where, layer.id,
+            );
+            if (skipped > 0) {
+                toast.show('info', `${skipped} locked layer${skipped === 1 ? '' : 's'} skipped`);
+            }
+        } catch (e: any) {
+            toast.show('error', e.message ?? String(e));
         }
         onupdate();
     }
@@ -270,6 +319,7 @@
 <div
     class="layer-item"
     class:active={isActive}
+    class:selected={isSelected}
     class:drop-above={dropPos === 'above'}
     class:drop-below={dropPos === 'below'}
     onclick={onLayerClick}
@@ -383,20 +433,22 @@
         <!-- Duplicate is a read-of-source / create-new-layer op; it does
              not mutate the locked layer, so it stays enabled. -->
         <button onclick={menuDuplicate}>
-            Duplicate layer
+            {dupLabel}
         </button>
-        <button onclick={menuAddMask} disabled={!canAddMask}>
-            Add mask
+        {#if !isMulti}
+            <button onclick={menuAddMask} disabled={!canAddMask}>
+                Add mask
+            </button>
+        {/if}
+        <button onclick={menuMerge} disabled={!isMulti && (!canMergeDownForThis || !editable)}>
+            {mergeLabel}
         </button>
-        <button onclick={menuMergeDown} disabled={!canMergeDownForThis || !editable}>
-            Merge down
-        </button>
-        {#if hasMask}
+        {#if !isMulti && hasMask}
             <button onclick={menuFlatten} disabled={!editable}>Flatten</button>
         {/if}
         <div class="layer-menu-sep"></div>
-        <button onclick={menuDelete} disabled={!editable}>
-            Delete layer
+        <button onclick={menuDelete} disabled={!isMulti && !editable}>
+            {deleteLabel}
         </button>
     </div>
 {/if}
@@ -420,6 +472,10 @@
     }
 
     .layer-item:hover {
+        background: var(--bg-hover);
+    }
+
+    .layer-item.selected {
         background: var(--bg-hover);
     }
 

--- a/frontend/wasm/src/api.rs
+++ b/frontend/wasm/src/api.rs
@@ -1156,6 +1156,103 @@ impl DarklyHandle {
             .move_layer(LayerId::from_ffi(layer_id as u64), target)
     }
 
+    /// Remove every layer in `ids` in a single undo step. Returns the
+    /// number of locked layers that were skipped so the UI can toast.
+    /// Errors only when removing the editable set would leave the
+    /// document with zero layers.
+    pub fn remove_layers(&self, ids: Vec<f64>) -> Result<u32, JsError> {
+        self.flush_if_needed();
+        let ids: Vec<LayerId> = ids
+            .into_iter()
+            .map(|v| LayerId::from_ffi(v as u64))
+            .collect();
+        self.engine
+            .borrow_mut()
+            .remove_layers(ids)
+            .map(|n| n as u32)
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Move every layer in `ids` to land contiguously at the drop target,
+    /// preserving their relative panel order. Returns the count of locked
+    /// layers skipped. Errors when the drop target is one of the moved
+    /// ids or a descendant of one (self-referential drop).
+    pub fn move_layers(
+        &self,
+        ids: Vec<f64>,
+        target_type: &str,
+        target_id: f64,
+    ) -> Result<u32, JsError> {
+        self.flush_if_needed();
+        let target_id = LayerId::from_ffi(target_id as u64);
+        let target = match target_type {
+            "before" => MoveTarget::Before(target_id),
+            "after" => MoveTarget::After(target_id),
+            "into_top" => MoveTarget::IntoGroupTop(target_id),
+            "into_bottom" => MoveTarget::IntoGroupBottom(target_id),
+            _ => return Err(JsError::new("unknown move target")),
+        };
+        let ids: Vec<LayerId> = ids
+            .into_iter()
+            .map(|v| LayerId::from_ffi(v as u64))
+            .collect();
+        self.engine
+            .borrow_mut()
+            .move_layers(ids, target)
+            .map(|n| n as u32)
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Duplicate every node in `ids` in panel order. Returns the new
+    /// node ids in the same order, suitable for re-selecting the copies.
+    pub fn duplicate_nodes(&self, ids: Vec<f64>) -> Vec<f64> {
+        self.flush_if_needed();
+        let ids: Vec<LayerId> = ids
+            .into_iter()
+            .map(|v| LayerId::from_ffi(v as u64))
+            .collect();
+        self.engine
+            .borrow_mut()
+            .duplicate_nodes(ids)
+            .into_iter()
+            .map(|id| id.to_ffi() as f64)
+            .collect()
+    }
+
+    /// Create a new group and move every layer in `ids` into it. The group
+    /// lands at the panel-topmost selected layer's slot; sources from
+    /// other parents are pulled in. Locked layers and ancestors-of-other-
+    /// sources are silently skipped. Returns the new group's id.
+    pub fn group_layers(&self, ids: Vec<f64>) -> Result<f64, JsError> {
+        self.flush_if_needed();
+        let ids: Vec<LayerId> = ids
+            .into_iter()
+            .map(|v| LayerId::from_ffi(v as u64))
+            .collect();
+        self.engine
+            .borrow_mut()
+            .group_layers(ids)
+            .map(|id| id.to_ffi() as f64)
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Bake every layer in `ids` (≥2) into one raster at the panel-topmost
+    /// selected layer's slot. Cross-parent selections are supported.
+    /// Returns the result id, or an error message if any source is locked
+    /// or fewer than two distinct ids are given.
+    pub fn merge_layers(&self, ids: Vec<f64>) -> Result<f64, JsError> {
+        self.flush_if_needed();
+        let ids: Vec<LayerId> = ids
+            .into_iter()
+            .map(|v| LayerId::from_ffi(v as u64))
+            .collect();
+        self.engine
+            .borrow_mut()
+            .merge_layers(ids)
+            .map(|id| id.to_ffi() as f64)
+            .map_err(|e| JsError::new(&e))
+    }
+
     /// Deep-copy a layer or group, placing the duplicate directly above the
     /// source. Returns the new node's id, or `0` (a null `LayerId`) if the
     /// source id is unknown.


### PR DESCRIPTION
## Multi-Layer Selection + Layer Hotkeys

Adds multi-layer selection to the layer panel with batch operations, fills in missing layer-action hotkeys across all four presets, and refreshes the README with the user-facing hotkey story.

### Multi-selection in the layer panel

Layer rows now support standard selection gestures and visual feedback:

- **Plain-click** replaces the selection with the clicked row; **ctrl/cmd-click** toggles a row in/out; **shift-click** extends the range over the visible (uncollapsed) tree.
- The active layer (the "primary" within the selection) drives per-row emphasis and the shift-click anchor; selected rows show a dimmer highlight underneath.
- **Right-click** on a row not in the selection replaces the selection with just it; right-click on a row already in the selection leaves the selection intact. Context-menu labels update with the count ("Delete 3 Layers", "Duplicate 3 Layers", "Merge 3 Layers"). The selection set is the source of truth — actions read it at dispatch time rather than taking a row-id override, which was the central bug in an earlier attempt.
- **Drag** picks up the whole selection if the grabbed row is in it; otherwise drags just the grabbed row and replaces the selection with it. Payload moved from `text/plain` (single id) to `application/x-darkly-layers` (JSON array).

### Batch operations

Each is one undo step. Cross-parent selections are supported throughout — sources from different groups are handled per-op.

- **Delete N layers** — locked layers are silently skipped (toasted with a count).
- **Duplicate N layers** — each copy lands directly above its own original (fixed a long-standing bug where every duplicate stacked at the top of root).
- **Move N layers** — drag preserves the selection's relative panel order at the destination; self-referential drops (target inside the moved set) are rejected.
- **Merge N layers** — bakes the selection into one raster at the panel-topmost selected layer's slot, inheriting its name / blend mode / opacity / visibility. Locked sources abort the merge.
- **Group N layers** — the footer "New Group" button is now selection-aware: with layers selected, wraps them in a new group at the topmost selected layer's slot; with nothing selected, creates an empty group at the active layer's anchor.

Property edits (opacity, blend mode, eye, lock) intentionally stay single-active-layer — out of scope.

### Engine

- New batch entry points in `crates/darkly/src/engine/`: `remove_layers`, `move_layers`, `duplicate_nodes`, `merge_layers`, `group_layers`. Each refactors the existing single-id op so the action-returning core can be reused.
- `batched_undo<F>` helper in `undo_dispatch.rs` collects per-id `UndoAction`s into one `CompoundAction` — replaces N copy-paste `*_multi` functions per the Modularity Principle.
- New document helpers: `is_ancestor_of` (for ancestor-dedup), `all_node_ids_in_order` (DFS over the full tree for batch ordering), `#[derive(Clone, Copy)]` on `MoveTarget`.
- Four new batch WASM methods in `frontend/wasm/src/api.rs`; existing single-id methods retained for per-row buttons.

### Layer-action hotkeys

Filled the gaps across all four presets per the placement rule documented in `presets/defaults.yaml`'s header.

- Registered `newLayer` and `newGroup` as actions so the footer's `+` and group buttons surface hotkeys in their tooltips via `tooltipForAction`.
- `mergeDown` is now selection-aware (≥2 selected → routes to `merge_layers`; 1 → classic merge-down). One hotkey covers both — matches Photoshop's Ctrl+E convention. Dropped the separate `mergeSelected` action.
- **defaults.yaml**: added `newGroup` (Ctrl+G) and `mergeDown` (Ctrl+E). `addMask` and `flatten` deliberately left unbound — no host editor has a default for `addMask` (button is the discovery path), and Krita's Ctrl+Shift+E is "Flatten image" (whole-canvas) which doesn't semantically match Darkly's single-layer `flatten`.
- **photoshop.yaml** / **gimp.yaml**: added `newLayer: Ctrl+Shift+N` (host default in both).
- **krita.yaml**: added `newLayer: Insert` (Krita's binding).
- Removed redundant `mergeDown` overrides from `photoshop.yaml` and `krita.yaml` (same value as defaults now).

### Documentation

- `AGENTS.md` gained a one-sentence pointer to the hotkey preset system: the three-layer resolution chain and where the placement rule and host references live. Replaces a longer overweight section.
- `README.md` reorganization: added "Familiar Hotkeys" and "Hotkey Cheatsheet" sections, split "Features" (the universally-expected stuff like the brush engine) from "Dark Arts" (the Darkly-original veils/voids).

### Tests

- 12 new Rust integration tests in `crates/darkly/tests/`: multi-delete/move/duplicate/merge round-trips, locked-skip, ancestor-dedup, cross-parent merge, group-layers placement, refuses-to-empty, refuses-self-target, each-duplicate-above-source (regression).
- 17 new vitest cases in `frontend/src/state/__tests__/selection.test.ts`: plain/ctrl/shift transitions, no-anchor shift, ctrl-removing the active id (demote-to-next-in-tree-order), shift across collapsed groups, `selectLayers([])` clearing, modifier routing.

### Test plan
- [ ] Add 5 layers. Ctrl-click 1, 3, 5. Right-click 3 → menu reads "Delete 3 Layers". Click → 1/3/5 gone; Ctrl+Z restores all in one step.
- [ ] Re-select 1/3/5. Right-click → "Duplicate 3 Layers". Each copy lands directly above its original (not stacked at the top).
- [ ] Select two layers in different groups. Right-click → "Merge 2 Layers". Result lands at the topmost selected layer's slot, inheriting its name/blend; the other source's group loses its child.
- [ ] Select 3 layers, press Ctrl+G → wrapped into a new group at the topmost's slot. Ctrl+Z restores the original tree.
- [ ] Press Ctrl+E with 3 layers selected → multi-merge. With 1 selected and a layer below → single merge-down.
- [ ] Press Ctrl+Shift+N (Insert on Krita preset) → new layer.
- [ ] Lock a layer in a multi-selection then delete → toast says "1 locked layer skipped"; locked layer remains.
- [ ] Drag a selected layer onto an unselected layer → whole selection moves above the target in original relative order.