### PR TITLE
Boolean gate node, ordered brush inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,14 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          # Coverage upload is best-effort: tests are the gate, and we
+          # don't want a Codecov-side outage to redden a PR whose tests
+          # pass. The GPG signature check on Codecov's CLI binary stays
+          # ON — when their keyserver fails to serve the public key the
+          # upload step aborts before running the unverified binary
+          # (which has access to CODECOV_TOKEN and the repo), and CI
+          # surfaces it as a job-level warning instead of a failure.
+          fail_ci_if_error: false
           flags: rust
 
   wasm-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --workspace --all-targets --exclude darkly-wasm --features darkly/testing -- -D warnings
 
   clippy-wasm:
@@ -40,7 +39,6 @@ jobs:
         with:
           components: clippy
           targets: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
       - run: cargo clippy -p darkly-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings
 
   test:
@@ -56,7 +54,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
-      - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov
@@ -80,7 +77,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
       - uses: jetli/wasm-pack-action@v0.4.0
         with:
           version: latest
@@ -96,12 +92,9 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
       - uses: jetli/wasm-pack-action@v0.4.0
         with:
           version: latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "base64",
  "bytemuck",
  "image",
+ "indexmap",
  "log",
  "naga",
  "png 0.17.16",
@@ -475,6 +476,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Darkly features a unified node-based brush system. Every brush type -- clone, li
 
 <img src="https://github.com/user-attachments/assets/63544586-f006-4616-b378-97dd54e321d3" width="400"/>
 
-On first launch, Darkly will ask you which editor preset you want.  Currently we support GIMP, Krita, and Photoshop. I come from Krita, so that one's gotten the most TLC. We want them all to feel natural to new users. If you find any gaps, please let us know!
+On first launch, Darkly will ask you which editor preset you want.  Currently we support GIMP, Krita, and Photoshop. I come from Krita, so that one's gotten the most TLC. But we want everyone to feel at home no matter which editor they come from. If you find any gaps, please let us know!
 
 ### Hotkey Cheatsheet
 

--- a/crates/darkly/Cargo.toml
+++ b/crates/darkly/Cargo.toml
@@ -28,6 +28,7 @@ base64 = { workspace = true }
 thiserror = { workspace = true }
 slotmap = { workspace = true }
 smallvec = { workspace = true }
+indexmap = { version = "2", features = ["serde"] }
 
 [dev-dependencies]
 pollster = "0.4"

--- a/crates/darkly/brushes/airbrush.yaml
+++ b/crates/darkly/brushes/airbrush.yaml
@@ -6,7 +6,7 @@ nodes:
   2:
     type: paint_color
   3:
-    type: circle
+    type: shape
     port_defaults:
       softness: 1.0
   4:

--- a/crates/darkly/brushes/airbrush.yaml
+++ b/crates/darkly/brushes/airbrush.yaml
@@ -20,7 +20,8 @@ connections:
 - '3.mask -> 4.tip'
 - '4.dab -> 5.rgba'
 exposed_ports:
+  "1.stabilize": {}
+  "5.size": {}
   "3.softness": {}
   "5.flow": {}
   "5.opacity": {}
-  "5.size": {}

--- a/crates/darkly/brushes/airbrush.yaml
+++ b/crates/darkly/brushes/airbrush.yaml
@@ -9,19 +9,18 @@ nodes:
     type: circle
     port_defaults:
       softness: 1.0
-    exposed:
-    - softness
   4:
     type: stamp
   5:
     type: paint
-    exposed:
-    - flow
-    - opacity
-    - size
 connections:
 - '1.position -> 5.position'
 - '1.pressure -> 5.flow'
 - '2.color -> 4.color'
 - '3.mask -> 4.tip'
 - '4.dab -> 5.rgba'
+exposed_ports:
+  "3.softness": {}
+  "5.flow": {}
+  "5.opacity": {}
+  "5.size": {}

--- a/crates/darkly/brushes/charcoal.yaml
+++ b/crates/darkly/brushes/charcoal.yaml
@@ -17,7 +17,6 @@ nodes:
       amplitude: 0.5
       frequency: 3.0
       rotation: 5.750458
-      rotation_input: 4.7
       softness: 0.32
   5:
     type: multiply

--- a/crates/darkly/brushes/charcoal.yaml
+++ b/crates/darkly/brushes/charcoal.yaml
@@ -10,7 +10,7 @@ nodes:
   3:
     type: split_color
   4:
-    type: circle
+    type: shape
     params:
       algorithm: 2
     port_defaults:

--- a/crates/darkly/brushes/charcoal.yaml
+++ b/crates/darkly/brushes/charcoal.yaml
@@ -78,7 +78,8 @@ connections:
 - '11.output -> 7.flow'
 - '12.output -> 5.a'
 exposed_ports:
+  "1.stabilize": {}
+  "7.size": {}
   "4.rotation": {}
   "7.flow": {}
   "7.opacity": {}
-  "7.size": {}

--- a/crates/darkly/brushes/charcoal.yaml
+++ b/crates/darkly/brushes/charcoal.yaml
@@ -91,7 +91,7 @@ exposed_ports:
     description: Spin the shape around its centre. Wire a changing signal into Rotation Input instead if you want it to move as you draw.
     icon: fa-solid fa-rotate
   '13.select':
-    label: Freeze Rotation
+    label: Lock Rotation
     description: Routes one of two inputs to the output. If the chosen input is unconnected, downstream falls back to its own port default.
-    icon: fa-solid fa-snowflake
+    icon: fa-solid fa-lock
   '7.flow': {}

--- a/crates/darkly/brushes/charcoal.yaml
+++ b/crates/darkly/brushes/charcoal.yaml
@@ -19,8 +19,6 @@ nodes:
       rotation: 3.14159
       rotation_input: 4.7
       softness: 0.32
-    exposed:
-    - rotation
   5:
     type: multiply
   6:
@@ -30,10 +28,6 @@ nodes:
     port_defaults:
       flow: 0.5
       size: 0.12
-    exposed:
-    - flow
-    - opacity
-    - size
   8:
     type: image
     params:
@@ -83,3 +77,8 @@ connections:
 - '10.output -> 9.in_low'
 - '11.output -> 7.flow'
 - '12.output -> 5.a'
+exposed_ports:
+  "4.rotation": {}
+  "7.flow": {}
+  "7.opacity": {}
+  "7.size": {}

--- a/crates/darkly/brushes/charcoal.yaml
+++ b/crates/darkly/brushes/charcoal.yaml
@@ -16,7 +16,7 @@ nodes:
     port_defaults:
       amplitude: 0.5
       frequency: 3.0
-      rotation: 3.14159
+      rotation: 5.750458
       rotation_input: 4.7
       softness: 0.32
   5:
@@ -63,7 +63,12 @@ nodes:
         - 0.53
       - - 1.0
         - 1.0
+  13:
+    type: switch
+    port_defaults:
+      select: 1.0
 connections:
+- '1.drawing_angle -> 13.in_0_scalar'
 - '1.position -> 7.position'
 - '1.pressure -> 10.input'
 - '1.pressure -> 11.input'
@@ -77,9 +82,17 @@ connections:
 - '10.output -> 9.in_low'
 - '11.output -> 7.flow'
 - '12.output -> 5.a'
+- '13.out_scalar -> 4.rotation_input'
 exposed_ports:
-  "1.stabilize": {}
-  "7.size": {}
-  "4.rotation": {}
-  "7.flow": {}
-  "7.opacity": {}
+  '1.stabilize': {}
+  '7.size': {}
+  '7.opacity': {}
+  '4.rotation':
+    label: Rotation
+    description: Spin the shape around its centre. Wire a changing signal into Rotation Input instead if you want it to move as you draw.
+    icon: fa-solid fa-rotate
+  '13.select':
+    label: Freeze Rotation
+    description: Routes one of two inputs to the output. If the chosen input is unconnected, downstream falls back to its own port default.
+    icon: fa-solid fa-snowflake
+  '7.flow': {}

--- a/crates/darkly/brushes/ink_pen.yaml
+++ b/crates/darkly/brushes/ink_pen.yaml
@@ -8,7 +8,7 @@ nodes:
   2:
     type: paint_color
   3:
-    type: circle
+    type: shape
     port_defaults:
       softness: 0.1
   4:

--- a/crates/darkly/brushes/ink_pen.yaml
+++ b/crates/darkly/brushes/ink_pen.yaml
@@ -35,7 +35,7 @@ connections:
 - '6.output -> 5.size_input'
 exposed_ports:
   "1.stabilize": {}
+  "5.size": {}
   "3.softness": {}
   "5.flow": {}
   "5.opacity": {}
-  "5.size": {}

--- a/crates/darkly/brushes/ink_pen.yaml
+++ b/crates/darkly/brushes/ink_pen.yaml
@@ -5,24 +5,16 @@ nodes:
     type: pen_input
     port_defaults:
       stabilize: 0.6
-    exposed:
-    - stabilize
   2:
     type: paint_color
   3:
     type: circle
     port_defaults:
       softness: 0.1
-    exposed:
-    - softness
   4:
     type: stamp
   5:
     type: paint
-    exposed:
-    - flow
-    - opacity
-    - size
   6:
     type: curve
     params:
@@ -41,3 +33,9 @@ connections:
 - '3.mask -> 4.tip'
 - '4.dab -> 5.rgba'
 - '6.output -> 5.size_input'
+exposed_ports:
+  "1.stabilize": {}
+  "3.softness": {}
+  "5.flow": {}
+  "5.opacity": {}
+  "5.size": {}

--- a/crates/darkly/brushes/liquify.yaml
+++ b/crates/darkly/brushes/liquify.yaml
@@ -14,6 +14,7 @@ connections:
 - '1.motion -> 2.motion'
 - '1.position -> 2.position'
 exposed_ports:
+  "1.stabilize": {}
   "2.size": {}
   "2.softness": {}
   "2.strength": {}

--- a/crates/darkly/brushes/liquify.yaml
+++ b/crates/darkly/brushes/liquify.yaml
@@ -8,12 +8,12 @@ nodes:
       spacing_min_px: 4.0
   2:
     type: liquify
-    exposed:
-    - size
-    - softness
-    - strength
 connections:
 - '1.distance -> 2.distance'
 - '1.drawing_angle -> 2.direction'
 - '1.motion -> 2.motion'
 - '1.position -> 2.position'
+exposed_ports:
+  "2.size": {}
+  "2.softness": {}
+  "2.strength": {}

--- a/crates/darkly/brushes/rough_ink.yaml
+++ b/crates/darkly/brushes/rough_ink.yaml
@@ -48,6 +48,6 @@ connections:
 - '8.dab -> 9.rgba'
 exposed_ports:
   "1.stabilize": {}
+  "9.size": {}
   "9.flow": {}
   "9.opacity": {}
-  "9.size": {}

--- a/crates/darkly/brushes/rough_ink.yaml
+++ b/crates/darkly/brushes/rough_ink.yaml
@@ -5,8 +5,6 @@ nodes:
     type: pen_input
     port_defaults:
       stabilize: 0.6
-    exposed:
-    - stabilize
   2:
     type: paint_color
   3:
@@ -37,10 +35,6 @@ nodes:
     type: stamp
   9:
     type: paint
-    exposed:
-    - flow
-    - opacity
-    - size
 connections:
 - '1.position -> 9.position'
 - '1.pressure -> 3.input'
@@ -52,3 +46,8 @@ connections:
 - '6.value -> 7.seed'
 - '7.mask -> 8.tip'
 - '8.dab -> 9.rgba'
+exposed_ports:
+  "1.stabilize": {}
+  "9.flow": {}
+  "9.opacity": {}
+  "9.size": {}

--- a/crates/darkly/brushes/rough_ink.yaml
+++ b/crates/darkly/brushes/rough_ink.yaml
@@ -24,7 +24,7 @@ nodes:
   6:
     type: random
   7:
-    type: circle
+    type: shape
     params:
       algorithm: 1
     port_defaults:

--- a/crates/darkly/brushes/rough_watercolor.yaml
+++ b/crates/darkly/brushes/rough_watercolor.yaml
@@ -5,8 +5,6 @@ nodes:
     type: pen_input
     port_defaults:
       stabilize: 0.5
-    exposed:
-    - stabilize
   2:
     type: paint_color
   3:
@@ -19,17 +17,8 @@ nodes:
       octaves: 4.0
       persistence: 0.55
       softness: 0.05
-    exposed:
-    - softness
   4:
     type: watercolor
-    exposed:
-    - deposit
-    - flow
-    - opacity
-    - pickup_size
-    - size
-    - wetness
   5:
     type: random
 connections:
@@ -38,3 +27,12 @@ connections:
 - '2.color -> 4.color'
 - '3.mask -> 4.mask'
 - '5.value -> 3.seed'
+exposed_ports:
+  "1.stabilize": {}
+  "3.softness": {}
+  "4.deposit": {}
+  "4.flow": {}
+  "4.opacity": {}
+  "4.pickup_size": {}
+  "4.size": {}
+  "4.wetness": {}

--- a/crates/darkly/brushes/rough_watercolor.yaml
+++ b/crates/darkly/brushes/rough_watercolor.yaml
@@ -29,10 +29,10 @@ connections:
 - '5.value -> 3.seed'
 exposed_ports:
   "1.stabilize": {}
+  "4.size": {}
   "3.softness": {}
   "4.deposit": {}
   "4.flow": {}
   "4.opacity": {}
   "4.pickup_size": {}
-  "4.size": {}
   "4.wetness": {}

--- a/crates/darkly/brushes/rough_watercolor.yaml
+++ b/crates/darkly/brushes/rough_watercolor.yaml
@@ -8,7 +8,7 @@ nodes:
   2:
     type: paint_color
   3:
-    type: circle
+    type: shape
     params:
       algorithm: 1
     port_defaults:

--- a/crates/darkly/brushes/round.yaml
+++ b/crates/darkly/brushes/round.yaml
@@ -7,16 +7,10 @@ nodes:
     type: paint_color
   3:
     type: circle
-    exposed:
-    - softness
   4:
     type: stamp
   5:
     type: paint
-    exposed:
-    - flow
-    - opacity
-    - size
   6:
     type: curve
 connections:
@@ -27,3 +21,8 @@ connections:
 - '3.mask -> 4.tip'
 - '4.dab -> 5.rgba'
 - '6.output -> 5.size_input'
+exposed_ports:
+  "3.softness": {}
+  "5.flow": {}
+  "5.opacity": {}
+  "5.size": {}

--- a/crates/darkly/brushes/round.yaml
+++ b/crates/darkly/brushes/round.yaml
@@ -22,7 +22,8 @@ connections:
 - '4.dab -> 5.rgba'
 - '6.output -> 5.size_input'
 exposed_ports:
+  "1.stabilize": {}
+  "5.size": {}
   "3.softness": {}
   "5.flow": {}
   "5.opacity": {}
-  "5.size": {}

--- a/crates/darkly/brushes/round.yaml
+++ b/crates/darkly/brushes/round.yaml
@@ -6,7 +6,7 @@ nodes:
   2:
     type: paint_color
   3:
-    type: circle
+    type: shape
   4:
     type: stamp
   5:

--- a/crates/darkly/brushes/smooth_watercolor.yaml
+++ b/crates/darkly/brushes/smooth_watercolor.yaml
@@ -8,7 +8,7 @@ nodes:
   2:
     type: paint_color
   3:
-    type: circle
+    type: shape
     port_defaults:
       amplitude: 0.05
       frequency: 5.0

--- a/crates/darkly/brushes/smooth_watercolor.yaml
+++ b/crates/darkly/brushes/smooth_watercolor.yaml
@@ -24,10 +24,10 @@ connections:
 - '5.value -> 3.rotation_input'
 exposed_ports:
   "1.stabilize": {}
+  "4.size": {}
   "3.softness": {}
   "4.deposit": {}
   "4.flow": {}
   "4.opacity": {}
-  "4.pickup_size": {}
-  "4.size": {}
   "4.wetness": {}
+  "4.pickup_size": {}

--- a/crates/darkly/brushes/smooth_watercolor.yaml
+++ b/crates/darkly/brushes/smooth_watercolor.yaml
@@ -5,8 +5,6 @@ nodes:
     type: pen_input
     port_defaults:
       stabilize: 0.5
-    exposed:
-    - stabilize
   2:
     type: paint_color
   3:
@@ -14,17 +12,8 @@ nodes:
     port_defaults:
       amplitude: 0.05
       frequency: 5.0
-    exposed:
-    - softness
   4:
     type: watercolor
-    exposed:
-    - deposit
-    - flow
-    - opacity
-    - pickup_size
-    - size
-    - wetness
   5:
     type: random
 connections:
@@ -33,3 +22,12 @@ connections:
 - '2.color -> 4.color'
 - '3.mask -> 4.mask'
 - '5.value -> 3.rotation_input'
+exposed_ports:
+  "1.stabilize": {}
+  "3.softness": {}
+  "4.deposit": {}
+  "4.flow": {}
+  "4.opacity": {}
+  "4.pickup_size": {}
+  "4.size": {}
+  "4.wetness": {}

--- a/crates/darkly/brushes/smudge.yaml
+++ b/crates/darkly/brushes/smudge.yaml
@@ -6,22 +6,20 @@ nodes:
     port_defaults:
       spacing: 0.01
       stabilize: 0.4
-    exposed:
-    - stabilize
   2:
     type: circle
     port_defaults:
       softness: 0.4
-    exposed:
-    - softness
   3:
     type: smudge
-    exposed:
-    - opacity
-    - rate
-    - size
 connections:
 - '1.motion -> 3.motion'
 - '1.position -> 3.position'
 - '1.pressure -> 3.size_input'
 - '2.mask -> 3.mask'
+exposed_ports:
+  "1.stabilize": {}
+  "2.softness": {}
+  "3.opacity": {}
+  "3.rate": {}
+  "3.size": {}

--- a/crates/darkly/brushes/smudge.yaml
+++ b/crates/darkly/brushes/smudge.yaml
@@ -7,7 +7,7 @@ nodes:
       spacing: 0.01
       stabilize: 0.4
   2:
-    type: circle
+    type: shape
     port_defaults:
       softness: 0.4
   3:

--- a/crates/darkly/brushes/smudge.yaml
+++ b/crates/darkly/brushes/smudge.yaml
@@ -19,7 +19,7 @@ connections:
 - '2.mask -> 3.mask'
 exposed_ports:
   "1.stabilize": {}
+  "3.size": {}
   "2.softness": {}
   "3.opacity": {}
   "3.rate": {}
-  "3.size": {}

--- a/crates/darkly/presets/defaults.yaml
+++ b/crates/darkly/presets/defaults.yaml
@@ -2,14 +2,22 @@
 #
 #   user override → overlay[active editor] → defaults  (this file)
 #
-# Hotkeys / mouse_clicks inclusion rule: if all three reference editors
-# (Krita, Photoshop, GIMP) have a binding for an action — whether or not
-# they happen to agree on the key — the binding lives per-editor in
-# krita.yaml / photoshop.yaml / gimp.yaml, NOT here. defaults.yaml only
-# carries:
-#   - Darkly-original actions (no reference-editor prior art), and
-#   - actions where fewer than three reference editors have an opinion
-#     (Darkly picks a sensible default; an overlay may still override).
+# Hotkeys / mouse_clicks inclusion rule:
+#
+#   1. A binding lives here iff Krita, Photoshop, and GIMP all agree on its
+#      value. Verify against the actual editor sources (krita/, gimp/, and
+#      Photoshop docs) — not against memory or web claims — before adding.
+#
+#   2. Darkly-original actions (no reference editor has any prior art) also
+#      live here. Mark them explicitly so reviewers don't mistake them for #1.
+#
+#   3. Anything else — any binding where the editors disagree, or where some
+#      editors have an opinion and others don't — must be split into each
+#      per-editor overlay (krita.yaml / photoshop.yaml / gimp.yaml). The
+#      `user → overlay → defaults` fallthrough makes silent inheritance the
+#      default; this rule keeps the per-editor file authoritative for any
+#      action that any editor would assign a key to, so an overlay can't
+#      accidentally reuse the same key for a different action.
 #
 # Settings inclusion rule: Darkly-specific configuration (canvas size,
 # animation rates, theme, …) that has no direct reference-editor analog
@@ -17,53 +25,42 @@
 # tools.colorPickerSampleSource) are split into the per-editor overlays.
 
 hotkeys:
-  # Photoshop binds Edit > Preferences to $mod+K; Krita/GIMP have no
-  # default. Darkly picks the macOS preferences convention.
-  openSettings: $mod+Comma
-  # Photoshop & GIMP both have export (Photoshop: $mod+Alt+W for "Export
-  # As"; GIMP: $mod+Shift+E for "Export As…"). Krita's `file_export_file`
-  # is explicitly `none`. Darkly picks GIMP's binding.
-  exportImage: $mod+Shift+KeyE
-  # Photoshop binds Lasso to L and Polygonal Lasso to Shift+L; Krita's
-  # selection-tool .action files have empty <shortcut>; GIMP's analog is
-  # "Free Select" (KeyF) with no polygonal counterpart. Darkly inherits
-  # Photoshop's choice; per-editor overlays can override.
-  lassoSelectTool: KeyL
-  polygonSelectTool: Shift+KeyL
-  # Krita binds View > Mirror View to M; Photoshop/GIMP have no default.
-  mirrorViewH: KeyM
-  # Darkly-original (brush builder).
+  # Universal edit / clipboard / file bindings — all three editors agree.
+  # (redo, pasteInPlace differ between editors and live per-overlay.)
+  undo: $mod+KeyZ
+  copy: $mod+KeyC
+  cut: $mod+KeyX
+  paste: $mod+KeyV
+  saveDocument: $mod+KeyS
+  saveDocumentAs: $mod+Shift+KeyS
+  open: $mod+KeyO
+  selectAll: $mod+KeyA
+  # Floating-selection commit / cancel. Enter / Escape are the universal
+  # commit/cancel keys across PS, Krita, and GIMP's floating-selection
+  # handlers.
+  clearSelectionContents: Delete
+  commitFloating: Enter
+  cancelFloating: Escape
+  # Colors — all three editors use D to reset, X to swap.
+  resetColors: KeyD
+  swapColors: KeyX
+  # Brush parameter hotkeys — `[` / `]` is the universal sizing convention.
+  brushSizeUp: BracketRight
+  brushSizeDown: BracketLeft
+  # Darkly-original (brush builder) — no reference-editor prior art.
   addBrushNode: Shift+KeyA
-  # PS + Krita both bind Quick Group to Ctrl+G. GIMP has no default
-  # (the Layer menu's group commands aren't bound). With layers
-  # selected, the action handler wraps them in the new group; with
-  # nothing selected, creates an empty group.
-  newGroup: $mod+KeyG
-  # PS + Krita both bind Merge Down to Ctrl+E. GIMP's only layer-merge
-  # default is Ctrl+M for "Merge Visible Layers" — semantically
-  # different. The `mergeDown` action handler is selection-aware:
-  # with ≥2 selected it bakes the selection via merge_layers, with 1
-  # it does the classic single-layer merge-down. One hotkey, two ops.
-  mergeDown: $mod+KeyE
-  # `flatten` and `addMask` are intentionally left unbound here:
-  #   - addMask: no reference editor has a default key (PS, Krita,
-  #     and GIMP all expose mask creation through a button click).
-  #     Inventing a Darkly-only binding would surprise users with no
-  #     prior-art expectation, and commit a key slot we'd later have
-  #     to fight if we register e.g. GIMP's Ctrl+M "Merge Visible".
+  # `flatten` and `addMask` are intentionally left unbound:
+  #   - addMask: no reference editor has a default key (PS, Krita, and
+  #     GIMP all expose mask creation through a button click). Inventing
+  #     a Darkly-only binding would surprise users with no prior-art
+  #     expectation, and commit a key slot we'd later have to fight if
+  #     we register e.g. GIMP's Ctrl+M "Merge Visible".
   #   - flatten: Krita binds Ctrl+Shift+E to "Flatten image" (the
   #     whole-canvas composite, which is Darkly's `flatten_image`
   #     engine op — not yet a registered action). Borrowing that key
   #     for Darkly's single-layer flatten (apply-mask / flatten-group)
   #     would mislead Krita users. If someone registers `flattenImage`
   #     as an action, that's where Ctrl+Shift+E belongs.
-
-mouse_clicks:
-  # Photoshop and Krita both use Alt+click on a layer/mask thumbnail to
-  # isolate; GIMP has no direct equivalent.
-  isolateLayer:
-    - layerThumb:alt+click
-    - maskThumb:alt+click
 
 settings:
   # Canvas defaults.
@@ -89,7 +86,7 @@ settings:
   ui.brushBuilder.previewWidth: 320
   ui.brushBuilder.previewHeight: 120
   # Input.
-  input.fingerPainting: false
+  input.fingerPainting: true
   # Editing.
   edit.activateTransformAfterPaste: true
   # Colors.

--- a/crates/darkly/presets/gimp.yaml
+++ b/crates/darkly/presets/gimp.yaml
@@ -1,33 +1,26 @@
-# GIMP overlay. Self-contained: every binding that any of the three
-# reference editors has an opinion on is spelled out here explicitly.
+# GIMP overlay. Carries every binding where GIMP's choice differs from
+# at least one other reference editor, plus Darkly fallbacks for actions
+# where GIMP has no opinion but some other editor does. Unanimous
+# bindings live in defaults.yaml; see the rule in defaults.yaml.
 name: GIMP
 description: GIMP-style keybindings
 
 hotkeys:
-  # Edit / clipboard / file.
-  undo: $mod+KeyZ
+  # Edit / clipboard (non-unanimous slice).
   # GIMP binds Redo to <primary>Y; <primary><shift>Z is "Strong Undo".
   # See gimp/app/actions/edit-actions.c.
   redo: $mod+KeyY
-  copy: $mod+KeyC
-  cut: $mod+KeyX
-  paste: $mod+KeyV
   # GIMP's edit-paste-in-place is <primary><alt>V (NOT <shift>V).
   # See gimp/app/actions/edit-actions.c.
   pasteInPlace: $mod+Alt+KeyV
-  saveDocument: $mod+KeyS
-  saveDocumentAs: $mod+Shift+KeyS
-  open: $mod+KeyO
-  selectAll: $mod+KeyA
-  clearSelectionContents: Delete
-  commitFloating: Enter
-  cancelFloating: Escape
-  # Colors.
-  resetColors: KeyD
-  swapColors: KeyX
-  # Brush size.
-  brushSizeUp: BracketRight
-  brushSizeDown: BracketLeft
+  # GIMP has no native Preferences hotkey. Fall through to Darkly's pick.
+  openSettings: $mod+Comma
+  # GIMP binds File > Export As… to <primary><shift>E (see
+  # gimp/app/actions/file-actions.c — `file-export-as`).
+  exportImage: $mod+Shift+KeyE
+  # mirrorViewH: intentionally unbound. GIMP has no native mirror-view
+  # hotkey, and Krita's M would set no established GIMP-user expectation
+  # — leave it for explicit user binding rather than invent a default.
   # Tools.
   brushTool: KeyP
   fillTool: Shift+KeyB
@@ -38,6 +31,12 @@ hotkeys:
   magicWandTool: KeyU
   transformTool: KeyT
   toggleEraseMode: Shift+KeyE
+  # GIMP's "Free Select" tool is the closest analog to Lasso — it handles
+  # both free-form and polygonal segments via mode within one tool.
+  # Registered with `F` in gimp/app/tools/gimpfreeselecttool.c
+  # (`gimp_free_select_tool_register`). polygonSelectTool is left unbound
+  # because GIMP has no separate polygonal tool.
+  lassoSelectTool: KeyF
   # Layers.
   isolateLayer: KeyI
   # GIMP's layers-delete action has no global accelerator (its accel slot is
@@ -46,8 +45,16 @@ hotkeys:
   deleteLayer: layerPanel:Delete
   # GIMP binds Layer > Duplicate Layer(s) to Ctrl+Shift+D.
   duplicateLayer: $mod+Shift+KeyD
-  # GIMP's "New Layer…" is bound to Ctrl+Shift+N (host docs line 298).
+  # GIMP's "New Layer…" is bound to Ctrl+Shift+N (layers-actions.c).
   newLayer: $mod+Shift+KeyN
+  # GIMP's `layers-new-group` has no global accelerator (layers-actions.c
+  # accel slot is { NULL }). Fall through to PS+Krita's Ctrl+G; this
+  # doesn't collide with any GIMP-side binding.
+  newGroup: $mod+KeyG
+  # GIMP's `layers-merge-down` has no global accelerator either; GIMP's
+  # only layer-merge default is Ctrl+M for "Merge Visible Layers" — a
+  # different op. Fall through to PS+Krita's Ctrl+E.
+  mergeDown: $mod+KeyE
   # Selection.
   clearSelection: $mod+Shift+KeyA
   invertSelection: $mod+KeyI
@@ -58,6 +65,9 @@ mouse_clicks:
   # modifier role. Darkly uses drag (continuous sample while held) instead of
   # click; `$mod` carries the platform swap.
   sampleColor: canvas@paint:$mod+drag
+  # isolateLayer mouse_click: GIMP has no thumbnail-modifier equivalent,
+  # so intentionally unbound here. The hotkey form (KeyI above) is the
+  # GIMP-native path.
 
 settings:
   tools.colorPickerSampleSource: merged

--- a/crates/darkly/presets/krita.yaml
+++ b/crates/darkly/presets/krita.yaml
@@ -1,31 +1,30 @@
-# Krita overlay. Self-contained: every binding that any of the three editors
-# (Krita / Photoshop / GIMP) has an opinion on is spelled out here explicitly
-# — nothing about Krita is silently inherited from defaults.yaml when any of
-# the three reference editors would have a binding for the action.
+# Krita overlay. Carries every binding where Krita's choice differs from
+# at least one other reference editor, plus Darkly fallbacks for actions
+# where Krita has no opinion but some other editor does. Unanimous
+# bindings (those all three reference editors agree on) live in
+# defaults.yaml; see the rule in defaults.yaml's header.
 name: Krita
 description: Krita-style keybindings
 
 hotkeys:
-  # Edit / clipboard / file.
-  undo: $mod+KeyZ
+  # Edit / clipboard (non-unanimous slice). Krita matches PS on these but
+  # GIMP differs (Redo: <primary>Y, Paste-In-Place: <primary><alt>V — see
+  # gimp/app/actions/edit-actions.c), so each value is pinned per-overlay.
   redo: $mod+Shift+KeyZ
-  copy: $mod+KeyC
-  cut: $mod+KeyX
-  paste: $mod+KeyV
   pasteInPlace: $mod+Shift+KeyV
-  saveDocument: $mod+KeyS
-  saveDocumentAs: $mod+Shift+KeyS
-  open: $mod+KeyO
-  selectAll: $mod+KeyA
-  clearSelectionContents: Delete
-  commitFloating: Enter
-  cancelFloating: Escape
-  # Colors.
-  resetColors: KeyD
-  swapColors: KeyX
-  # Brush size.
-  brushSizeUp: BracketRight
-  brushSizeDown: BracketLeft
+  # Krita has no native Preferences hotkey. Fall through to Darkly's
+  # macOS-convention pick; users can rebind via the settings UI.
+  openSettings: $mod+Comma
+  # Krita's `file_export_file` is explicitly `none` (see
+  # kritamenu.action). GIMP binds Export As to <primary><shift>E
+  # (gimp/app/actions/file-actions.c — `file-export-as`); Darkly inherits
+  # that key here.
+  exportImage: $mod+Shift+KeyE
+  # View > Mirror View. Krita binds M (kritamenu.action `mirror_canvas`,
+  # <shortcut>M</shortcut>). Photoshop and GIMP have no opinion; their
+  # overlays leave mirrorViewH unbound rather than reuse M (Photoshop's
+  # M is rectSelectTool).
+  mirrorViewH: KeyM
   # Tools.
   brushTool: KeyB
   fillTool: KeyF
@@ -36,14 +35,23 @@ hotkeys:
   magicWandTool: KeyW
   transformTool: KeyT
   toggleEraseMode: KeyE
+  # Krita's selection-tool .action files have empty <shortcut>. Fall
+  # through to Photoshop's L / Shift+L convention.
+  lassoSelectTool: KeyL
+  polygonSelectTool: Shift+KeyL
   # Layers.
   isolateLayer: KeyI
   deleteLayer: Shift+Delete
   duplicateLayer: $mod+KeyJ
-  # Krita's "Add Paint Layer" is bound to Insert (host docs line 187).
+  # Krita's "Add Paint Layer" is bound to Insert (kritamenu.action).
   newLayer: Insert
-  # mergeDown lives in defaults.yaml at the same key — all 2/3-consensus
-  # bindings consolidate there per the placement rule. No override needed.
+  # Krita binds "Quick Group" to Ctrl+G (krita.action).
+  newGroup: $mod+KeyG
+  # Krita binds "Merge with Layer Below" to Ctrl+E (krita.action
+  # `merge_layer`, <shortcut>Ctrl+E</shortcut>). The action handler is
+  # selection-aware: with ≥2 selected it bakes the selection via
+  # merge_layers, with 1 it does the classic single-layer merge-down.
+  mergeDown: $mod+KeyE
   # Selection.
   clearSelection: $mod+Shift+KeyA
   invertSelection: $mod+Shift+KeyI
@@ -54,6 +62,10 @@ mouse_clicks:
   sampleColor: canvas@paint:$mod+drag
   # Krita's "Change Primary Setting" — shift+drag scrubs brush size.
   brushSizeAdjust: canvas@paint:shift+drag
+  # Krita uses Alt+click on a layer/mask thumbnail to isolate the node.
+  isolateLayer:
+    - layerThumb:alt+click
+    - maskThumb:alt+click
 
 settings:
   tools.colorPickerSampleSource: merged

--- a/crates/darkly/presets/photoshop.yaml
+++ b/crates/darkly/presets/photoshop.yaml
@@ -1,29 +1,24 @@
-# Photoshop overlay. Self-contained: every binding that any of the three
-# reference editors has an opinion on is spelled out here explicitly.
+# Photoshop overlay. Carries every binding where Photoshop's choice
+# differs from at least one other reference editor, plus Darkly fallbacks
+# for actions where Photoshop has no opinion but some other editor does.
+# Unanimous bindings live in defaults.yaml; see the rule in defaults.yaml.
 name: Photoshop
 description: Adobe Photoshop-style keybindings
 
 hotkeys:
-  # Edit / clipboard / file.
-  undo: $mod+KeyZ
+  # Edit / clipboard (non-unanimous slice). PS matches Krita on these but
+  # GIMP differs.
   redo: $mod+Shift+KeyZ
-  copy: $mod+KeyC
-  cut: $mod+KeyX
-  paste: $mod+KeyV
   pasteInPlace: $mod+Shift+KeyV
-  saveDocument: $mod+KeyS
-  saveDocumentAs: $mod+Shift+KeyS
-  open: $mod+KeyO
-  selectAll: $mod+KeyA
-  clearSelectionContents: Delete
-  commitFloating: Enter
-  cancelFloating: Escape
-  # Colors.
-  resetColors: KeyD
-  swapColors: KeyX
-  # Brush size.
-  brushSizeUp: BracketRight
-  brushSizeDown: BracketLeft
+  # Photoshop binds Edit > Preferences to Ctrl+K (Cmd+K on macOS).
+  openSettings: $mod+KeyK
+  # Photoshop's File > Export > Export As… is Alt+Shift+Ctrl+W; Darkly
+  # uses the closer Alt+Ctrl+W variant.
+  exportImage: $mod+Alt+KeyW
+  # mirrorViewH: intentionally unbound. Photoshop has no native mirror-
+  # view action, and M is already taken by rectSelectTool here. Users
+  # who want a mirror-view hotkey under the PS preset can set one via
+  # the settings UI.
   # Tools.
   brushTool: KeyB
   fillTool: KeyG
@@ -34,6 +29,9 @@ hotkeys:
   magicWandTool: KeyW
   transformTool: $mod+KeyT
   toggleEraseMode: KeyE
+  # Photoshop binds Lasso to L and Polygonal Lasso to Shift+L.
+  lassoSelectTool: KeyL
+  polygonSelectTool: Shift+KeyL
   # Layers.
   # Delete on the Layers panel deletes the active layer; the global Delete
   # binding (clearSelectionContents) coexists via the binding-site scope.
@@ -41,8 +39,10 @@ hotkeys:
   duplicateLayer: $mod+KeyJ
   # Photoshop's "New Layer" is Ctrl+Shift+N.
   newLayer: $mod+Shift+KeyN
-  # mergeDown lives in defaults.yaml at the same key — all 2/3-consensus
-  # bindings consolidate there per the placement rule. No override needed.
+  # Photoshop binds Layer > Group Layers ("Quick Group") to Ctrl+G.
+  newGroup: $mod+KeyG
+  # Photoshop binds Layer > Merge Down to Ctrl+E.
+  mergeDown: $mod+KeyE
   # Selection.
   clearSelection: $mod+KeyD
   invertSelection: $mod+Shift+KeyI
@@ -50,6 +50,10 @@ hotkeys:
 mouse_clicks:
   # Photoshop's eyedropper modifier is Alt+drag (not Ctrl+drag).
   sampleColor: canvas@paint:alt+drag
+  # Photoshop uses Alt+click on a layer/mask thumbnail to isolate.
+  isolateLayer:
+    - layerThumb:alt+click
+    - maskThumb:alt+click
 
 settings:
   # Photoshop's eyedropper samples the current layer by default.

--- a/crates/darkly/src/bin/stroke_replay_matrix.rs
+++ b/crates/darkly/src/bin/stroke_replay_matrix.rs
@@ -68,19 +68,19 @@ const STABILIZE: f32 = 1.0;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Topology {
     /// Ink Pen brush through the `paint` terminal —
-    /// `pen → paint_color → circle (disc) → stamp → paint`.
+    /// `pen → paint_color → shape (disc) → stamp → paint`.
     /// Single instanced render pass per phase.
     Paint,
-    /// Wet Media (`Smooth Watercolor`) — `pen → paint_color → circle
+    /// Wet Media (`Smooth Watercolor`) — `pen → paint_color → shape
     /// (sine) → watercolor`. Two-pass per phase (pickup atlas
     /// + composite), composite shader is per-brush compiled.
     Watercolor,
-    /// Rough Ink — `pen + 3×random → circle(perlin) → stamp →
+    /// Rough Ink — `pen + 3×random → shape(perlin) → stamp →
     /// paint`. The original demo brush for the compiled
     /// framework; same terminal as Paint but a more elaborate upstream
-    /// graph (per-dab random nodes drive the perlin shape).
+    /// graph (per-dab random nodes drive the perlin silhouette).
     RoughInk,
-    /// Smudge — `pen → circle → smudge`. Per-dab fragment
+    /// Smudge — `pen → shape → smudge`. Per-dab fragment
     /// pass with a `copy_texture_to_texture` barrier between dabs so
     /// each dab reads the prior dab's writeback. Stresses the per-dab
     /// serialization path; expected dab counts per event are tens

--- a/crates/darkly/src/brush/eval.rs
+++ b/crates/darkly/src/brush/eval.rs
@@ -257,7 +257,7 @@ fn prng_f32(seed: u32, index: u32) -> f32 {
 /// overlay to place the `KIND_MASKED_STAMP` primitive (the cursor halo)
 /// — the cursor-preview mask texture itself is bound to the overlay
 /// separately. Rotation lives in the mask texture, not on the primitive:
-/// the compiled brush pipeline bakes `circle.rotation_input` and
+/// the compiled brush pipeline bakes `shape.rotation_input` and
 /// `view_rotation` into the rendered mask via the skeleton's `theta`,
 /// so the overlay quad samples an already-oriented mask.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]

--- a/crates/darkly/src/brush/eval.rs
+++ b/crates/darkly/src/brush/eval.rs
@@ -256,13 +256,14 @@ fn prng_f32(seed: u32, index: u32) -> f32 {
 /// terminal after a cursor-preview-mode evaluation. Consumed by the
 /// overlay to place the `KIND_MASKED_STAMP` primitive (the cursor halo)
 /// — the cursor-preview mask texture itself is bound to the overlay
-/// separately.
+/// separately. Rotation lives in the mask texture, not on the primitive:
+/// the compiled brush pipeline bakes `circle.rotation_input` and
+/// `view_rotation` into the rendered mask via the skeleton's `theta`,
+/// so the overlay quad samples an already-oriented mask.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct BrushCursorPreviewInfo {
     /// Half-extent in canvas pixels — the overlay primitive's `p1`.
     pub half_extent_canvas_px: [f32; 2],
-    /// Rotation in radians — the overlay primitive's `rotation`.
-    pub rotation_rad: f32,
 }
 
 /// Trait implemented by each node to produce output values.

--- a/crates/darkly/src/brush/mod.rs
+++ b/crates/darkly/src/brush/mod.rs
@@ -219,16 +219,27 @@ pub fn compile_graph(
     graph: &crate::nodegraph::Graph<BrushWireType>,
 ) -> Result<eval::BrushGraphRunner, String> {
     let registry = registry();
+    // Rewrite Switch nodes on a throwaway clone before any downstream
+    // consumer reads the graph. Every consumer below (runner, topo
+    // compile, WGSL compile) must see the same rewritten shape so a
+    // Switch never leaks past this point. The persisted graph is
+    // untouched — save/load, undo, and the brush-builder UI keep seeing
+    // the original placement.
+    let rewritten = {
+        let mut g = graph.clone();
+        nodes::switch::apply_to(&mut g);
+        g
+    };
     let evaluators = registry.evaluators();
-    let mut runner = eval::BrushGraphRunner::new(graph, registry.as_map(), evaluators)
+    let mut runner = eval::BrushGraphRunner::new(&rewritten, registry.as_map(), evaluators)
         .map_err(|e| format!("{e}"))?;
     if runner.has_terminal() {
         let plan =
-            crate::nodegraph::compile(graph, registry.as_map()).map_err(|e| format!("{e}"))?;
+            crate::nodegraph::compile(&rewritten, registry.as_map()).map_err(|e| format!("{e}"))?;
         // Build a fresh evaluators map for the compiler — the runner
         // owns the live one. Cheap (just trait-object constructors).
         let compile_evals = registry.evaluators();
-        let compiled = wgsl::compile_brush_to_wgsl(graph, &plan, &compile_evals)
+        let compiled = wgsl::compile_brush_to_wgsl(&rewritten, &plan, &compile_evals)
             .map_err(|e| format!("paint WGSL compilation failed: {e}"))?;
         runner.set_compiled_brush(std::sync::Arc::new(compiled));
     }
@@ -265,6 +276,12 @@ pub fn compile_from_json(json: &str) -> Result<eval::BrushGraphRunner, String> {
 pub fn reset_exposed_scrubs(graph: &mut crate::nodegraph::Graph<BrushWireType>) {
     let registry = registry();
     let mut resets: Vec<(crate::nodegraph::NodeId, String, f32)> = Vec::new();
+    // Walk every node and consult the *registration*'s `.exposed()`
+    // flag — only ports the node type declares as user-tunable by
+    // default get neutralized. Author-added entries in
+    // `graph.exposed_ports` (size, opacity, etc. that the author
+    // surfaced themselves) are part of the brush's identity and stay
+    // at the author's configured values for the thumbnail.
     for (id, node) in graph.nodes() {
         let Some(reg) = registry.get(&node.type_id) else {
             continue;
@@ -287,8 +304,11 @@ pub fn reset_exposed_scrubs(graph: &mut crate::nodegraph::Graph<BrushWireType>) 
 ///
 /// Returns Ok(()) or a human-readable error string.
 pub fn validate_graph_json(json: &str) -> Result<(), String> {
-    let graph: crate::nodegraph::Graph<BrushWireType> =
+    let mut graph: crate::nodegraph::Graph<BrushWireType> =
         serde_json::from_str(json).map_err(|e| format!("invalid graph JSON: {e}"))?;
+    // Mirror compile_graph: Switch rewriting must happen before the topo
+    // pass for validation to match what compilation will actually see.
+    nodes::switch::apply_to(&mut graph);
     let registry = registry();
     crate::nodegraph::compile(&graph, registry.as_map())
         .map_err(|e| format!("graph validation failed: {e}"))?;

--- a/crates/darkly/src/brush/mod.rs
+++ b/crates/darkly/src/brush/mod.rs
@@ -147,7 +147,7 @@ pub fn find_terminal(
 
 /// Build the default brush graph: pressure-sensitive disc through the
 /// compiled `paint` terminal. Same shape as Round in
-/// [`builtin_brushes`] — `pen → paint_color → circle (sine, amplitude 0)
+/// [`builtin_brushes`] — `pen → paint_color → shape (sine, amplitude 0)
 /// → stamp → paint` — minus the per-brush configuration
 /// closure (no exposed softness, no flow wire).
 pub fn default_graph() -> crate::nodegraph::Graph<BrushWireType> {
@@ -167,9 +167,9 @@ pub fn default_graph() -> crate::nodegraph::Graph<BrushWireType> {
         registry.get("paint_color").unwrap().ports.clone(),
         vec![],
     );
-    let circle = graph.add_node(
-        "circle",
-        registry.get("circle").unwrap().ports.clone(),
+    let shape = graph.add_node(
+        "shape",
+        registry.get("shape").unwrap().ports.clone(),
         vec![ParamValue::Int(0)], // sine, amplitude 0 → plain disc
     );
     let stamp = graph.add_node(
@@ -186,7 +186,7 @@ pub fn default_graph() -> crate::nodegraph::Graph<BrushWireType> {
     let wires = [
         (pen, "pressure", terminal, "flow"),
         (paint_color, "color", stamp, "color"),
-        (circle, "mask", stamp, "tip"),
+        (shape, "mask", stamp, "tip"),
         (stamp, "dab", terminal, "rgba"),
         (pen, "position", terminal, "position"),
     ];

--- a/crates/darkly/src/brush/nodes/circle.rs
+++ b/crates/darkly/src/brush/nodes/circle.rs
@@ -45,6 +45,7 @@ pub fn register() -> BrushNodeRegistration {
         type_id: TYPE_ID,
         category: "shape",
         display_name: "Circle",
+        description: "Soft round shape used as the brush tip.",
         ports: vec![
             PortDef::input("softness", BrushWireType::Scalar)
                 .with_range(0.0, 1.0, 0.5)

--- a/crates/darkly/src/brush/nodes/curve.rs
+++ b/crates/darkly/src/brush/nodes/curve.rs
@@ -26,6 +26,7 @@ pub fn register() -> BrushNodeRegistration {
             type_id: TYPE_ID,
             category: "modulate",
             display_name: "Curve",
+            description: "Reshapes a value through an editable response curve — e.g. make pressure ramp up sharply or ease in.",
             ports: vec![
                 PortDef::input("input", BrushWireType::Scalar)
                     .with_natural_range(0.0, 1.0)

--- a/crates/darkly/src/brush/nodes/image.rs
+++ b/crates/darkly/src/brush/nodes/image.rs
@@ -42,6 +42,7 @@ pub fn register() -> BrushNodeRegistration {
             type_id: TYPE_ID,
             category: "texture",
             display_name: "Image",
+            description: "Uses a picture from the brush bundle as the brush tip shape.",
             ports: vec![PortDef::output("color", BrushWireType::Vec4)
                 .with_description("RGBA value sampled from the named texture at the fragment's canvas-pixel position")],
             params: &[

--- a/crates/darkly/src/brush/nodes/levels.rs
+++ b/crates/darkly/src/brush/nodes/levels.rs
@@ -32,6 +32,7 @@ pub fn register() -> BrushNodeRegistration {
             type_id: TYPE_ID,
             category: "modulate",
             display_name: "Levels",
+            description: "Adjusts a value's low end, high end, and midpoint — the same idea as the image-editing Levels filter.",
             ports: vec![
                 PortDef::input("input", BrushWireType::Scalar)
                     .with_natural_range(0.0, 1.0)

--- a/crates/darkly/src/brush/nodes/liquify.rs
+++ b/crates/darkly/src/brush/nodes/liquify.rs
@@ -303,6 +303,7 @@ pub fn register() -> BrushNodeRegistration {
             type_id: TYPE_ID,
             category: "output",
             display_name: "Liquify",
+            description: "Output that pushes existing canvas pixels around in the direction of the stroke, like a warp brush.",
             ports: vec![
                 PortDef::input("position", BrushWireType::Vec2)
                     .with_description("Where to apply the warp"),
@@ -644,7 +645,7 @@ impl BrushNodeEvaluator for LiquifyEvaluator {
         gpu: &mut BrushGpuContext,
     ) -> Vec<(String, ScalarValue)> {
         let radius = Self::effective_radius(ctx);
-        let _ = crate::brush::wgsl::render_compiled_cursor_preview(gpu, radius, 0.0);
+        let _ = crate::brush::wgsl::render_compiled_cursor_preview(gpu, radius);
         vec![]
     }
 

--- a/crates/darkly/src/brush/nodes/liquify.rs
+++ b/crates/darkly/src/brush/nodes/liquify.rs
@@ -367,7 +367,7 @@ pub fn register() -> BrushNodeRegistration {
                 // strength multiplies by the upstream coverage. If
                 // unwired, defaults to 1.0 (uniform inside the disc).
                 PortDef::input("mask", BrushWireType::Scalar).with_description(
-                    "Per-fragment shape mask (typically wired from circle.mask); \
+                    "Per-fragment shape mask (typically wired from shape.mask); \
                      defaults to 1.0 (uniform inside the disc) when unwired.",
                 ),
                 PortDef::output("dab_size", BrushWireType::Vec2)

--- a/crates/darkly/src/brush/nodes/mod.rs
+++ b/crates/darkly/src/brush/nodes/mod.rs
@@ -2,7 +2,6 @@
 // To add a new module, create a .rs file in this directory
 // that exports `pub fn register() -> crate::brush::BrushNodeRegistration`.
 
-pub mod circle;
 pub mod curve;
 pub mod image;
 pub mod levels;
@@ -13,6 +12,7 @@ pub mod paint;
 pub mod paint_color;
 pub mod pen_input;
 pub mod random;
+pub mod shape;
 pub mod smudge;
 pub mod split_color;
 pub mod stamp;
@@ -24,7 +24,6 @@ use crate::brush::BrushNodeRegistration;
 #[rustfmt::skip]
 pub fn registrations() -> Vec<BrushNodeRegistration> {
     vec![
-        circle::register(),
         curve::register(),
         image::register(),
         levels::register(),
@@ -35,6 +34,7 @@ pub fn registrations() -> Vec<BrushNodeRegistration> {
         paint_color::register(),
         pen_input::register(),
         random::register(),
+        shape::register(),
         smudge::register(),
         split_color::register(),
         stamp::register(),

--- a/crates/darkly/src/brush/nodes/mod.rs
+++ b/crates/darkly/src/brush/nodes/mod.rs
@@ -16,6 +16,7 @@ pub mod random;
 pub mod smudge;
 pub mod split_color;
 pub mod stamp;
+pub mod switch;
 pub mod watercolor;
 
 use crate::brush::BrushNodeRegistration;
@@ -37,6 +38,7 @@ pub fn registrations() -> Vec<BrushNodeRegistration> {
         smudge::register(),
         split_color::register(),
         stamp::register(),
+        switch::register(),
         watercolor::register(),
     ]
 }

--- a/crates/darkly/src/brush/nodes/multiply.rs
+++ b/crates/darkly/src/brush/nodes/multiply.rs
@@ -47,7 +47,7 @@ impl BrushNodeEvaluator for MultiplyEvaluator {
     /// Inline scalar product into the compiled fragment shader.
     /// Required so brushes that route scalars through `multiply` on
     /// the way to the `paint` terminal (e.g. Charcoal:
-    /// `paper.luminance * threshold * circle.mask`) compile —
+    /// `paper.luminance * threshold * shape.mask`) compile —
     /// every upstream node of a compiled terminal must emit WGSL.
     fn compile_wgsl(&self, cctx: &CompileWgslCtx) -> Result<NodeWgsl, String> {
         let mut wgsl = NodeWgsl::default();

--- a/crates/darkly/src/brush/nodes/multiply.rs
+++ b/crates/darkly/src/brush/nodes/multiply.rs
@@ -15,6 +15,7 @@ pub fn register() -> BrushNodeRegistration {
             type_id: TYPE_ID,
             category: "math",
             display_name: "Multiply",
+            description: "Multiplies two values — use it to scale one signal by another, e.g. fade pressure by texture.",
             ports: vec![
                 PortDef::input("a", BrushWireType::Scalar)
                     .with_range(0.0, 1.0, 1.0)

--- a/crates/darkly/src/brush/nodes/noise.rs
+++ b/crates/darkly/src/brush/nodes/noise.rs
@@ -45,6 +45,7 @@ pub fn register() -> BrushNodeRegistration {
             type_id: TYPE_ID,
             category: "texture",
             display_name: "Noise",
+            description: "Procedural noise sampled where the brush touches the canvas — for grain, jitter, and texture.",
             ports: vec![
                 PortDef::output("color", BrushWireType::Vec4).with_description(
                     "Grayscale RGBA value noise at the fragment's canvas-pixel position",

--- a/crates/darkly/src/brush/nodes/paint.rs
+++ b/crates/darkly/src/brush/nodes/paint.rs
@@ -351,6 +351,7 @@ pub fn register() -> BrushNodeRegistration {
             type_id: TYPE_ID,
             category: "output",
             display_name: "Paint",
+            description: "Output that deposits a brush mark onto the canvas. Plug a Stamp Tip (or any colored mark) into the dab input — this is where paint actually lands.",
             ports: vec![
                 PortDef::input("position", BrushWireType::Vec2)
                     .with_description("Canvas-pixel pen tip for this dab"),
@@ -386,16 +387,6 @@ pub fn register() -> BrushNodeRegistration {
                     .with_icon("fa-solid fa-fill-drip")
                     .exposed()
                     .with_description("Stroke-level opacity cap (applied at commit)"),
-                // Cursor-preview rotation in radians. Wire from
-                // `pen.tilt_direction` or `pen.drawing_angle` to make
-                // the hover-cursor mask rotate with the pen. The
-                // current paint shader doesn't apply this to the
-                // stroke deposit — it's read only by
-                // `render_cursor_preview` for the overlay. Defaults to 0
-                // (no rotation).
-                PortDef::input("rotation", BrushWireType::Scalar)
-                    .with_range(-std::f32::consts::TAU, std::f32::consts::TAU, 0.0)
-                    .with_description("Cursor-preview rotation (radians)"),
                 // Typed as `Texture` to match the upstream `stamp.dab`
                 // output's wire type — the wire-type label is shared
                 // with the per-dab dispatch model where it'd be a
@@ -644,8 +635,7 @@ impl BrushNodeEvaluator for PaintEvaluator {
         gpu: &mut BrushGpuContext,
     ) -> Vec<(String, ScalarValue)> {
         let radius = Self::effective_radius(ctx);
-        let rotation_rad = ctx.input_f32("rotation");
-        let _ = crate::brush::wgsl::render_compiled_cursor_preview(gpu, radius, rotation_rad);
+        let _ = crate::brush::wgsl::render_compiled_cursor_preview(gpu, radius);
         vec![]
     }
 

--- a/crates/darkly/src/brush/nodes/paint.rs
+++ b/crates/darkly/src/brush/nodes/paint.rs
@@ -14,7 +14,7 @@
 //! - **The uniform buffer carries stroke-constant values** from any
 //!   upstream nodes that declared `uniform_fields` (e.g. `paint_color`).
 //!
-//! Upstream nodes (`circle`, `stamp`, etc.) compile inline into the
+//! Upstream nodes (`shape`, `stamp`, etc.) compile inline into the
 //! fragment shader and evaluate per-fragment-per-dab — no intermediate
 //! textures.
 //!

--- a/crates/darkly/src/brush/nodes/paint_color.rs
+++ b/crates/darkly/src/brush/nodes/paint_color.rs
@@ -20,6 +20,7 @@ pub fn register() -> BrushNodeRegistration {
             type_id: TYPE_ID,
             category: "color",
             display_name: "Paint Color",
+            description: "The color currently selected in the toolbar.",
             ports: vec![PortDef::output("color", BrushWireType::Vec4)
                 .with_description("Current foreground painting color (RGBA)")],
             params: &[],

--- a/crates/darkly/src/brush/nodes/pen_input.rs
+++ b/crates/darkly/src/brush/nodes/pen_input.rs
@@ -256,7 +256,7 @@ impl BrushNodeEvaluator for PenInputEvaluator {
             });
             // `drawing_angle` is `atan2(canvas_dy, canvas_dx)` — a
             // canvas-frame angle. The skeleton subtracts `view_rotation`
-            // from `theta`, so to keep `pen.drawing_angle → circle.rotation_input`
+            // from `theta`, so to keep `pen.drawing_angle → shape.rotation_input`
             // (the canonical stroke-follow wire) aligned with the on-
             // screen stroke direction, subtract `view_rotation` here too:
             // canvas-frame angle minus V = screen-frame angle. Both

--- a/crates/darkly/src/brush/nodes/pen_input.rs
+++ b/crates/darkly/src/brush/nodes/pen_input.rs
@@ -55,6 +55,7 @@ pub fn register() -> BrushNodeRegistration {
             type_id: TYPE_ID,
             category: "input",
             display_name: "Pen Input",
+            description: "Live data from the stylus: pressure, tilt, velocity, and position along the stroke.",
             ports: vec![
             PortDef::output("pressure", BrushWireType::Scalar)
                 .with_natural_range(0.0, 1.0)

--- a/crates/darkly/src/brush/nodes/random.rs
+++ b/crates/darkly/src/brush/nodes/random.rs
@@ -3,7 +3,7 @@
 //! Outputs a single scalar random value in `[0, 1)` — the raw PRNG natural
 //! range. Declares this as its wire-side `natural_range` so the runner
 //! remaps to whichever range the downstream port wants (e.g. `[0, 1024]`
-//! for `circle.seed`, `[-TAU, TAU]` for `circle.rotation`). A consumer that
+//! for `shape.seed`, `[-TAU, TAU]` for `shape.rotation`). A consumer that
 //! wants bipolar values just declares a `[-x, x]` natural range on its
 //! input — no special casing in this node.
 //!

--- a/crates/darkly/src/brush/nodes/random.rs
+++ b/crates/darkly/src/brush/nodes/random.rs
@@ -29,6 +29,7 @@ pub fn register() -> BrushNodeRegistration {
             type_id: TYPE_ID,
             category: "input",
             display_name: "Random",
+            description: "A new random value for every brush mark — useful for jittering size, color, angle, etc.",
             ports: vec![PortDef::output("value", BrushWireType::Scalar)
                 .with_natural_range(0.0, 1.0)
                 .with_description("Random value in [0, 1)")],

--- a/crates/darkly/src/brush/nodes/shape.rs
+++ b/crates/darkly/src/brush/nodes/shape.rs
@@ -1,4 +1,4 @@
-//! Procedural shape coverage GPU node.
+//! Procedural shape coverage GPU node — the brush-tip silhouette.
 //!
 //! Compile-only: contributes a per-fragment scalar coverage expression
 //! (`f32` in `[0, 1]`) to the brush's compiled WGSL via [`compile_wgsl`].
@@ -34,18 +34,18 @@ const ALGO_SINE: u32 = 0;
 const ALGO_PERLIN: u32 = 1;
 const ALGO_SUPERFORMULA: u32 = 2;
 
-pub const TYPE_ID: &str = "circle";
+pub const TYPE_ID: &str = "shape";
 
 pub fn register() -> BrushNodeRegistration {
     BrushNodeRegistration {
         pipelines: vec![],
-        evaluator: || Box::new(CircleEvaluator),
+        evaluator: || Box::new(ShapeEvaluator),
         lifecycle: crate::brush::node::Lifecycle::None,
         node: NodeRegistration {
         type_id: TYPE_ID,
         category: "shape",
-        display_name: "Circle",
-        description: "Soft round shape used as the brush tip.",
+        display_name: "Shape",
+        description: "Procedural brush-tip silhouette — disc, bumpy circle, or superformula.",
         ports: vec![
             PortDef::input("softness", BrushWireType::Scalar)
                 .with_range(0.0, 1.0, 0.5)
@@ -161,10 +161,10 @@ pub fn register() -> BrushNodeRegistration {
 }
 
 /// Gielis superformula with `a = b = 1`. Used only by
-/// [`CircleEvaluator::extent`] to bound the dab footprint when the
+/// [`ShapeEvaluator::extent`] to bound the dab footprint when the
 /// shape is set to Superformula; the per-fragment math lives in
 /// `shaders/brush/_shape.wgsl` and the compiled brush splices it in
-/// via [`CircleEvaluator::compile_wgsl`].
+/// via [`ShapeEvaluator::compile_wgsl`].
 fn superformula_r(theta: f32, frequency: f32, n1: f32, n2: f32, n3: f32) -> f32 {
     let m_quarter = frequency * theta * 0.25;
     let term_a = (m_quarter.cos().abs()).powf(n2);
@@ -176,9 +176,9 @@ fn superformula_r(theta: f32, frequency: f32, n1: f32, n2: f32, n3: f32) -> f32 
     sum.powf(-1.0 / n1)
 }
 
-pub struct CircleEvaluator;
+pub struct ShapeEvaluator;
 
-impl BrushNodeEvaluator for CircleEvaluator {
+impl BrushNodeEvaluator for ShapeEvaluator {
     fn evaluate_cpu(&self, _ctx: &EvalContext) -> Vec<(String, ScalarValue)> {
         vec![]
     }
@@ -222,8 +222,8 @@ impl BrushNodeEvaluator for CircleEvaluator {
         // block-let preserves a single `let` binding name downstream
         // nodes can substitute.
         //
-        // Edge coverage mirrors `shaders/brush/circle.wgsl`:
-        // smoothstep over a constant softness band (in unit-disc /
+        // Edge coverage: smoothstep over a constant softness band
+        // (in unit-disc /
         // natural units, independent of `r_at`), with a 0.004 AA
         // floor so softness == 0 still produces a one-pixel-ish
         // anti-aliased boundary instead of jagged stair-steps.
@@ -233,8 +233,8 @@ impl BrushNodeEvaluator for CircleEvaluator {
         // outward bumps get softer than inward dips — which reads as
         // "wonky" and exaggerates the noise band when the dab is
         // large.
-        let params_ident = cctx.ident("circle_params");
-        let shape_ident = cctx.ident("circle_shape");
+        let params_ident = cctx.ident("shape_params");
+        let shape_ident = cctx.ident("shape");
         let body = format!(
             "    let {params_ident}: ShapeParams = ShapeParams(\n\
              \x20       {algorithm}u,\n\

--- a/crates/darkly/src/brush/nodes/smudge.rs
+++ b/crates/darkly/src/brush/nodes/smudge.rs
@@ -283,6 +283,7 @@ pub fn register() -> BrushNodeRegistration {
             type_id: TYPE_ID,
             category: "output",
             display_name: "Smudge",
+            description: "Output that drags existing canvas pixels along the stroke, like smearing wet paint with a finger.",
             ports: vec![
                 PortDef::input("position", BrushWireType::Vec2)
                     .with_description("Canvas-pixel pen tip for this dab"),
@@ -607,15 +608,14 @@ impl BrushNodeEvaluator for SmudgeEvaluator {
 
     /// Hover-cursor preview. Routes through the shared preview helper.
     /// Smudge has no rotation port — the cursor is symmetric, and
-    /// rotating it wouldn't carry meaningful information for the
-    /// user. Publishes `rotation_rad: 0.0`.
+    /// rotating it wouldn't carry meaningful information for the user.
     fn render_cursor_preview(
         &self,
         ctx: &EvalContext,
         gpu: &mut BrushGpuContext,
     ) -> Vec<(String, ScalarValue)> {
         let radius = Self::effective_radius(ctx);
-        let _ = crate::brush::wgsl::render_compiled_cursor_preview(gpu, radius, 0.0);
+        let _ = crate::brush::wgsl::render_compiled_cursor_preview(gpu, radius);
         vec![]
     }
 

--- a/crates/darkly/src/brush/nodes/smudge.rs
+++ b/crates/darkly/src/brush/nodes/smudge.rs
@@ -328,7 +328,7 @@ pub fn register() -> BrushNodeRegistration {
                         "Overall stroke strength. Lower values reduce how much the smudge affects the canvas.",
                     ),
                 PortDef::input("mask", BrushWireType::Scalar).with_description(
-                    "Per-fragment shape mask (typically wired from circle.mask)",
+                    "Per-fragment shape mask (typically wired from shape.mask)",
                 ),
                 PortDef::output("dab_size", BrushWireType::Vec2)
                     .with_description("Brush mark size in canvas pixels"),

--- a/crates/darkly/src/brush/nodes/split_color.rs
+++ b/crates/darkly/src/brush/nodes/split_color.rs
@@ -24,6 +24,7 @@ pub fn register() -> BrushNodeRegistration {
             type_id: TYPE_ID,
             category: "math",
             display_name: "Split Color",
+            description: "Breaks a color into its red, green, blue, and opacity channels for separate processing.",
             ports: vec![
                 PortDef::input("color", BrushWireType::Vec4)
                     .with_description("The RGBA color to decompose into channels"),

--- a/crates/darkly/src/brush/nodes/stamp.rs
+++ b/crates/darkly/src/brush/nodes/stamp.rs
@@ -2,7 +2,7 @@
 //!
 //! Inlines `color × mask` into the brush's WGSL via [`compile_wgsl`].
 //! The upstream `tip` input is a scalar coverage expression (typically
-//! from `circle.texture`'s compile output); the emitted `dab` output is
+//! from `shape.mask`'s compile output); the emitted `dab` output is
 //! premultiplied RGBA that downstream paint terminals consume.
 //!
 //! Flow lives on the `paint` terminal — that is the single, authoritative

--- a/crates/darkly/src/brush/nodes/stamp.rs
+++ b/crates/darkly/src/brush/nodes/stamp.rs
@@ -27,6 +27,7 @@ pub fn register() -> BrushNodeRegistration {
             type_id: TYPE_ID,
             category: "shape",
             display_name: "Stamp Tip",
+            description: "Combines a tip shape with a color to form a colored brush mark. Feed this into a Paint output to deposit it on the canvas.",
             ports: vec![
                 PortDef::input("tip", BrushWireType::Scalar)
                     .with_natural_range(0.0, 1.0)

--- a/crates/darkly/src/brush/nodes/switch.rs
+++ b/crates/darkly/src/brush/nodes/switch.rs
@@ -49,6 +49,7 @@ pub fn register() -> BrushNodeRegistration {
             type_id: TYPE_ID,
             category: "math",
             display_name: "Switch",
+            description: "Toggle that picks one of two inputs. Wire one side only and it acts as an on/off switch for that branch.",
             ports: vec![
                 PortDef::input("in_0_scalar", BrushWireType::Scalar)
                     .with_description("Routed to out_scalar when select=0"),

--- a/crates/darkly/src/brush/nodes/switch.rs
+++ b/crates/darkly/src/brush/nodes/switch.rs
@@ -1,0 +1,417 @@
+//! Switch node — routes one of two inputs through to the output based on
+//! a static `select` flag, or removes the wire entirely so downstream falls
+//! back to its own port default.
+//!
+//! Generalises a gate: wire only `in_0_X`, leave `in_1_X` unconnected, and
+//! the switch behaves as an enable-on toggle (when `select` flips to 1 the
+//! chosen side is unconnected, so downstream sees no wire). Wire both sides
+//! and it becomes a 2-way mux.
+//!
+//! `select` is a Bool input port (not a `ParamDef`) so the brush author can
+//! expose it to the brush user as a toggle in BrushOptions. Per-instance
+//! `label`/`description` overrides (set via `Graph::set_port_label` /
+//! `set_port_description`) let the author rename the toggle for the brush
+//! user without inventing a parallel mechanism.
+//!
+//! The switch is dispatched at graph-rewrite time, before compilation, by
+//! [`apply_to`]: that walks the graph and, for every switch whose `select`
+//! port is *unconnected* (i.e. driven by its own default), splices the
+//! chosen upstream directly into the downstream, drops the other side, and
+//! removes the switch node. Switches whose `select` is dynamically wired
+//! are left in place and rejected by [`SwitchEvaluator::compile_wgsl`] in
+//! v1 — a runtime WGSL `select(...)` fallback is a follow-up if anyone
+//! actually wires it dynamically.
+
+use crate::brush::eval::{BrushNodeEvaluator, EvalContext};
+use crate::brush::node::BrushNodeRegistration;
+use crate::brush::wgsl::{CompileWgslCtx, NodeWgsl};
+use crate::brush::wire::{BrushWireType, ScalarValue};
+use crate::nodegraph::{Connection, Graph, NodeRegistration, PortDef, PortDir, PortRef};
+
+pub const TYPE_ID: &str = "switch";
+
+/// `(in_0, in_1, out)` port-name triplet per wire-type. The switch declares
+/// one triplet for each [`BrushWireType`]; the brush author wires whichever
+/// triplets they need and leaves the others unconnected.
+const TRIPLETS: &[(&str, &str, &str)] = &[
+    ("in_0_scalar", "in_1_scalar", "out_scalar"),
+    ("in_0_int", "in_1_int", "out_int"),
+    ("in_0_bool", "in_1_bool", "out_bool"),
+    ("in_0_vec2", "in_1_vec2", "out_vec2"),
+    ("in_0_vec4", "in_1_vec4", "out_vec4"),
+];
+
+const SELECT_PORT: &str = "select";
+
+pub fn register() -> BrushNodeRegistration {
+    BrushNodeRegistration::compute(
+        NodeRegistration {
+            type_id: TYPE_ID,
+            category: "math",
+            display_name: "Switch",
+            ports: vec![
+                PortDef::input("in_0_scalar", BrushWireType::Scalar)
+                    .with_description("Routed to out_scalar when select=0"),
+                PortDef::input("in_1_scalar", BrushWireType::Scalar)
+                    .with_description("Routed to out_scalar when select=1"),
+                PortDef::output("out_scalar", BrushWireType::Scalar)
+                    .with_description("Selected scalar"),
+                PortDef::input("in_0_int", BrushWireType::Int)
+                    .with_description("Routed to out_int when select=0"),
+                PortDef::input("in_1_int", BrushWireType::Int)
+                    .with_description("Routed to out_int when select=1"),
+                PortDef::output("out_int", BrushWireType::Int).with_description("Selected int"),
+                PortDef::input("in_0_bool", BrushWireType::Bool)
+                    .with_description("Routed to out_bool when select=0"),
+                PortDef::input("in_1_bool", BrushWireType::Bool)
+                    .with_description("Routed to out_bool when select=1"),
+                PortDef::output("out_bool", BrushWireType::Bool).with_description("Selected bool"),
+                PortDef::input("in_0_vec2", BrushWireType::Vec2)
+                    .with_description("Routed to out_vec2 when select=0"),
+                PortDef::input("in_1_vec2", BrushWireType::Vec2)
+                    .with_description("Routed to out_vec2 when select=1"),
+                PortDef::output("out_vec2", BrushWireType::Vec2).with_description("Selected vec2"),
+                PortDef::input("in_0_vec4", BrushWireType::Vec4)
+                    .with_description("Routed to out_vec4 when select=0"),
+                PortDef::input("in_1_vec4", BrushWireType::Vec4)
+                    .with_description("Routed to out_vec4 when select=1"),
+                PortDef::output("out_vec4", BrushWireType::Vec4).with_description("Selected vec4"),
+                PortDef::input(SELECT_PORT, BrushWireType::Bool)
+                    .with_range(0.0, 1.0, 0.0)
+                    .with_step(1.0)
+                    .with_label("Select")
+                    .with_description(
+                        "Routes one of two inputs to the output. If the \
+                         chosen input is unconnected, downstream falls back \
+                         to its own port default.",
+                    ),
+            ],
+            params: &[],
+            is_gpu: false,
+            is_terminal: false,
+            supports_erase: true,
+        },
+        || Box::new(SwitchEvaluator),
+    )
+}
+
+pub struct SwitchEvaluator;
+
+impl BrushNodeEvaluator for SwitchEvaluator {
+    /// Safety net only. [`apply_to`] removes Switch nodes before the
+    /// runner ever sees them; if one survives (dynamic `select` wiring),
+    /// just route the chosen side so a CPU eval doesn't produce garbage.
+    fn evaluate_cpu(&self, ctx: &EvalContext) -> Vec<(String, ScalarValue)> {
+        let select_to_1 = ctx.input(SELECT_PORT).as_f32() >= 0.5;
+        let mut out = Vec::with_capacity(TRIPLETS.len());
+        for (in_0, in_1, out_name) in TRIPLETS {
+            let chosen = if select_to_1 { *in_1 } else { *in_0 };
+            out.push(((*out_name).to_string(), ctx.input(chosen)));
+        }
+        out
+    }
+
+    fn compile_wgsl(&self, _cctx: &CompileWgslCtx) -> Result<NodeWgsl, String> {
+        // Reaching this means `apply_to` left the switch in place — which
+        // only happens when `select` is dynamically wired. v1 rejects.
+        Err(
+            "Switch.select must be a static value; dynamic wiring is not \
+             yet supported. Disconnect the wire on the `select` port and \
+             toggle it via its exposed slider/value instead."
+                .into(),
+        )
+    }
+}
+
+/// Rewrite every Switch node in `graph` in place: splice the chosen input
+/// through to all downstreams (or drop the wire entirely if the chosen
+/// input is unconnected), then remove the Switch.
+///
+/// Switches whose `select` port has an incoming connection are left alone
+/// — those are dynamic and handled (rejected, in v1) by
+/// [`SwitchEvaluator::compile_wgsl`].
+///
+/// Called by [`crate::brush::compile_graph`] on a throwaway clone of the
+/// user's graph — the persisted graph is never mutated.
+pub(crate) fn apply_to(graph: &mut Graph<BrushWireType>) {
+    let switch_ids: Vec<_> = graph
+        .nodes()
+        .iter()
+        .filter(|(_, n)| n.type_id == TYPE_ID)
+        .map(|(id, _)| *id)
+        .collect();
+
+    for switch_id in switch_ids {
+        // Dynamic select → leave for WGSL compile to reject.
+        let select_wired = graph
+            .connections
+            .iter()
+            .any(|c| c.to.node == switch_id && c.to.port == SELECT_PORT);
+        if select_wired {
+            continue;
+        }
+
+        // Read the (possibly per-instance overridden) default of `select`.
+        let select_to_1 = {
+            let Some(node) = graph.nodes().get(&switch_id) else {
+                continue;
+            };
+            node.ports
+                .iter()
+                .find(|p| p.name == SELECT_PORT && p.dir == PortDir::Input)
+                .map(|p| p.default >= 0.5)
+                .unwrap_or(false)
+        };
+
+        for (in_0, in_1, out_name) in TRIPLETS {
+            let chosen_in = if select_to_1 { *in_1 } else { *in_0 };
+
+            // Snapshot the chosen upstream and every downstream first so
+            // we can mutate `graph.connections` without overlapping borrows.
+            let upstream: Option<PortRef> = graph
+                .connections
+                .iter()
+                .find(|c| c.to.node == switch_id && c.to.port == chosen_in)
+                .map(|c| c.from.clone());
+            let downstreams: Vec<PortRef> = graph
+                .connections
+                .iter()
+                .filter(|c| c.from.node == switch_id && c.from.port == *out_name)
+                .map(|c| c.to.clone())
+                .collect();
+
+            // Drop every edge touching this triplet's switch ports
+            // (including the unchosen `in_X`, which now goes nowhere).
+            graph.connections.retain(|c| {
+                !(c.to.node == switch_id && (c.to.port == *in_0 || c.to.port == *in_1))
+                    && !(c.from.node == switch_id && c.from.port == *out_name)
+            });
+
+            // Splice upstream → downstreams. If no upstream, the
+            // downstreams are now unconnected and fall back to their
+            // declared port defaults via `EvalContext::input` /
+            // `CompileWgslCtx::input`.
+            if let Some(up) = upstream {
+                for down in downstreams {
+                    graph.connections.push(Connection {
+                        from: up.clone(),
+                        to: down,
+                    });
+                }
+            }
+        }
+
+        // remove_node also drops any stray edges still touching the switch
+        // (e.g. anyone wiring `out_X` after we cleared it — shouldn't
+        // happen, but cheap insurance).
+        let _ = graph.remove_node(switch_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::brush;
+    use crate::gpu::params::ParamValue;
+    use crate::nodegraph::{Connection, Graph, NodeId, PortRef};
+
+    /// Helper: instantiate a node of `type_id` from the live registry,
+    /// using the registration's default params.
+    fn add_node(graph: &mut Graph<BrushWireType>, type_id: &str) -> NodeId {
+        let registry = brush::registry();
+        let reg = registry
+            .get(type_id)
+            .unwrap_or_else(|| panic!("no registration for {type_id}"));
+        let params: Vec<ParamValue> = reg.params.iter().map(|p| p.default_value()).collect();
+        graph.add_node(type_id, reg.ports.clone(), params)
+    }
+
+    fn pr(node: NodeId, port: &str) -> PortRef {
+        PortRef {
+            node,
+            port: port.into(),
+        }
+    }
+
+    /// `paint_color → switch.in_0_vec4 → switch.out_vec4 → stamp.color`,
+    /// select=0 → expect a direct `paint_color → stamp.color` after rewrite.
+    #[test]
+    fn enabled_default_splices_through() {
+        let mut graph = Graph::<BrushWireType>::new();
+        let paint_color = add_node(&mut graph, "paint_color");
+        let switch_id = add_node(&mut graph, TYPE_ID);
+        let stamp = add_node(&mut graph, "stamp");
+
+        graph
+            .connect(pr(paint_color, "color"), pr(switch_id, "in_0_vec4"))
+            .unwrap();
+        graph
+            .connect(pr(switch_id, "out_vec4"), pr(stamp, "color"))
+            .unwrap();
+
+        apply_to(&mut graph);
+
+        // Switch removed.
+        assert!(
+            graph.nodes().get(&switch_id).is_none(),
+            "switch node should be removed after rewrite"
+        );
+        // Direct edge spliced through.
+        assert!(
+            graph
+                .connections
+                .iter()
+                .any(|c| c.from == pr(paint_color, "color") && c.to == pr(stamp, "color")),
+            "expected paint_color → stamp.color after splice; got {:?}",
+            graph.connections
+        );
+    }
+
+    /// Same wiring, `select=1` → chosen side (`in_1_vec4`) is unconnected,
+    /// so `stamp.color` ends up disconnected after rewrite.
+    #[test]
+    fn disabled_drops_wire_so_downstream_uses_default() {
+        let mut graph = Graph::<BrushWireType>::new();
+        let paint_color = add_node(&mut graph, "paint_color");
+        let switch_id = add_node(&mut graph, TYPE_ID);
+        let stamp = add_node(&mut graph, "stamp");
+
+        graph
+            .connect(pr(paint_color, "color"), pr(switch_id, "in_0_vec4"))
+            .unwrap();
+        graph
+            .connect(pr(switch_id, "out_vec4"), pr(stamp, "color"))
+            .unwrap();
+
+        // Flip select to 1 — `in_1_vec4` is unconnected so the wire is dropped.
+        graph.set_port_default(switch_id, SELECT_PORT, 1.0).unwrap();
+
+        apply_to(&mut graph);
+
+        assert!(graph.nodes().get(&switch_id).is_none());
+        assert!(
+            !graph.connections.iter().any(|c| c.to == pr(stamp, "color")),
+            "stamp.color should be unconnected after rewrite; got {:?}",
+            graph.connections
+        );
+    }
+
+    /// Two inputs wired; toggling `select` routes one through and drops the other.
+    #[test]
+    fn mux_mode_routes_chosen_input_and_drops_unchosen() {
+        // select=0 → in_0 wired through.
+        {
+            let mut graph = Graph::<BrushWireType>::new();
+            let paint_color = add_node(&mut graph, "paint_color");
+            let switch_id = add_node(&mut graph, TYPE_ID);
+            let stamp = add_node(&mut graph, "stamp");
+
+            // Both sides wired; in_0 from paint_color, in_1 from another
+            // unrelated source. We don't have a "constant color" node handy
+            // so we fake it by leaving in_1 connected to a second paint_color.
+            let paint_color_b = add_node(&mut graph, "paint_color");
+            graph
+                .connect(pr(paint_color, "color"), pr(switch_id, "in_0_vec4"))
+                .unwrap();
+            graph
+                .connect(pr(paint_color_b, "color"), pr(switch_id, "in_1_vec4"))
+                .unwrap();
+            graph
+                .connect(pr(switch_id, "out_vec4"), pr(stamp, "color"))
+                .unwrap();
+
+            apply_to(&mut graph);
+
+            assert!(graph.nodes().get(&switch_id).is_none());
+            assert!(
+                graph
+                    .connections
+                    .iter()
+                    .any(|c| c.from == pr(paint_color, "color") && c.to == pr(stamp, "color")),
+                "select=0 should route paint_color (in_0) → stamp.color"
+            );
+            assert!(
+                !graph
+                    .connections
+                    .iter()
+                    .any(|c| c.from == pr(paint_color_b, "color")),
+                "paint_color_b (in_1) should be disconnected"
+            );
+        }
+
+        // select=1 → in_1 wired through.
+        {
+            let mut graph = Graph::<BrushWireType>::new();
+            let paint_color = add_node(&mut graph, "paint_color");
+            let switch_id = add_node(&mut graph, TYPE_ID);
+            let stamp = add_node(&mut graph, "stamp");
+            let paint_color_b = add_node(&mut graph, "paint_color");
+            graph
+                .connect(pr(paint_color, "color"), pr(switch_id, "in_0_vec4"))
+                .unwrap();
+            graph
+                .connect(pr(paint_color_b, "color"), pr(switch_id, "in_1_vec4"))
+                .unwrap();
+            graph
+                .connect(pr(switch_id, "out_vec4"), pr(stamp, "color"))
+                .unwrap();
+
+            graph.set_port_default(switch_id, SELECT_PORT, 1.0).unwrap();
+
+            apply_to(&mut graph);
+
+            assert!(graph.nodes().get(&switch_id).is_none());
+            assert!(
+                graph
+                    .connections
+                    .iter()
+                    .any(|c| c.from == pr(paint_color_b, "color") && c.to == pr(stamp, "color")),
+                "select=1 should route paint_color_b (in_1) → stamp.color"
+            );
+            assert!(
+                !graph
+                    .connections
+                    .iter()
+                    .any(|c| c.from == pr(paint_color, "color")),
+                "paint_color (in_0) should be disconnected"
+            );
+        }
+    }
+
+    /// A wire into the `select` port keeps the switch in the graph so the
+    /// WGSL compile can reject it. There's no other Bool-output node in the
+    /// registry today (the switch is the first), so we synthesize the
+    /// connection directly — `apply_to` doesn't re-validate wire types.
+    #[test]
+    fn dynamic_select_leaves_switch_in_place() {
+        let mut graph = Graph::<BrushWireType>::new();
+        let paint_color = add_node(&mut graph, "paint_color");
+        let switch_id = add_node(&mut graph, TYPE_ID);
+        let stamp = add_node(&mut graph, "stamp");
+        graph
+            .connect(pr(paint_color, "color"), pr(switch_id, "in_0_vec4"))
+            .unwrap();
+        graph
+            .connect(pr(switch_id, "out_vec4"), pr(stamp, "color"))
+            .unwrap();
+        // Synthetic dynamic-select wire (no real Bool source exists yet).
+        graph.connections.push(Connection {
+            from: pr(paint_color, "color"),
+            to: pr(switch_id, SELECT_PORT),
+        });
+
+        apply_to(&mut graph);
+
+        assert!(
+            graph.nodes().get(&switch_id).is_some(),
+            "switch with dynamic select should NOT be rewritten away"
+        );
+        assert!(
+            graph
+                .connections
+                .iter()
+                .any(|c| c.to == pr(switch_id, SELECT_PORT)),
+            "dynamic select wire should still be present"
+        );
+    }
+}

--- a/crates/darkly/src/brush/nodes/watercolor.rs
+++ b/crates/darkly/src/brush/nodes/watercolor.rs
@@ -597,6 +597,7 @@ pub fn register() -> BrushNodeRegistration {
                     .with_natural_range(0.0, 1.0)
                     .with_label("Deposit")
                     .with_unit(UnitType::Percent)
+                    .with_icon("fa-solid fa-circle")
                     .exposed()
                     .with_description(
                         "How strongly the brush color replaces the pickup canvas color",

--- a/crates/darkly/src/brush/nodes/watercolor.rs
+++ b/crates/darkly/src/brush/nodes/watercolor.rs
@@ -13,7 +13,7 @@
 //!    atlas_w)`.
 //! 2. **Composite pass.** One instanced draw, N quads. The fragment
 //!    shader is the framework-assembled per-brush WGSL: upstream
-//!    nodes (`circle`, `paint_color`, etc.) compile inline; this
+//!    nodes (`shape`, `paint_color`, etc.) compile inline; this
 //!    terminal contributes the watercolor blend math (atlas pickup +
 //!    deposit/wetness load) and the extra atlas bind group.
 //!
@@ -23,12 +23,12 @@
 //!   `amplitude`, `frequency`, etc. as ports on the terminal and
 //!   evaluated the procedural shape inline. Here the upstream graph
 //!   provides a scalar `mask` input (typically wired from
-//!   `circle.texture`), and the composite's fragment shader inlines
-//!   whatever WGSL the circle node emits.
+//!   `shape.mask`), and the composite's fragment shader inlines
+//!   whatever WGSL the shape node emits.
 //! - **No CPU centroid integration.** `watercolor_batched` integrated
 //!   the asymmetric shape's centroid on the CPU and packed it into
 //!   the dab record to pin the shape to the pen tip. The compiled
-//!   `circle` currently emits its shape centered on the local origin
+//!   `shape` currently emits its silhouette centered on the local origin
 //!   without translation. If the compiled shape's centroid drifts off
 //!   the pen tip noticeably, restoring a centroid step is a focused
 //!   follow-up.
@@ -625,7 +625,7 @@ pub fn register() -> BrushNodeRegistration {
                 PortDef::input("color", BrushWireType::Vec4)
                     .with_description("Brush color (typically wired from paint_color)"),
                 PortDef::input("mask", BrushWireType::Scalar).with_description(
-                    "Per-fragment shape mask (typically wired from circle.mask)",
+                    "Per-fragment shape mask (typically wired from shape.mask)",
                 ),
                 PortDef::output("dab_size", BrushWireType::Vec2)
                     .with_description("Brush mark size in canvas pixels"),

--- a/crates/darkly/src/brush/nodes/watercolor.rs
+++ b/crates/darkly/src/brush/nodes/watercolor.rs
@@ -557,6 +557,7 @@ pub fn register() -> BrushNodeRegistration {
             type_id: TYPE_ID,
             category: "output",
             display_name: "Watercolor",
+            description: "Output for wet-on-wet watercolor: pigment bleeds, pools, and darkens at the edges.",
             ports: vec![
                 PortDef::input("position", BrushWireType::Vec2)
                     .with_description("Canvas-pixel pen tip for this dab"),
@@ -623,14 +624,6 @@ pub fn register() -> BrushNodeRegistration {
                     ),
                 PortDef::input("color", BrushWireType::Vec4)
                     .with_description("Brush color (typically wired from paint_color)"),
-                // Cursor-preview rotation in radians. Read only by
-                // `render_cursor_preview` and published into
-                // `BrushCursorPreviewInfo.rotation_rad`; the stroke shader
-                // doesn't apply it (rotation in stroke deposit is a
-                // separate concern). Defaults to 0.
-                PortDef::input("rotation", BrushWireType::Scalar)
-                    .with_range(-std::f32::consts::TAU, std::f32::consts::TAU, 0.0)
-                    .with_description("Cursor-preview rotation (radians)"),
                 PortDef::input("mask", BrushWireType::Scalar).with_description(
                     "Per-fragment shape mask (typically wired from circle.mask)",
                 ),
@@ -903,8 +896,7 @@ impl BrushNodeEvaluator for WatercolorEvaluator {
         gpu: &mut BrushGpuContext,
     ) -> Vec<(String, ScalarValue)> {
         let radius = Self::effective_radius(ctx);
-        let rotation_rad = ctx.input_f32("rotation");
-        let _ = crate::brush::wgsl::render_compiled_cursor_preview(gpu, radius, rotation_rad);
+        let _ = crate::brush::wgsl::render_compiled_cursor_preview(gpu, radius);
         vec![]
     }
 

--- a/crates/darkly/src/brush/paint_info.rs
+++ b/crates/darkly/src/brush/paint_info.rs
@@ -100,7 +100,17 @@ impl PaintInformation {
 
         let dx = self.pos[0] - prev.pos[0];
         let dy = self.pos[1] - prev.pos[1];
-        self.drawing_angle = dy.atan2(dx);
+        // Coalesced pointer events at the same coords would make
+        // `atan2(0, 0) = 0` snap drawing_angle to 0 on stationary
+        // frames, flickering the cursor preview between the real
+        // direction and 0. Mirrors `stroke_engine.rs`'s 0.001 px
+        // arc-length floor: preserve prev's direction across a
+        // stationary segment.
+        if segment_length > 1.0e-3 {
+            self.drawing_angle = dy.atan2(dx);
+        } else {
+            self.drawing_angle = prev.drawing_angle;
+        }
         self.distance = prev.distance + segment_length;
 
         let dt = self.time - prev.time;

--- a/crates/darkly/src/brush/portable.rs
+++ b/crates/darkly/src/brush/portable.rs
@@ -454,18 +454,18 @@ mod tests {
     fn port_overrides_survive() {
         let registry = registry();
         let mut graph = crate::brush::default_graph();
-        let circle = *graph
+        let shape = *graph
             .nodes()
             .iter()
-            .find(|(_, n)| n.type_id == "circle")
+            .find(|(_, n)| n.type_id == "shape")
             .map(|(id, _)| id)
-            .expect("default has a circle node");
-        graph.set_port_default(circle, "softness", 0.37).unwrap();
-        graph.expose_port(circle, "softness").unwrap();
-        let circle_key = exposed_port_key(circle, "softness");
+            .expect("default has a shape node");
+        graph.set_port_default(shape, "softness", 0.37).unwrap();
+        graph.expose_port(shape, "softness").unwrap();
+        let shape_key = exposed_port_key(shape, "softness");
         graph
             .set_exposed_port_meta(
-                &circle_key,
+                &shape_key,
                 "Softness".into(),
                 "Edge falloff".into(),
                 "fa-solid fa-circle-half-stroke".into(),
@@ -478,19 +478,19 @@ mod tests {
             .unwrap()
             .into_graph(registry)
             .unwrap();
-        let restored_circle = restored
+        let restored_shape = restored
             .nodes()
             .values()
-            .find(|n| n.type_id == "circle")
-            .expect("restored graph has a circle node");
-        let port = restored_circle
+            .find(|n| n.type_id == "shape")
+            .expect("restored graph has a shape node");
+        let port = restored_shape
             .ports
             .iter()
             .find(|p| p.name == "softness")
             .unwrap();
         assert!((port.default - 0.37).abs() < 1e-6);
-        assert!(restored.is_port_exposed(restored_circle.id, "softness"));
-        let restored_key = exposed_port_key(restored_circle.id, "softness");
+        assert!(restored.is_port_exposed(restored_shape.id, "softness"));
+        let restored_key = exposed_port_key(restored_shape.id, "softness");
         let meta = &restored.exposed_ports[&restored_key];
         assert_eq!(meta.label, "Softness");
         assert_eq!(meta.description, "Edge falloff");
@@ -521,7 +521,7 @@ nodes:
         let yaml = "\
 nodes:
   1:
-    type: circle
+    type: shape
     params:
       this_param_does_not_exist: 1
 ";
@@ -538,7 +538,7 @@ nodes:
         let yaml = "\
 nodes:
   1:
-    type: circle
+    type: shape
     params:
       algorithm: [[0.0, 0.0], [1.0, 1.0]]
 ";

--- a/crates/darkly/src/brush/portable.rs
+++ b/crates/darkly/src/brush/portable.rs
@@ -37,7 +37,8 @@ use crate::brush::stabilizer::StabilizerConfig;
 use crate::brush::wire::BrushWireType;
 use crate::brush::BrushNodeRegistry;
 use crate::gpu::params::{ParamValue, PortableValue};
-use crate::nodegraph::{Graph, NodeId, PortDir, PortRef};
+use crate::nodegraph::{exposed_port_key, ExposedPortMeta, Graph, NodeId, PortDir, PortRef};
+use indexmap::IndexMap;
 
 /// Portable, YAML-friendly snapshot of a brush. Top-level metadata is
 /// optional — present for full brushes, omitted for graph-only snippets
@@ -61,6 +62,13 @@ pub struct PortableBrush {
     pub nodes: BTreeMap<u64, PortableNode>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub connections: Vec<PortableConnection>,
+    /// Ordered brush-bar entries. Keys are `"<yaml_node_id>.<port_name>"`
+    /// (matching the `nodes` map). On import the yaml id is rewritten to
+    /// the freshly-assigned internal `NodeId`. Order is the brush-bar
+    /// display order — `IndexMap` preserves it through every YAML/JSON
+    /// round trip.
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub exposed_ports: IndexMap<String, ExposedPortMeta>,
 }
 
 /// A single node entry in the portable form.
@@ -73,8 +81,6 @@ pub struct PortableNode {
     pub params: BTreeMap<String, PortableValue>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub port_defaults: BTreeMap<String, f32>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub exposed: Vec<String>,
 }
 
 /// A wire serialized as `"<from_id>.<from_port> -> <to_id>.<to_port>"`.
@@ -194,10 +200,6 @@ impl PortableBrush {
             // values are; cross-reference the registration to know
             // which to drop.
             let mut port_defaults = BTreeMap::new();
-            // Exposed: complete list of input ports flagged exposed on
-            // the instance. Declarative, no registration lookup needed
-            // on import.
-            let mut exposed = Vec::new();
             for port in &node.ports {
                 if port.dir != PortDir::Input {
                     continue;
@@ -210,11 +212,7 @@ impl PortableBrush {
                 if Some(port.default) != reg_default {
                     port_defaults.insert(port.name.clone(), port.default);
                 }
-                if port.exposed {
-                    exposed.push(port.name.clone());
-                }
             }
-            exposed.sort();
 
             nodes.insert(
                 id.0,
@@ -222,7 +220,6 @@ impl PortableBrush {
                     type_id: node.type_id.clone(),
                     params,
                     port_defaults,
-                    exposed,
                 },
             );
         }
@@ -247,9 +244,15 @@ impl PortableBrush {
             ))
         });
 
+        // Brush-bar entries: graph keys are already `"<NodeId>.<port>"`
+        // and the in-memory `id.0` doubles as the yaml id, so the map
+        // can be copied wholesale.
+        let exposed_ports = graph.exposed_ports.clone();
+
         Ok(Self {
             nodes,
             connections,
+            exposed_ports,
             ..Self::default()
         })
     }
@@ -319,7 +322,7 @@ impl PortableBrush {
             }
 
             // Ports: clone from registration, then apply port_defaults
-            // and exposed overrides.
+            // overrides.
             let mut ports = reg.ports.clone();
             for (name, &value) in &pn.port_defaults {
                 let port = ports
@@ -332,22 +335,6 @@ impl PortableBrush {
                         )
                     })?;
                 port.default = value;
-            }
-            // Exposed list is declarative: every input port's `exposed`
-            // flag is reset, then ports named in the list are set true.
-            for port in ports.iter_mut() {
-                if port.dir == PortDir::Input {
-                    port.exposed = false;
-                }
-            }
-            for name in &pn.exposed {
-                let port = ports
-                    .iter_mut()
-                    .find(|p| p.name == *name && p.dir == PortDir::Input)
-                    .ok_or_else(|| {
-                        format!("unknown input port '{name}' on '{}' (exposed)", pn.type_id)
-                    })?;
-                port.exposed = true;
             }
 
             let new_id = graph.add_node(pn.type_id.clone(), ports, params);
@@ -384,6 +371,27 @@ impl PortableBrush {
                 &b.to.port,
             ))
         });
+
+        // Brush-bar entries: `add_node` auto-populated `exposed_ports`
+        // from each registration's `.exposed()` flag. The portable form
+        // is authoritative, so clear that and re-populate from the saved
+        // map, rewriting yaml ids to the freshly-assigned NodeIds.
+        // Malformed or stale keys are skipped silently — the import
+        // already validated nodes/ports above.
+        graph.exposed_ports.clear();
+        for (yaml_key, meta) in &self.exposed_ports {
+            let Some((yid_str, port_name)) = yaml_key.split_once('.') else {
+                continue;
+            };
+            let Ok(yaml_id) = yid_str.parse::<u64>() else {
+                continue;
+            };
+            let Some(&new_id) = id_map.get(&yaml_id) else {
+                continue;
+            };
+            let new_key = exposed_port_key(new_id, port_name);
+            graph.exposed_ports.insert(new_key, meta.clone());
+        }
         Ok(graph)
     }
 }
@@ -394,12 +402,8 @@ mod tests {
     use crate::brush::registry;
 
     /// Round-trip the default graph and confirm the result compiles to
-    /// the same shape (nodes, connections, params, port defaults,
-    /// exposed flags) as the original. This is the headline guarantee
-    /// of the portable form. The default graph has unique type_ids per
-    /// node, so we match originals to restorations by type_id rather
-    /// than by NodeId — the round trip is not required to preserve
-    /// internal ids, only topology.
+    /// the same shape (nodes, connections, params, port defaults) as the
+    /// original. Brush-bar entries are covered by `port_overrides_survive`.
     #[test]
     fn default_graph_round_trip() {
         let registry = registry();
@@ -436,18 +440,16 @@ mod tests {
                     port.default,
                     r.default
                 );
-                assert_eq!(
-                    port.exposed, r.exposed,
-                    "exposed mismatch on {}.{}",
-                    original.type_id, port.name
-                );
             }
         }
+        // Brush-bar entry count matches across the round trip.
+        assert_eq!(graph.exposed_ports.len(), restored.exposed_ports.len());
     }
 
-    /// Port-default overrides and exposed flags must survive a round
-    /// trip — the round trip is reversible if and only if the per-port
-    /// state encoded in `port_defaults` and `exposed` returns intact.
+    /// Port-default overrides and brush-bar exposure (with custom meta)
+    /// must survive a round trip — the round trip is reversible if and
+    /// only if both per-port defaults and the graph-level
+    /// `exposed_ports` map return intact.
     #[test]
     fn port_overrides_survive() {
         let registry = registry();
@@ -459,7 +461,16 @@ mod tests {
             .map(|(id, _)| id)
             .expect("default has a circle node");
         graph.set_port_default(circle, "softness", 0.37).unwrap();
-        graph.set_port_exposed(circle, "softness", true).unwrap();
+        graph.expose_port(circle, "softness").unwrap();
+        let circle_key = exposed_port_key(circle, "softness");
+        graph
+            .set_exposed_port_meta(
+                &circle_key,
+                "Softness".into(),
+                "Edge falloff".into(),
+                "fa-solid fa-circle-half-stroke".into(),
+            )
+            .unwrap();
 
         let portable = PortableBrush::from_graph_only(&graph, registry).unwrap();
         let yaml = serde_yml::to_string(&portable).unwrap();
@@ -478,7 +489,12 @@ mod tests {
             .find(|p| p.name == "softness")
             .unwrap();
         assert!((port.default - 0.37).abs() < 1e-6);
-        assert!(port.exposed);
+        assert!(restored.is_port_exposed(restored_circle.id, "softness"));
+        let restored_key = exposed_port_key(restored_circle.id, "softness");
+        let meta = &restored.exposed_ports[&restored_key];
+        assert_eq!(meta.label, "Softness");
+        assert_eq!(meta.description, "Edge falloff");
+        assert_eq!(meta.icon, "fa-solid fa-circle-half-stroke");
     }
 
     /// Unknown node `type:` must fail import with a clear error,

--- a/crates/darkly/src/brush/wgsl/extent.rs
+++ b/crates/darkly/src/brush/wgsl/extent.rs
@@ -35,9 +35,9 @@ use crate::nodegraph::{ExecutionPlan, NodeId, PortDef, PortDir};
 pub enum ExtentContribution {
     /// No effect — bbox passes through unchanged from upstream.
     Identity,
-    /// Multiplier on upstream extent. `circle` uses `1 + amp_max` for
+    /// Multiplier on upstream extent. `shape` uses `1 + amp_max` for
     /// sine/perlin (or the superformula's `r_max`) so the bbox covers
-    /// the shape's worst-case rasterized footprint.
+    /// the silhouette's worst-case rasterized footprint.
     Multiply(f32),
     /// Additive canvas-pixel padding on top of upstream. Future
     /// displacement / warp nodes use this (e.g. warp by ±strength px).

--- a/crates/darkly/src/brush/wgsl/mod.rs
+++ b/crates/darkly/src/brush/wgsl/mod.rs
@@ -572,10 +572,12 @@ pub fn pack_uniforms(
 
 /// Shared compiled-brush preview render path. Sized, packed, and
 /// dispatched identically across paint / watercolor / smudge /
-/// liquify — the differences (effective_radius derivation, rotation
-/// source) are caller-supplied. Returns `Some(())` on success, `None`
-/// when the brush has no compiled state or the preview mask refuses
-/// to allocate.
+/// liquify — the only caller-supplied difference is `effective_radius`.
+/// Rotation lives entirely in the rendered mask (via the skeleton's
+/// `theta - view_rotation` and any wired `circle.rotation_input`), so
+/// the overlay quad samples a pre-oriented mask without a CPU-side
+/// rotation. Returns `Some(())` on success, `None` when the brush has
+/// no compiled state or the preview mask refuses to allocate.
 ///
 /// What this does:
 /// 1. Grows the preview mask to fit `radius × brush_extent_factor +
@@ -596,7 +598,6 @@ pub fn pack_uniforms(
 pub fn render_compiled_cursor_preview(
     gpu: &mut crate::brush::gpu_context::BrushGpuContext,
     radius: f32,
-    rotation_rad: f32,
 ) -> Option<()> {
     let compiled = gpu.dab_batch.compiled_brush.clone()?;
     // Brush-intrinsic bbox in canvas pixels — this is the dab's
@@ -677,7 +678,6 @@ pub fn render_compiled_cursor_preview(
     if let Some(preview) = gpu.preview.as_mut() {
         preview.info = Some(crate::brush::eval::BrushCursorPreviewInfo {
             half_extent_canvas_px: [bbox_canvas_px, bbox_canvas_px],
-            rotation_rad,
         });
     }
     Some(())

--- a/crates/darkly/src/brush/wgsl/mod.rs
+++ b/crates/darkly/src/brush/wgsl/mod.rs
@@ -8,7 +8,7 @@
 //! ## Two execution models, chosen per brush at the terminal
 //!
 //! A brush graph compiles its entire upstream chain into one fragment
-//! shader per terminal — `circle`, `stamp`, `paint_color`, etc. fuse
+//! shader per terminal — `shape`, `stamp`, `paint_color`, etc. fuse
 //! inline, evaluated per-fragment-per-dab. No upstream per-dab GPU
 //! dispatch happens.
 //!
@@ -574,7 +574,7 @@ pub fn pack_uniforms(
 /// dispatched identically across paint / watercolor / smudge /
 /// liquify — the only caller-supplied difference is `effective_radius`.
 /// Rotation lives entirely in the rendered mask (via the skeleton's
-/// `theta - view_rotation` and any wired `circle.rotation_input`), so
+/// `theta - view_rotation` and any wired `shape.rotation_input`), so
 /// the overlay quad samples a pre-oriented mask without a CPU-side
 /// rotation. Returns `Some(())` on success, `None` when the brush has
 /// no compiled state or the preview mask refuses to allocate.

--- a/crates/darkly/src/config/mod.rs
+++ b/crates/darkly/src/config/mod.rs
@@ -352,7 +352,7 @@ mod tests {
         assert_eq!(get_i64("animation.veil_divisor"), 2);
         assert_eq!(get_i64("canvas.width"), 1920);
         assert_eq!(get_str("hotkeys.nav.trigger"), "Space");
-        assert!(!get_bool("input.fingerPainting"));
+        assert!(get_bool("input.fingerPainting"));
         // Darkly-original hotkey defined in defaults.yaml (no reference-editor
         // prior art, so it stays in the agnostic baseline).
         assert_eq!(get_str("hotkeys.addBrushNode"), "Shift+KeyA");

--- a/crates/darkly/src/engine/brush_graph.rs
+++ b/crates/darkly/src/engine/brush_graph.rs
@@ -889,108 +889,114 @@ impl DarklyEngine {
         self.brush_blend_mode = mode;
     }
 
-    /// Return info about all exposed ports in the active brush graph.
+    /// Return info about every brush-bar entry in the active brush graph,
+    /// in the dict's insertion order (which is the user-facing display
+    /// order — the brush-bar node lets the author drag-reorder).
     ///
-    /// Scans all nodes for input ports with `exposed == true`.
-    ///
-    /// The result is ordered by auto-layout position (top-to-bottom,
-    /// left-to-right) for a stable order in the properties panel.
+    /// Entries that reference a node/port no longer present, or whose
+    /// target port has an incoming connection (the user can't scrub a
+    /// wire-driven value), are skipped silently.
     pub fn brush_exposed_ports(&self) -> Vec<ExposedPortInfo> {
         let registry = crate::brush::registry();
         let tool = self.tool_session.read();
         let brush = tool.get::<BrushState>().expect(NO_BRUSH_STATE);
-        let layout = brush.graph.auto_layout();
-        let mut result: Vec<ExposedPortInfo> = Vec::new();
+        let mut result: Vec<ExposedPortInfo> = Vec::with_capacity(brush.graph.exposed_ports.len());
 
-        for node in brush.graph.nodes().values() {
+        for (key, meta) in &brush.graph.exposed_ports {
+            // Key shape: "<node_id>.<port_name>".
+            let Some((nid_str, port_name)) = key.split_once('.') else {
+                continue;
+            };
+            let Ok(node_id_raw) = nid_str.parse::<u64>() else {
+                continue;
+            };
+            let node_id = NodeId(node_id_raw);
+            let Some(node) = brush.graph.nodes().get(&node_id) else {
+                continue;
+            };
+            let Some(port) = node
+                .ports
+                .iter()
+                .find(|p| p.name == port_name && p.dir == PortDir::Input)
+            else {
+                continue;
+            };
+
+            // A connected input is driven by its wire, not the user.
+            if brush
+                .graph
+                .connections
+                .iter()
+                .any(|c| c.to.node == node_id && c.to.port == port_name)
+            {
+                continue;
+            }
+
             let reg = registry.get(&node.type_id);
-            let display_name = reg.map(|r| r.display_name).unwrap_or("");
-
-            for port in &node.ports {
-                if !port.exposed || port.dir != PortDir::Input {
-                    continue;
-                }
-
-                // Only Scalar ports for now.
-                if port.wire_type != BrushWireType::Scalar {
-                    continue;
-                }
-
-                // A connected input is driven by its wire, not the user.
-                let connected = brush
-                    .graph
-                    .connections
+            let reg_port = reg.and_then(|r| {
+                r.ports
                     .iter()
-                    .any(|c| c.to.node == node.id && c.to.port == port.name);
-                if connected {
-                    continue;
-                }
+                    .find(|rp| rp.name == port.name && rp.dir == port.dir)
+            });
 
-                // Display metadata comes from the registration (canonical),
-                // per-instance state (default, exposed) from the instance.
-                let reg_port = reg.and_then(|r| {
-                    r.ports
-                        .iter()
-                        .find(|rp| rp.name == port.name && rp.dir == port.dir)
-                });
-                let unit_type = reg_port.map_or(port.unit_type, |rp| rp.unit_type);
-                let label = reg_port
-                    .map(|rp| &rp.label)
-                    .filter(|l| !l.is_empty())
-                    .cloned()
-                    .unwrap_or_else(|| port.name.clone());
-                let icon = reg_port.map_or_else(|| port.icon.clone(), |rp| rp.icon.clone());
-                let description =
-                    reg_port.map_or_else(|| port.description.clone(), |rp| rp.description.clone());
-
-                // Reset target = the value snapshotted at brush load
-                // time. Falls back to the registration default for ports
-                // on nodes the user added after load (those weren't part
-                // of the brush, so registration default is the right
-                // baseline).
-                let reset_default = brush
-                    .defaults
-                    .get(&(node.id, port.name.clone()))
-                    .copied()
-                    .unwrap_or_else(|| reg_port.map(|rp| rp.default).unwrap_or(port.default));
-                result.push(ExposedPortInfo {
-                    node_id: node.id.0,
-                    port_name: port.name.clone(),
-                    label,
-                    icon,
-                    description,
-                    node_display_name: display_name.to_string(),
-                    data: ExposedValue::Scalar {
+            // Build the type-specific payload. Wire types without a
+            // toolbar widget (Int/Vec2/Vec4) are skipped — the entry
+            // stays in the dict but doesn't render until a widget exists.
+            let data = match port.wire_type {
+                BrushWireType::Scalar => {
+                    let unit_type = reg_port.map_or(port.unit_type, |rp| rp.unit_type);
+                    let reset_default = brush
+                        .defaults
+                        .get(&(node_id, port_name.to_string()))
+                        .copied()
+                        .unwrap_or_else(|| reg_port.map(|rp| rp.default).unwrap_or(port.default));
+                    ExposedValue::Scalar {
                         value: unit_type.to_display(port.default),
                         min: unit_type.to_display(port.min),
                         max: unit_type.to_display(port.max),
                         default: unit_type.to_display(reset_default),
                         unit_type,
-                    },
-                });
-            }
-        }
+                    }
+                }
+                BrushWireType::Bool => ExposedValue::Bool {
+                    value: port.default >= 0.5,
+                },
+                _ => continue,
+            };
 
-        // Sort by layout position: top-to-bottom (y), then left-to-right (x).
-        // Layout is computed above; entries for unknown nodes default to origin.
-        let key = |info: &ExposedPortInfo| -> [f32; 2] {
-            layout
-                .get(&NodeId(info.node_id))
-                .copied()
-                .unwrap_or([0.0, 0.0])
-        };
-        result.sort_by(|a, b| {
-            let ka = key(a);
-            let kb = key(b);
-            ka[1]
-                .partial_cmp(&kb[1])
-                .unwrap_or(std::cmp::Ordering::Equal)
-                .then_with(|| {
-                    ka[0]
-                        .partial_cmp(&kb[0])
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                })
-        });
+            // Brush-bar entry meta wins; fall back to registration label /
+            // description / icon, then to the port name.
+            let label = if !meta.label.is_empty() {
+                meta.label.clone()
+            } else {
+                reg_port
+                    .map(|rp| &rp.label)
+                    .filter(|l| !l.is_empty())
+                    .cloned()
+                    .unwrap_or_else(|| port_name.to_string())
+            };
+            let icon = if !meta.icon.is_empty() {
+                meta.icon.clone()
+            } else {
+                reg_port.map_or_else(String::new, |rp| rp.icon.clone())
+            };
+            let description = if !meta.description.is_empty() {
+                meta.description.clone()
+            } else {
+                reg_port.map_or_else(String::new, |rp| rp.description.clone())
+            };
+
+            result.push(ExposedPortInfo {
+                key: key.clone(),
+                node_id: node_id.0,
+                port_name: port_name.to_string(),
+                label,
+                icon,
+                description,
+                node_display_name: reg.map(|r| r.display_name).unwrap_or("").to_string(),
+                data,
+            });
+        }
 
         result
     }
@@ -1046,24 +1052,77 @@ impl DarklyEngine {
         })
     }
 
-    /// Toggle whether a port is exposed in the brush properties panel.
-    /// Metadata-only — no compile needed (exposed flag doesn't affect
-    /// rendered output) — but bump the topology version so the frontend
-    /// treats this as a structural change and clears the active preset
-    /// name. Bumping the graph version too keeps the editor preview
-    /// consistent with other graph mutations.
-    pub fn brush_graph_set_port_exposed(
+    /// Add a brush-bar entry. Idempotent. Bumps the topology version so
+    /// the frontend treats the change as structural and clears the active
+    /// preset name. No recompile — exposure doesn't affect render output.
+    pub fn brush_graph_expose_port(
         &mut self,
         node_id: u64,
         port_name: &str,
-        exposed: bool,
     ) -> Result<String, String> {
         self.tool_session
             .write()
             .get_mut::<BrushState>()
             .expect(NO_BRUSH_STATE)
             .graph
-            .set_port_exposed(NodeId(node_id), port_name, exposed)
+            .expose_port(NodeId(node_id), port_name)
+            .map_err(|e| format!("{e}"))?;
+        self.bump_brush_topology_version();
+        Ok(self.active_graph_json())
+    }
+
+    /// Remove a brush-bar entry. Idempotent (missing entries aren't an
+    /// error). Bumps the topology version so the frontend clears the
+    /// active preset name.
+    pub fn brush_graph_unexpose_port(
+        &mut self,
+        node_id: u64,
+        port_name: &str,
+    ) -> Result<String, String> {
+        self.tool_session
+            .write()
+            .get_mut::<BrushState>()
+            .expect(NO_BRUSH_STATE)
+            .graph
+            .unexpose_port(NodeId(node_id), port_name);
+        self.bump_brush_topology_version();
+        Ok(self.active_graph_json())
+    }
+
+    /// Overwrite the meta (label / description / icon) on a brush-bar
+    /// entry — single batched call so the brush-bar modal hits the engine
+    /// once. Icon validation lives in `Graph::set_exposed_port_meta`.
+    pub fn brush_graph_set_exposed_port_meta(
+        &mut self,
+        key: &str,
+        label: String,
+        description: String,
+        icon: String,
+    ) -> Result<String, String> {
+        self.tool_session
+            .write()
+            .get_mut::<BrushState>()
+            .expect(NO_BRUSH_STATE)
+            .graph
+            .set_exposed_port_meta(key, label, description, icon)
+            .map_err(|e| format!("{e}"))?;
+        self.bump_brush_topology_version();
+        Ok(self.active_graph_json())
+    }
+
+    /// Move a brush-bar entry to a target index. Backs the drag-reorder
+    /// UX in the brush-bar node.
+    pub fn brush_graph_reorder_exposed_port(
+        &mut self,
+        key: &str,
+        new_index: u32,
+    ) -> Result<String, String> {
+        self.tool_session
+            .write()
+            .get_mut::<BrushState>()
+            .expect(NO_BRUSH_STATE)
+            .graph
+            .reorder_exposed_port(key, new_index as usize)
             .map_err(|e| format!("{e}"))?;
         self.bump_brush_topology_version();
         Ok(self.active_graph_json())
@@ -1094,9 +1153,14 @@ pub enum ExposedValue {
         #[serde(rename = "unitType")]
         unit_type: UnitType,
     },
+    /// Boolean toggle. Currently emitted by the Switch node's `select`
+    /// port; any other Bool input port marked `exposed` works too.
+    Bool {
+        /// Current value.
+        value: bool,
+    },
     // Future variants:
     // Int { value: i32, min: i32, max: i32 },
-    // Bool { value: bool },
     // Color { value: [f32; 4] },
 }
 
@@ -1104,6 +1168,11 @@ pub enum ExposedValue {
 #[derive(Clone, Debug, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExposedPortInfo {
+    /// `"<node_id>.<port_name>"` — the same string used to address the
+    /// entry in `Graph::exposed_ports`. Frontend passes it back to
+    /// `set_exposed_port_meta` / `reorder_exposed_port` without having
+    /// to reconstruct the format.
+    pub key: String,
     pub node_id: u64,
     pub port_name: String,
     pub label: String,

--- a/crates/darkly/src/engine/brush_graph.rs
+++ b/crates/darkly/src/engine/brush_graph.rs
@@ -26,7 +26,7 @@ enum ChangeKind {
     /// Exposed-port scrub on a port marked `persist_in_thumbnail` — its
     /// value bleeds through to the dab thumbnail render, so both
     /// version counters need to bump to invalidate both preview caches.
-    /// Used for orientation knobs like `circle.rotation`.
+    /// Used for orientation knobs like `shape.rotation`.
     ThumbnailRelevantScrub,
     /// User-facing exposed-port scrub on a port the editor preview
     /// pipeline actually reads (size, opacity, hardness, …). Bumps only

--- a/crates/darkly/src/gpu/params.rs
+++ b/crates/darkly/src/gpu/params.rs
@@ -255,13 +255,13 @@ mod tests {
     use super::*;
 
     /// Regression: `ParamValue::Int(n)` must round-trip through JSON without
-    /// degrading to `ParamValue::Float`. The bug: Rough Watercolor's circle
+    /// degrading to `ParamValue::Float`. The bug: Rough Watercolor's shape
     /// node was configured with `algorithm = Int(1)` (Perlin), but after
     /// `brush_load` (graph → JSON → graph) the variant became `Float(1.0)`,
-    /// and `circle.rs`'s `match Some(ParamValue::Int(v))` silently fell
+    /// and `shape.rs`'s `match Some(ParamValue::Int(v))` silently fell
     /// through to the default `0` (Sine). Port defaults — which are floats
     /// natively — round-tripped fine, so the UI showed correct numbers
-    /// while the GPU rendered the wrong shape. Fix was to reorder the
+    /// while the GPU rendered the wrong silhouette. Fix was to reorder the
     /// `#[serde(untagged)]` variants so the more-specific `Bool` and `Int`
     /// are attempted before `Float`.
     #[test]

--- a/crates/darkly/src/nodegraph/compiler.rs
+++ b/crates/darkly/src/nodegraph/compiler.rs
@@ -242,6 +242,7 @@ mod tests {
                 type_id: "source",
                 category: "test",
                 display_name: "Source",
+                description: "",
                 ports: vec![PortDef::output("out", TestWireKind::Scalar)],
                 params: &[],
                 is_gpu: false,
@@ -255,6 +256,7 @@ mod tests {
                 type_id: "passthrough",
                 category: "test",
                 display_name: "Passthrough",
+                description: "",
                 ports: vec![
                     PortDef::input("in", TestWireKind::Scalar),
                     PortDef::output("out", TestWireKind::Scalar),
@@ -271,6 +273,7 @@ mod tests {
                 type_id: "sink",
                 category: "test",
                 display_name: "Sink",
+                description: "",
                 ports: vec![PortDef::input("in", TestWireKind::Scalar)],
                 params: &[],
                 is_gpu: false,
@@ -525,6 +528,7 @@ mod tests {
                 type_id: "source",
                 category: "test",
                 display_name: "Source",
+                description: "",
                 ports: vec![
                     PortDef::output("out1", TestWireKind::Scalar),
                     PortDef::output("out2", TestWireKind::Scalar),
@@ -541,6 +545,7 @@ mod tests {
                 type_id: "sink",
                 category: "test",
                 display_name: "Sink",
+                description: "",
                 ports: vec![
                     PortDef::input("in1", TestWireKind::Scalar),
                     PortDef::input("in2", TestWireKind::Scalar),

--- a/crates/darkly/src/nodegraph/graph.rs
+++ b/crates/darkly/src/nodegraph/graph.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use super::registration::NodeRegistration;
@@ -406,6 +407,26 @@ pub enum GraphError {
         node: NodeId,
         port: String,
     },
+    /// `exposed_ports` lookup by key (`"<node_id>.<port>"`) failed.
+    ExposedPortNotFound {
+        key: String,
+    },
+    /// Icon string contained a character outside the FontAwesome-class
+    /// shape (`[a-zA-Z0-9- ]`). Rejected so the value stays safe to
+    /// bind directly into an HTML `class=` attribute.
+    InvalidIcon {
+        icon: String,
+    },
+}
+
+/// Accept only the byte shape FontAwesome class strings use:
+/// lowercase/uppercase letters, digits, hyphens, and spaces. Keeping
+/// the value within this alphabet means it can be bound into a Svelte
+/// `class={...}` attribute without further escaping (Svelte already
+/// HTML-escapes attribute values, but staying inside the alphabet
+/// removes any debate about edge cases).
+fn is_safe_icon_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'-' || b == b' '
 }
 
 impl std::fmt::Display for GraphError {
@@ -421,6 +442,16 @@ impl std::fmt::Display for GraphError {
             Self::NodeNotFound(id) => write!(f, "node {:?} not found", id),
             Self::InputAlreadyConnected { node, port } => {
                 write!(f, "input '{}' on {:?} already connected", port, node)
+            }
+            Self::ExposedPortNotFound { key } => {
+                write!(f, "exposed-port entry '{}' not found", key)
+            }
+            Self::InvalidIcon { icon } => {
+                write!(
+                    f,
+                    "icon '{}' contains characters outside [a-zA-Z0-9- ]",
+                    icon
+                )
             }
         }
     }
@@ -454,6 +485,35 @@ impl std::fmt::Display for FindTerminalError {
 
 impl std::error::Error for FindTerminalError {}
 
+// ── Exposed port metadata ────────────────────────────────────────────
+
+/// Per-placement metadata for an entry in a graph's `exposed_ports` map.
+/// All fields are optional: empty strings fall back to the registration's
+/// `PortDef::label` / `PortDef::description` / `PortDef::icon` when the
+/// brush bar renders the entry.
+///
+/// Lives in `Graph::exposed_ports` rather than on `PortDef` per instance
+/// because the brush bar is a single user-facing surface — centralizing
+/// "what the user sees" in one ordered dict makes display order natural
+/// (map iteration order is the brush-bar order) and gives the
+/// brush-author editor one canonical place to read and write.
+#[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExposedPortMeta {
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub label: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub icon: String,
+}
+
+/// Format the canonical key for an exposed-port entry. Keys are
+/// `"<node_id>.<port_name>"` strings so the dict round-trips through
+/// JSON/YAML without needing tuple-key encoding.
+pub fn exposed_port_key(node: NodeId, port: &str) -> String {
+    format!("{}.{}", node.0, port)
+}
+
 // ── Graph ────────────────────────────────────────────────────────────
 
 /// A directed acyclic graph of nodes connected by typed wires.
@@ -463,6 +523,12 @@ pub struct Graph<W: WireKind> {
     nodes: HashMap<NodeId, NodeInstance<W>>,
     pub connections: Vec<Connection>,
     next_id: u64,
+    /// Ordered set of exposed-port entries. Insertion order is the
+    /// brush-bar display order — `IndexMap` preserves it through every
+    /// mutation and JSON/YAML round-trip. Keys come from
+    /// [`exposed_port_key`].
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub exposed_ports: IndexMap<String, ExposedPortMeta>,
 }
 
 impl<W: WireKind> Default for Graph<W> {
@@ -477,6 +543,7 @@ impl<W: WireKind> Graph<W> {
             nodes: HashMap::new(),
             connections: Vec::new(),
             next_id: 1,
+            exposed_ports: IndexMap::new(),
         }
     }
 
@@ -488,7 +555,10 @@ impl<W: WireKind> Graph<W> {
         &self.nodes
     }
 
-    /// Add a node and return its assigned id.
+    /// Add a node and return its assigned id. Any input port whose
+    /// registration `PortDef` declares `.exposed()` is auto-appended to
+    /// `exposed_ports` with empty meta — preserves the "size etc. are
+    /// exposed by default" affordance.
     pub fn add_node(
         &mut self,
         type_id: impl Into<String>,
@@ -497,6 +567,14 @@ impl<W: WireKind> Graph<W> {
     ) -> NodeId {
         let id = NodeId(self.next_id);
         self.next_id += 1;
+        // Walk before move: every input port flagged exposed gets a
+        // default brush-bar entry.
+        for port in ports.iter() {
+            if port.dir == PortDir::Input && port.exposed {
+                let key = exposed_port_key(id, &port.name);
+                self.exposed_ports.insert(key, ExposedPortMeta::default());
+            }
+        }
         self.nodes.insert(
             id,
             NodeInstance {
@@ -509,13 +587,95 @@ impl<W: WireKind> Graph<W> {
         id
     }
 
-    /// Remove a node and all its connections.
+    /// Remove a node, all its connections, and every brush-bar entry
+    /// referencing one of its ports.
     pub fn remove_node(&mut self, id: NodeId) -> Result<(), GraphError> {
         if self.nodes.remove(&id).is_none() {
             return Err(GraphError::NodeNotFound(id));
         }
         self.connections
             .retain(|c| c.from.node != id && c.to.node != id);
+        let prefix = format!("{}.", id.0);
+        self.exposed_ports
+            .retain(|key, _| !key.starts_with(&prefix));
+        Ok(())
+    }
+
+    /// Add a brush-bar entry for an input port, no-op if already present.
+    /// The entry starts with empty meta (registration values are used as
+    /// fallback at render time).
+    pub fn expose_port(&mut self, id: NodeId, port_name: &str) -> Result<(), GraphError> {
+        // Validate that the port exists and is an input.
+        let node = self.nodes.get(&id).ok_or(GraphError::NodeNotFound(id))?;
+        if !node
+            .ports
+            .iter()
+            .any(|p| p.name == port_name && p.dir == PortDir::Input)
+        {
+            return Err(GraphError::PortNotFound {
+                node: id,
+                port: port_name.to_string(),
+            });
+        }
+        let key = exposed_port_key(id, port_name);
+        self.exposed_ports.entry(key).or_default();
+        Ok(())
+    }
+
+    /// Drop a brush-bar entry by `(node, port)`. Idempotent — missing
+    /// entries are not an error.
+    pub fn unexpose_port(&mut self, id: NodeId, port_name: &str) {
+        let key = exposed_port_key(id, port_name);
+        self.exposed_ports.shift_remove(&key);
+    }
+
+    /// Returns true when the named input port has a live brush-bar entry.
+    pub fn is_port_exposed(&self, id: NodeId, port_name: &str) -> bool {
+        self.exposed_ports
+            .contains_key(&exposed_port_key(id, port_name))
+    }
+
+    /// Overwrite all three meta fields on a brush-bar entry in one call.
+    /// The icon field is restricted to FontAwesome-friendly characters
+    /// (`[a-zA-Z0-9- ]*`) — keeps the value safe to bind directly into
+    /// an HTML `class=` attribute on the frontend without further
+    /// sanitization. Out-of-shape icon strings are rejected loudly so
+    /// the caller learns about the constraint rather than seeing the
+    /// icon silently dropped.
+    pub fn set_exposed_port_meta(
+        &mut self,
+        key: &str,
+        label: String,
+        description: String,
+        icon: String,
+    ) -> Result<(), GraphError> {
+        if !icon.bytes().all(is_safe_icon_byte) {
+            return Err(GraphError::InvalidIcon { icon });
+        }
+        let entry =
+            self.exposed_ports
+                .get_mut(key)
+                .ok_or_else(|| GraphError::ExposedPortNotFound {
+                    key: key.to_string(),
+                })?;
+        entry.label = label;
+        entry.description = description;
+        entry.icon = icon;
+        Ok(())
+    }
+
+    /// Move an exposed-port entry to position `new_index`. The map's
+    /// iteration order is the brush-bar display order, so this is how
+    /// drag-reorder is realised. `new_index` is clamped to the map's
+    /// length.
+    pub fn reorder_exposed_port(&mut self, key: &str, new_index: usize) -> Result<(), GraphError> {
+        let from = self.exposed_ports.get_index_of(key).ok_or_else(|| {
+            GraphError::ExposedPortNotFound {
+                key: key.to_string(),
+            }
+        })?;
+        let target = new_index.min(self.exposed_ports.len().saturating_sub(1));
+        self.exposed_ports.move_index(from, target);
         Ok(())
     }
 
@@ -637,28 +797,9 @@ impl<W: WireKind> Graph<W> {
         Ok(())
     }
 
-    /// Toggle whether an input port is exposed in the brush properties panel.
-    pub fn set_port_exposed(
-        &mut self,
-        id: NodeId,
-        port_name: &str,
-        exposed: bool,
-    ) -> Result<(), GraphError> {
-        let node = self
-            .nodes
-            .get_mut(&id)
-            .ok_or(GraphError::NodeNotFound(id))?;
-        let port = node
-            .ports
-            .iter_mut()
-            .find(|p| p.name == port_name && p.dir == PortDir::Input)
-            .ok_or_else(|| GraphError::PortNotFound {
-                node: id,
-                port: port_name.to_string(),
-            })?;
-        port.exposed = exposed;
-        Ok(())
-    }
+    // Note: brush-bar exposure / label / description / icon overrides
+    // live in `Graph::exposed_ports` now. Use `expose_port`,
+    // `unexpose_port`, `set_exposed_port_meta`, and `reorder_exposed_port`.
 
     /// Update a single parameter value on a node.
     pub fn set_param(
@@ -1044,26 +1185,136 @@ mod tests {
         assert_eq!(back.description, "Per-dab opacity");
     }
 
-    // ── set_port_exposed ────────────────────────────────────────────
+    // ── exposed_ports ──────────────────────────────────────────────
 
     #[test]
-    fn set_port_exposed_toggles() {
+    fn expose_then_unexpose_round_trips() {
         let mut g = Graph::<TestWireKind>::new();
         let id = g.add_node("node", vec![scalar_in("val")], vec![]);
 
-        assert!(!g.nodes[&id].ports[0].exposed);
-        g.set_port_exposed(id, "val", true).unwrap();
-        assert!(g.nodes[&id].ports[0].exposed);
-        g.set_port_exposed(id, "val", false).unwrap();
-        assert!(!g.nodes[&id].ports[0].exposed);
+        assert!(!g.is_port_exposed(id, "val"));
+        g.expose_port(id, "val").unwrap();
+        assert!(g.is_port_exposed(id, "val"));
+        // Idempotent — double-expose doesn't add a duplicate.
+        g.expose_port(id, "val").unwrap();
+        assert_eq!(g.exposed_ports.len(), 1);
+        g.unexpose_port(id, "val");
+        assert!(!g.is_port_exposed(id, "val"));
     }
 
     #[test]
-    fn set_port_exposed_wrong_port() {
+    fn expose_port_rejects_output_port() {
         let mut g = Graph::<TestWireKind>::new();
         let id = g.add_node("node", vec![scalar_out("out")], vec![]);
-        // Output ports can't be exposed (set_port_exposed looks for Input).
-        let err = g.set_port_exposed(id, "out", true).unwrap_err();
-        matches!(err, GraphError::PortNotFound { .. });
+        let err = g.expose_port(id, "out").unwrap_err();
+        assert!(matches!(err, GraphError::PortNotFound { .. }));
+    }
+
+    #[test]
+    fn add_node_seeds_exposed_from_registration_flag() {
+        let mut g = Graph::<TestWireKind>::new();
+        // Two inputs: only the second is flagged `.exposed()` at the
+        // registration level. add_node should auto-append it to
+        // exposed_ports with empty meta.
+        let mut a = scalar_in("a");
+        let mut b = scalar_in("b");
+        a.exposed = false;
+        b.exposed = true;
+        let id = g.add_node("node", vec![a, b], vec![]);
+        assert!(!g.is_port_exposed(id, "a"));
+        assert!(g.is_port_exposed(id, "b"));
+        // Empty meta — falls back to registration at render time.
+        let key = exposed_port_key(id, "b");
+        assert_eq!(g.exposed_ports[&key], ExposedPortMeta::default());
+    }
+
+    #[test]
+    fn remove_node_drops_exposed_entries() {
+        let mut g = Graph::<TestWireKind>::new();
+        let a = g.add_node("node", vec![scalar_in("x"), scalar_in("y")], vec![]);
+        let b = g.add_node("node", vec![scalar_in("x")], vec![]);
+        g.expose_port(a, "x").unwrap();
+        g.expose_port(a, "y").unwrap();
+        g.expose_port(b, "x").unwrap();
+        assert_eq!(g.exposed_ports.len(), 3);
+
+        g.remove_node(a).unwrap();
+        // Only b.x survives.
+        assert_eq!(g.exposed_ports.len(), 1);
+        assert!(g.is_port_exposed(b, "x"));
+    }
+
+    #[test]
+    fn reorder_moves_entry_to_target_index() {
+        let mut g = Graph::<TestWireKind>::new();
+        let id = g.add_node(
+            "node",
+            vec![scalar_in("a"), scalar_in("b"), scalar_in("c")],
+            vec![],
+        );
+        g.expose_port(id, "a").unwrap();
+        g.expose_port(id, "b").unwrap();
+        g.expose_port(id, "c").unwrap();
+        let keys: Vec<&str> = g.exposed_ports.keys().map(String::as_str).collect();
+        assert_eq!(keys.len(), 3);
+
+        // Move b to index 0.
+        let b_key = exposed_port_key(id, "b");
+        g.reorder_exposed_port(&b_key, 0).unwrap();
+
+        let order: Vec<&str> = g.exposed_ports.keys().map(String::as_str).collect();
+        let a_key = exposed_port_key(id, "a");
+        let c_key = exposed_port_key(id, "c");
+        assert_eq!(order, vec![b_key.as_str(), a_key.as_str(), c_key.as_str()]);
+    }
+
+    #[test]
+    fn set_meta_rejects_unsafe_icon() {
+        let mut g = Graph::<TestWireKind>::new();
+        let id = g.add_node("node", vec![scalar_in("val")], vec![]);
+        g.expose_port(id, "val").unwrap();
+        let key = exposed_port_key(id, "val");
+
+        // Safe icon class — accepted.
+        g.set_exposed_port_meta(
+            &key,
+            "Label".into(),
+            "Desc".into(),
+            "fa-solid fa-sun".into(),
+        )
+        .unwrap();
+        assert_eq!(g.exposed_ports[&key].icon, "fa-solid fa-sun");
+
+        // Unsafe icon (contains `<`) — rejected; previous value retained.
+        let err = g
+            .set_exposed_port_meta(
+                &key,
+                "Label2".into(),
+                "Desc2".into(),
+                "<script>x</script>".into(),
+            )
+            .unwrap_err();
+        assert!(matches!(err, GraphError::InvalidIcon { .. }));
+        assert_eq!(g.exposed_ports[&key].icon, "fa-solid fa-sun");
+        assert_eq!(g.exposed_ports[&key].label, "Label");
+    }
+
+    #[test]
+    fn exposed_ports_round_trip_preserves_order() {
+        let mut g = Graph::<TestWireKind>::new();
+        let id = g.add_node(
+            "node",
+            vec![scalar_in("a"), scalar_in("b"), scalar_in("c")],
+            vec![],
+        );
+        g.expose_port(id, "c").unwrap();
+        g.expose_port(id, "a").unwrap();
+        g.expose_port(id, "b").unwrap();
+        let before: Vec<String> = g.exposed_ports.keys().cloned().collect();
+
+        let json = serde_json::to_string(&g).unwrap();
+        let back: Graph<TestWireKind> = serde_json::from_str(&json).unwrap();
+        let after: Vec<String> = back.exposed_ports.keys().cloned().collect();
+        assert_eq!(before, after);
     }
 }

--- a/crates/darkly/src/nodegraph/graph.rs
+++ b/crates/darkly/src/nodegraph/graph.rs
@@ -104,9 +104,9 @@ pub struct PortDef<W: WireKind> {
     /// Quantization step. `0.0` (the default) means continuous; any positive
     /// value snaps the slider, scrub, and typed-value commits to multiples of
     /// `step` from `min`. Used when the wire takes a value but only certain
-    /// quantized values produce well-defined behavior — e.g. the circle
+    /// quantized values produce well-defined behavior — e.g. the shape
     /// node's `frequency`, where only integer values yield a seam-free
-    /// closed shape. Frontend honors the snap; the engine should still
+    /// closed silhouette. Frontend honors the snap; the engine should still
     /// defend by quantizing inputs in the node evaluator (a wired-in float
     /// from a curve or pen-pressure modulator bypasses the slider).
     #[serde(default)]
@@ -176,7 +176,7 @@ pub struct PortDef<W: WireKind> {
     /// value is outside the allowed list. This is purely a UI affordance —
     /// the engine still accepts and reads the port's value normally; it
     /// just stops showing the user a control they wouldn't act on.
-    /// Used by the Circle node to hide algorithm-specific knobs (Perlin's
+    /// Used by the Shape node to hide algorithm-specific knobs (Perlin's
     /// `seed`, Superformula's `n1`/`n2`/`n3`) under the wrong algorithm.
     #[serde(default)]
     pub visible_when: Option<(String, Vec<i32>)>,

--- a/crates/darkly/src/nodegraph/mod.rs
+++ b/crates/darkly/src/nodegraph/mod.rs
@@ -12,8 +12,8 @@ mod registration;
 
 pub use compiler::{ExecStep, ExecutionPlan, InputSlot};
 pub use graph::{
-    Connection, FindTerminalError, Graph, GraphError, NodeId, NodeInstance, PortDef, PortDir,
-    PortRef, UnitType,
+    exposed_port_key, Connection, ExposedPortMeta, FindTerminalError, Graph, GraphError, NodeId,
+    NodeInstance, PortDef, PortDir, PortRef, UnitType,
 };
 pub use layout::NodeLayout;
 pub use registration::NodeRegistration;

--- a/crates/darkly/src/nodegraph/registration.rs
+++ b/crates/darkly/src/nodegraph/registration.rs
@@ -22,6 +22,12 @@ pub struct NodeRegistration<W: WireKind> {
     pub category: &'static str,
     /// Human-readable name (e.g. "Pen Input", "Multiply").
     pub display_name: &'static str,
+    /// Short, single-sentence description of what this node does — shown as
+    /// the add-node menu tooltip. Should read as a noun-phrase or imperative
+    /// fragment in painter vocabulary (never engine-internal terms like
+    /// "scalar" or "fragment shader"); per-port detail goes on the ports
+    /// themselves via `PortDef::with_description`.
+    pub description: &'static str,
     /// Port definitions for this node type.
     pub ports: Vec<PortDef<W>>,
     /// Parameter definitions (for inline UI sliders).

--- a/crates/darkly/tests/brush_editor_preview.rs
+++ b/crates/darkly/tests/brush_editor_preview.rs
@@ -313,7 +313,7 @@ fn airbrush_endpoint_dabs_not_clipped_against_cache_border() {
     // — black bg, white stroke.
     engine.set_preview_theme([1.0, 1.0, 1.0, 1.0], [0.0, 0.0, 0.0, 1.0]);
 
-    // Airbrush is a built-in: circle tip with a fixed `size_input` constant
+    // Airbrush is a built-in: shape tip with a fixed `size_input` constant
     // (no pressure→size_input wire), so the dab radius doesn't scale with
     // the synthetic stroke's pressure ramp. Same invariant the old
     // "Hard Round" test exercised before that brush was removed.
@@ -406,7 +406,7 @@ fn stabilize_scrub_does_not_bump_editor_preview_version() {
 
     // Negative control: scrubbing a port the preview *does* read must
     // still bump the version. After the compiled-WGSL migration
-    // `softness` lives on the upstream `circle` node (the
+    // `softness` lives on the upstream `shape` node (the
     // `paint` terminal has no softness port). It has no
     // `preview_irrelevant_scrub` flag, is read by the preview shader,
     // and is unwired — the perfect canary for "rule too broad". Find
@@ -415,7 +415,7 @@ fn stabilize_scrub_does_not_bump_editor_preview_version() {
         .brush_exposed_ports()
         .into_iter()
         .find(|p| p.port_name == "softness")
-        .expect("Ink Pen exposes a `softness` port (on circle after migration)");
+        .expect("Ink Pen exposes a `softness` port (on shape after migration)");
     let v_before_softness = engine.brush_graph_version();
     engine
         .brush_set_exposed_port(softness.node_id, "softness", 0.5)

--- a/crates/darkly/tests/brush_picker_backend.rs
+++ b/crates/darkly/tests/brush_picker_backend.rs
@@ -340,17 +340,17 @@ fn size_scrub_does_not_change_active_dab_pixels() {
     );
 
     // Conversely, a structural change MUST advance the topology version,
-    // so the frontend correctly clears the preset name. Toggle a port's
-    // exposed flag — cheaper than brush_load and avoids extra GPU work
-    // (no compile_active call), but still classified as topology.
+    // so the frontend correctly clears the preset name. Unexpose a port
+    // — cheaper than brush_load and avoids extra GPU work (no
+    // compile_active call), but still classified as topology.
     let topo_before_toggle = engine.brush_topology_version();
     engine
-        .brush_graph_set_port_exposed(size.node_id, "size", false)
-        .expect("toggle exposed");
+        .brush_graph_unexpose_port(size.node_id, "size")
+        .expect("unexpose size port");
     assert_ne!(
         engine.brush_topology_version(),
         topo_before_toggle,
-        "set_port_exposed is a structural change and must advance the topology version"
+        "exposing/unexposing a port is a structural change and must advance the topology version"
     );
 }
 

--- a/crates/darkly/tests/engine.rs
+++ b/crates/darkly/tests/engine.rs
@@ -3881,7 +3881,7 @@ fn long_stabilized_stroke_no_fallback() {
     let mut engine = test_engine(w, h);
     let layer_id = engine.add_raster_layer(None);
 
-    // Default brush (circle + stamp + color_output) is enough to exercise
+    // Default brush (shape + stamp + color_output) is enough to exercise
     // the checkpoint ring's coverage invariant — this test is about the
     // stabilizer's full-rerender fallback, not anything scatter-specific.
     let pen_id = find_node_id(&engine, pen_input::TYPE_ID);

--- a/crates/darkly/tests/paint_info_derive_sensors.rs
+++ b/crates/darkly/tests/paint_info_derive_sensors.rs
@@ -1,0 +1,69 @@
+//! Unit regression for `PaintInformation::derive_sensors`. The cursor
+//! preview path (`brush_graph::regenerate_brush_cursor_preview_with_pen`)
+//! calls this every pointer event with the chord between the previous
+//! and current hover positions. Coalesced events can land at the same
+//! coordinates, which used to make `atan2(0, 0) = 0` snap drawing_angle
+//! to 0 for that frame — flickering the hover cursor between the real
+//! direction and 0° on alternating events.
+//!
+//! `derive_sensors` now preserves the previous sample's `drawing_angle`
+//! when the chord is below the same `0.001` floor the stroke engine
+//! uses (`stroke_engine.rs:282`). This test pins that behavior.
+
+use darkly::brush::paint_info::PaintInformation;
+
+#[test]
+fn zero_delta_preserves_drawing_angle() {
+    let mut prev = PaintInformation {
+        pos: [10.0, 10.0],
+        ..Default::default()
+    };
+    prev.drawing_angle = 0.7;
+
+    let mut cur = PaintInformation {
+        pos: prev.pos, // identical position — chord = 0
+        ..Default::default()
+    };
+    cur.derive_sensors(Some(&prev), 0.0);
+
+    assert_eq!(
+        cur.drawing_angle, prev.drawing_angle,
+        "zero-delta segment must preserve prev's drawing_angle, not \
+         snap to atan2(0, 0) = 0",
+    );
+}
+
+#[test]
+fn real_motion_overwrites_drawing_angle() {
+    let mut prev = PaintInformation {
+        pos: [10.0, 10.0],
+        ..Default::default()
+    };
+    prev.drawing_angle = 0.7;
+
+    let mut cur = PaintInformation {
+        pos: [20.0, 10.0], // +x motion → drawing_angle should be 0
+        ..Default::default()
+    };
+    cur.derive_sensors(Some(&prev), 10.0);
+
+    assert!(
+        cur.drawing_angle.abs() < 1.0e-5,
+        "rightward motion should set drawing_angle to ~0, got {}",
+        cur.drawing_angle,
+    );
+}
+
+#[test]
+fn first_point_leaves_drawing_angle_at_default() {
+    let mut cur = PaintInformation {
+        pos: [10.0, 10.0],
+        ..Default::default()
+    };
+    cur.derive_sensors(None, 0.0);
+
+    assert_eq!(
+        cur.drawing_angle, 0.0,
+        "first point has no segment — drawing_angle stays at its default 0",
+    );
+}

--- a/crates/darkly/tests/preview_rotation.rs
+++ b/crates/darkly/tests/preview_rotation.rs
@@ -1,4 +1,4 @@
-//! End-to-end verification that `pen.drawing_angle → circle.rotation_input`
+//! End-to-end verification that `pen.drawing_angle → shape.rotation_input`
 //! actually rotates the **rendered mask** in the cursor preview pipeline.
 //!
 //! The previous version of this test asserted on
@@ -6,7 +6,7 @@
 //! only affected the cursor halo, not the painted dab. That port was removed
 //! because it produced "rotation that only the cursor sees, not the paint",
 //! which surprised users. Rotation now lives in the WGSL pipeline (sum of
-//! `circle.rotation` + `circle.rotation_input`, minus `view_rotation`), so
+//! `shape.rotation` + `shape.rotation_input`, minus `view_rotation`), so
 //! the cursor preview and the stroke deposit always agree.
 //!
 //! This test renders an asymmetric superformula shape twice — once
@@ -52,8 +52,8 @@ fn preview_target(device: &wgpu::Device) -> (wgpu::Texture, wgpu::TextureView) {
     (tex, view)
 }
 
-/// Build a minimal paint graph with `pen.drawing_angle → circle.rotation_input`.
-/// Circle is set to the superformula algorithm so the shape has a four-fold
+/// Build a minimal paint graph with `pen.drawing_angle → shape.rotation_input`.
+/// Shape is set to the superformula algorithm so the silhouette has a four-fold
 /// symmetry whose orientation reads cleanly off rotation_input.
 fn build_graph_with_rotation_wire() -> Graph<BrushWireType> {
     let registry = registry();
@@ -69,9 +69,9 @@ fn build_graph_with_rotation_wire() -> Graph<BrushWireType> {
         registry.get("paint_color").unwrap().ports.clone(),
         vec![],
     );
-    let circle = graph.add_node(
-        "circle",
-        registry.get("circle").unwrap().ports.clone(),
+    let shape = graph.add_node(
+        "shape",
+        registry.get("shape").unwrap().ports.clone(),
         // Algorithm = 2 (Superformula).
         vec![darkly::gpu::params::ParamValue::Int(2)],
     );
@@ -90,9 +90,9 @@ fn build_graph_with_rotation_wire() -> Graph<BrushWireType> {
         (pen, "position", term, "position"),
         // Canonical stroke-follow wire — what users wire when they want
         // the dab to face the stroke direction.
-        (pen, "drawing_angle", circle, "rotation_input"),
+        (pen, "drawing_angle", shape, "rotation_input"),
         (paint_color, "color", stamp, "color"),
-        (circle, "mask", stamp, "tip"),
+        (shape, "mask", stamp, "tip"),
         (stamp, "dab", term, "rgba"),
     ];
     for (from_node, from_port, to_node, to_port) in wires {
@@ -113,11 +113,11 @@ fn build_graph_with_rotation_wire() -> Graph<BrushWireType> {
     graph.set_port_default(term, "size", 0.4).unwrap();
     // Superformula with a 4-pointed silhouette so rotation moves the
     // shape's lobes from axes to diagonals (and vice versa).
-    graph.set_port_default(circle, "frequency", 4.0).unwrap();
-    graph.set_port_default(circle, "amplitude", 0.8).unwrap();
-    graph.set_port_default(circle, "n1", 1.0).unwrap();
-    graph.set_port_default(circle, "n2", 1.0).unwrap();
-    graph.set_port_default(circle, "n3", 1.0).unwrap();
+    graph.set_port_default(shape, "frequency", 4.0).unwrap();
+    graph.set_port_default(shape, "amplitude", 0.8).unwrap();
+    graph.set_port_default(shape, "n1", 1.0).unwrap();
+    graph.set_port_default(shape, "n2", 1.0).unwrap();
+    graph.set_port_default(shape, "n3", 1.0).unwrap();
     graph
 }
 
@@ -160,7 +160,7 @@ fn render_at_angle(angle_rad: f32) -> Vec<u8> {
 
     // Seed `drawing_angle` directly — `seed_sensors` writes the raw
     // `info.drawing_angle` into the pen_input slot, which the wire then
-    // feeds into `circle.rotation_input` via the compiled WGSL.
+    // feeds into `shape.rotation_input` via the compiled WGSL.
     let mut info = PaintInformation {
         pos: [PREVIEW_SIDE as f32 * 0.5, PREVIEW_SIDE as f32 * 0.5],
         pressure: 1.0,
@@ -219,7 +219,7 @@ fn drawing_angle_rotates_preview_mask() {
     let diff = (sum_baseline as i32 - sum_rotated as i32).unsigned_abs();
     assert!(
         diff > 64,
-        "drawing_angle wired to circle.rotation_input should rotate the \
+        "drawing_angle wired to shape.rotation_input should rotate the \
          rendered shape; baseline on-axis alpha={sum_baseline}, rotated \
          on-axis alpha={sum_rotated} (diff={diff}). If these are equal, \
          the rotation wire is dead.",

--- a/crates/darkly/tests/preview_rotation.rs
+++ b/crates/darkly/tests/preview_rotation.rs
@@ -1,8 +1,19 @@
-//! End-to-end verification that `pen.tilt_direction` flows through
-//! the runner's sensor-seeding into a terminal's `render_cursor_preview`
-//! and onward to `BrushCursorPreviewInfo.rotation_rad`. If the rotation
-//! port doesn't flow live values, the cursor mask can never rotate
-//! with the pen even though the overlay primitive supports it.
+//! End-to-end verification that `pen.drawing_angle → circle.rotation_input`
+//! actually rotates the **rendered mask** in the cursor preview pipeline.
+//!
+//! The previous version of this test asserted on
+//! `BrushCursorPreviewInfo.rotation_rad` — a CPU-side overlay rotation that
+//! only affected the cursor halo, not the painted dab. That port was removed
+//! because it produced "rotation that only the cursor sees, not the paint",
+//! which surprised users. Rotation now lives in the WGSL pipeline (sum of
+//! `circle.rotation` + `circle.rotation_input`, minus `view_rotation`), so
+//! the cursor preview and the stroke deposit always agree.
+//!
+//! This test renders an asymmetric superformula shape twice — once
+//! unrotated, once at 90° via `pen.drawing_angle` — and asserts that
+//! mask pixels at on-axis sampling positions differ between the two
+//! renders. If `drawing_angle → rotation_input` were silently dropped,
+//! both renders would be identical.
 
 use std::sync::Arc;
 
@@ -15,7 +26,7 @@ use darkly::brush::paint_info::PaintInformation;
 use darkly::brush::pipeline::BrushPipelines;
 use darkly::brush::registry;
 use darkly::brush::wire::BrushWireType;
-use darkly::gpu::test_utils::test_device;
+use darkly::gpu::test_utils::{readback_texture, test_device};
 use darkly::nodegraph::{Graph, PortRef};
 
 const PREVIEW_SIDE: u32 = 128;
@@ -41,12 +52,10 @@ fn preview_target(device: &wgpu::Device) -> (wgpu::Texture, wgpu::TextureView) {
     (tex, view)
 }
 
-#[test]
-fn pen_tilt_direction_drives_preview_rotation() {
-    // Build a minimal paint graph that wires
-    // `pen.tilt_direction → terminal.rotation`. The built-in brushes
-    // don't wire rotation today, so the test constructs its own
-    // graph rather than mutating a builtin's defaults.
+/// Build a minimal paint graph with `pen.drawing_angle → circle.rotation_input`.
+/// Circle is set to the superformula algorithm so the shape has a four-fold
+/// symmetry whose orientation reads cleanly off rotation_input.
+fn build_graph_with_rotation_wire() -> Graph<BrushWireType> {
     let registry = registry();
     let mut graph = Graph::<BrushWireType>::new();
 
@@ -63,7 +72,8 @@ fn pen_tilt_direction_drives_preview_rotation() {
     let circle = graph.add_node(
         "circle",
         registry.get("circle").unwrap().ports.clone(),
-        vec![darkly::gpu::params::ParamValue::Int(0)],
+        // Algorithm = 2 (Superformula).
+        vec![darkly::gpu::params::ParamValue::Int(2)],
     );
     let stamp = graph.add_node(
         "stamp",
@@ -78,7 +88,9 @@ fn pen_tilt_direction_drives_preview_rotation() {
 
     let wires = [
         (pen, "position", term, "position"),
-        (pen, "tilt_direction", term, "rotation"),
+        // Canonical stroke-follow wire — what users wire when they want
+        // the dab to face the stroke direction.
+        (pen, "drawing_angle", circle, "rotation_input"),
         (paint_color, "color", stamp, "color"),
         (circle, "mask", stamp, "tip"),
         (stamp, "dab", term, "rgba"),
@@ -97,13 +109,28 @@ fn pen_tilt_direction_drives_preview_rotation() {
             )
             .unwrap();
     }
-    graph.set_port_default(term, "size", 0.1).unwrap();
+    // Big size so the mask occupies most of the preview texture.
+    graph.set_port_default(term, "size", 0.4).unwrap();
+    // Superformula with a 4-pointed silhouette so rotation moves the
+    // shape's lobes from axes to diagonals (and vice versa).
+    graph.set_port_default(circle, "frequency", 4.0).unwrap();
+    graph.set_port_default(circle, "amplitude", 0.8).unwrap();
+    graph.set_port_default(circle, "n1", 1.0).unwrap();
+    graph.set_port_default(circle, "n2", 1.0).unwrap();
+    graph.set_port_default(circle, "n3", 1.0).unwrap();
+    graph
+}
+
+/// Render the preview mask with `info.drawing_angle = angle_rad` and
+/// return the RGBA8 bytes.
+fn render_at_angle(angle_rad: f32) -> Vec<u8> {
+    let graph = build_graph_with_rotation_wire();
 
     let (device, queue) = test_device();
     let device = Arc::new(device);
     let queue = Arc::new(queue);
     let pipelines = BrushPipelines::new(&device, &queue);
-    let (_target_tex, target_view) = preview_target(&device);
+    let (target_tex, target_view) = preview_target(&device);
 
     let mut runner: BrushGraphRunner = compile_graph(&graph).expect("brush compiles");
 
@@ -131,35 +158,70 @@ fn pen_tilt_direction_drives_preview_rotation() {
         dab_batch: DabBatch::default(),
     };
 
-    // Non-zero pen tilt direction. The runner's `seed_sensors` writes
-    // it straight into `pen_input.tilt_direction` and the wire
-    // remap (no `natural_range` on tilt_direction) passes the value
-    // through unchanged to the terminal's `rotation` input.
-    let expected = 1.5_f32;
+    // Seed `drawing_angle` directly — `seed_sensors` writes the raw
+    // `info.drawing_angle` into the pen_input slot, which the wire then
+    // feeds into `circle.rotation_input` via the compiled WGSL.
     let mut info = PaintInformation {
-        pos: [64.0, 64.0],
+        pos: [PREVIEW_SIDE as f32 * 0.5, PREVIEW_SIDE as f32 * 0.5],
         pressure: 1.0,
         ..Default::default()
     };
-    info.tilt_direction = expected;
+    info.drawing_angle = angle_rad;
     runner.seed_sensors(&info, [1.0, 0.0, 0.0, 1.0], 0xC0FFEE, 0);
     runner.execute_cpu();
     runner.render_cursor_preview_pipeline(&mut ctx);
-
-    let rotation = ctx
-        .preview
-        .as_ref()
-        .and_then(|p| p.info)
-        .expect("paint publishes brush_preview_info during preview")
-        .rotation_rad;
-
-    // Without the plumbing this would be 0; with it the seeded
-    // tilt_direction lands here. Allow a small epsilon for
-    // wire-remap float noise.
-    assert!(
-        (rotation - expected).abs() < 1e-3,
-        "expected rotation ≈ {expected}, got {rotation}",
-    );
-    // Drain the encoder so the device doesn't complain on drop.
     queue.submit([ctx.encoder.finish()]);
+
+    readback_texture(
+        &device,
+        &queue,
+        &target_tex,
+        wgpu::TextureFormat::Rgba8Unorm,
+        PREVIEW_SIDE,
+        PREVIEW_SIDE,
+    )
+}
+
+fn alpha(rgba: &[u8], x: u32, y: u32) -> u8 {
+    let i = ((y * PREVIEW_SIDE + x) * 4) as usize;
+    rgba[i + 3]
+}
+
+#[test]
+fn drawing_angle_rotates_preview_mask() {
+    let baseline = render_at_angle(0.0);
+    let rotated = render_at_angle(std::f32::consts::FRAC_PI_4); // 45°
+
+    // Average alpha over an off-axis arc at ~half the brush extent.
+    // A 4-pointed superformula has its lobes aligned with ±x / ±y at
+    // rotation=0; at 45° those lobes swing onto the diagonals. So a
+    // sample taken at an axis-aligned offset will be inside the shape
+    // in one render and outside in the other.
+    //
+    // Sample a small disc of pixels to absorb the smoothstep edge band
+    // — single-pixel reads are too noisy on the AA boundary.
+    let half = PREVIEW_SIDE as i32 / 2;
+    let probe_r = (PREVIEW_SIDE as i32 / 5).max(8);
+    let probe_samples = [
+        (half + probe_r, half),
+        (half - probe_r, half),
+        (half, half + probe_r),
+        (half, half - probe_r),
+    ];
+
+    let mut sum_baseline: u32 = 0;
+    let mut sum_rotated: u32 = 0;
+    for (x, y) in probe_samples {
+        sum_baseline += alpha(&baseline, x as u32, y as u32) as u32;
+        sum_rotated += alpha(&rotated, x as u32, y as u32) as u32;
+    }
+
+    let diff = (sum_baseline as i32 - sum_rotated as i32).unsigned_abs();
+    assert!(
+        diff > 64,
+        "drawing_angle wired to circle.rotation_input should rotate the \
+         rendered shape; baseline on-axis alpha={sum_baseline}, rotated \
+         on-axis alpha={sum_rotated} (diff={diff}). If these are equal, \
+         the rotation wire is dead.",
+    );
 }

--- a/crates/darkly/tests/preview_smudge.rs
+++ b/crates/darkly/tests/preview_smudge.rs
@@ -125,6 +125,6 @@ fn smudge_preview_shows_neutral_gray_footprint() {
             && (centre[1] as i32 - centre[2] as i32).abs() < 5,
         "Smudge preview should be neutral gray; got {centre:?}",
     );
-    // Smudge cursor is symmetric — rotation_rad is fixed at 0.0.
-    assert_eq!(published.rotation_rad, 0.0);
+    // Sanity: bbox publishes a non-zero footprint.
+    assert!(published.half_extent_canvas_px[0] > 0.0);
 }

--- a/crates/darkly/tests/rough_ink.rs
+++ b/crates/darkly/tests/rough_ink.rs
@@ -58,10 +58,10 @@ struct Harness {
 ///   pen_input.position → paint.position
 ///   pen_input.pressure → curve → paint.size_input
 ///   paint_color.color  → stamp.color
-///   circle.mask    → stamp.tip       (per-dab shape feed)
+///   shape.mask    → stamp.tip       (per-dab shape feed)
 ///   stamp.dab          → paint.rgba
 ///
-/// `algorithm` selects the circle's shape function. `amplitude`
+/// `algorithm` selects the shape's silhouette function. `amplitude`
 /// defaults to 0 (= disc) unless the caller overrides.
 fn build_test_graph(algorithm: i32, amplitude: f32, size: f32) -> Graph<BrushWireType> {
     let registry = registry();
@@ -82,9 +82,9 @@ fn build_test_graph(algorithm: i32, amplitude: f32, size: f32) -> Graph<BrushWir
         registry.get("curve").unwrap().ports.clone(),
         vec![ParamValue::Curve(vec![[0.0, 0.0], [1.0, 1.0]])],
     );
-    let circle = graph.add_node(
-        "circle",
-        registry.get("circle").unwrap().ports.clone(),
+    let shape = graph.add_node(
+        "shape",
+        registry.get("shape").unwrap().ports.clone(),
         vec![ParamValue::Int(algorithm)],
     );
     let stamp = graph.add_node(
@@ -99,9 +99,9 @@ fn build_test_graph(algorithm: i32, amplitude: f32, size: f32) -> Graph<BrushWir
     );
 
     graph
-        .set_port_default(circle, "amplitude", amplitude)
+        .set_port_default(shape, "amplitude", amplitude)
         .unwrap();
-    graph.set_port_default(circle, "softness", 0.0).unwrap();
+    graph.set_port_default(shape, "softness", 0.0).unwrap();
     graph.set_port_default(terminal, "size", size).unwrap();
     graph.set_port_default(terminal, "opacity", 1.0).unwrap();
     graph.set_port_default(terminal, "flow", 1.0).unwrap();
@@ -112,7 +112,7 @@ fn build_test_graph(algorithm: i32, amplitude: f32, size: f32) -> Graph<BrushWir
     let wires = [
         (pen, "pressure", curve, "input"),
         (curve, "output", terminal, "size_input"),
-        (circle, "mask", stamp, "tip"),
+        (shape, "mask", stamp, "tip"),
         (paint_color, "color", stamp, "color"),
         (stamp, "dab", terminal, "rgba"),
         (pen, "position", terminal, "position"),
@@ -337,9 +337,9 @@ fn two_dabs_same_flush_both_deposit() {
 #[test]
 fn builtin_rough_ink_brush_renders_within_declared_bbox() {
     // Render the actual Rough Ink builtin — exercises `random →
-    // circle` wires that pack per-dab values into the dab record
+    // shape` wires that pack per-dab values into the dab record
     // and reference them from the shape evaluator. Regression test
-    // for the case where circle's shape eval was emitted as a
+    // for the case where the shape evaluator's body was emitted as a
     // top-level WGSL function that captured `d.<field>` from outside
     // its scope (Dawn rejects, naga silently accepted on native).
     //
@@ -379,7 +379,7 @@ fn builtin_rough_ink_brush_renders_within_declared_bbox() {
 
     let runner = compile_graph(&graph).expect("Rough Ink compiles");
     let compiled = runner.compiled_brush().expect("compiled brush attached");
-    // Rough Ink wires `random → circle.amplitude` (natural_range max
+    // Rough Ink wires `random → shape.amplitude` (natural_range max
     // = 0.5) so the brush extent factor composes to 1.5.
     assert!(
         (compiled.brush_extent_factor - 1.5).abs() < 1e-4,

--- a/crates/darkly/tests/wgsl.rs
+++ b/crates/darkly/tests/wgsl.rs
@@ -8,7 +8,7 @@
 //!    same `topology_hash` so the per-brush pipeline cache shares
 //!    pipelines.
 //! 2. **The Rough Ink builtin compiles end-to-end** — the framework
-//!    handles a real graph with random + curve + circle + stamp +
+//!    handles a real graph with random + curve + shape + stamp +
 //!    paint and produces non-empty WGSL.
 
 use std::collections::HashMap;
@@ -73,7 +73,7 @@ fn rough_ink_brush_compiles_to_nonempty_wgsl() {
 /// argument rotates the geometry CCW in this frame; subtracting rotates
 /// it CW. The user-facing semantic is "rotation = α (radians) points the
 /// shape's θ=0 reference ray at screen angle α," which makes
-/// `pen.drawing_angle → circle.rotation_input` an identity wire that
+/// `pen.drawing_angle → shape.rotation_input` an identity wire that
 /// orients the shape along the stroke direction. That semantic requires
 /// subtraction. If a future reader is tempted to "clean up" the operator
 /// back to `+`, this test will catch it.
@@ -120,7 +120,7 @@ fn shape_rotation_subtracts_from_theta_for_drawing_angle_compatibility() {
 ///    `drawing_angle`'s wire output. `drawing_angle` is
 ///    `atan2(canvas_dy, canvas_dx)` — a canvas-frame angle. The
 ///    subtraction lifts it to screen-frame so the canonical
-///    `pen.drawing_angle → circle.rotation_input` wire keeps following
+///    `pen.drawing_angle → shape.rotation_input` wire keeps following
 ///    the on-screen stroke direction after the skeleton's
 ///    counteraction.
 ///
@@ -141,9 +141,9 @@ fn stamp_rotation_counteracts_view_rotation() {
         reg.get("paint_color").unwrap().ports.clone(),
         vec![],
     );
-    let circle = graph.add_node(
-        "circle",
-        reg.get("circle").unwrap().ports.clone(),
+    let shape = graph.add_node(
+        "shape",
+        reg.get("shape").unwrap().ports.clone(),
         vec![darkly::gpu::params::ParamValue::Int(0)], // Sine
     );
     let stamp = graph.add_node(
@@ -154,9 +154,9 @@ fn stamp_rotation_counteracts_view_rotation() {
     let term = graph.add_node("paint", reg.get("paint").unwrap().ports.clone(), vec![]);
     let wires = [
         (pen, "position", term, "position"),
-        (pen, "drawing_angle", circle, "rotation_input"),
+        (pen, "drawing_angle", shape, "rotation_input"),
         (paint_color, "color", stamp, "color"),
-        (circle, "mask", stamp, "tip"),
+        (shape, "mask", stamp, "tip"),
         (stamp, "dab", term, "rgba"),
     ];
     for (fnode, fport, tnode, tport) in wires {
@@ -233,8 +233,8 @@ fn topology_hash_is_stable_for_identical_graphs() {
 #[test]
 fn extent_protocol_composes_along_chain() {
     // Build the same skeleton the test harness builds for Perlin:
-    // pen + circle(perlin) + stamp + paint with a wire on
-    // `amplitude` so it counts as wired. circle's extent must report
+    // pen + shape(perlin) + stamp + paint with a wire on
+    // `amplitude` so it counts as wired. shape's extent must report
     // `1 + amplitude.natural_range.max = 1.5`, and the framework's
     // compose pass must surface it on the CompiledBrush.
     let reg = registry();
@@ -254,9 +254,9 @@ fn extent_protocol_composes_along_chain() {
         reg.get("random").unwrap().ports.clone(),
         vec![darkly::gpu::params::ParamValue::Int(0)],
     );
-    let circle = graph.add_node(
-        "circle",
-        reg.get("circle").unwrap().ports.clone(),
+    let shape = graph.add_node(
+        "shape",
+        reg.get("shape").unwrap().ports.clone(),
         vec![darkly::gpu::params::ParamValue::Int(1)], // Perlin
     );
     let stamp = graph.add_node(
@@ -266,8 +266,8 @@ fn extent_protocol_composes_along_chain() {
     );
     let term = graph.add_node("paint", reg.get("paint").unwrap().ports.clone(), vec![]);
     let wires = [
-        (rand_amp, "value", circle, "amplitude"),
-        (circle, "mask", stamp, "tip"),
+        (rand_amp, "value", shape, "amplitude"),
+        (shape, "mask", stamp, "tip"),
         (paint_color, "color", stamp, "color"),
         (stamp, "dab", term, "rgba"),
         (pen, "position", term, "position"),

--- a/crates/darkly/tests/wire_range_remap.rs
+++ b/crates/darkly/tests/wire_range_remap.rs
@@ -1,6 +1,6 @@
 //! End-to-end tests for wire-boundary range remap (`PortDef::natural_range`).
 //!
-//! The bug that motivated this: `random.value → circle.seed` produced the
+//! The bug that motivated this: `random.value → shape.seed` produced the
 //! same seed every dab because random's output (`[-1, 1]`) collapsed to 0
 //! when seed cast it through `as u32` (range `[0, 1024]`). The fix is that
 //! when both ends of a wire declare a `natural_range`, the runner remaps
@@ -49,7 +49,7 @@ fn run_one_dab(runner: &mut BrushGraphRunner, pressure: f32, dab_index: u32) {
 /// natural PRNG range), no longer the old `[-1, 1]` remap, and produces a
 /// fresh value each dab. The previous behavior — `random` outputting in
 /// `[-1, 1]` and any downstream `as u32` cast collapsing it to 0 — is what
-/// caused `random → circle.seed` to repeat.
+/// caused `random → shape.seed` to repeat.
 #[test]
 fn random_outputs_unit_range_and_varies_per_dab() {
     let registry = registry();
@@ -87,7 +87,7 @@ fn random_outputs_unit_range_and_varies_per_dab() {
 /// `random → seed-style port (natural_range [0, 1024])` produces values
 /// spread across the destination range, varying per dab.
 ///
-/// We can't observe `circle.seed` directly without a GPU, but the runner's
+/// We can't observe `shape.seed` directly without a GPU, but the runner's
 /// remap step happens at `gather_inputs` — same code path for CPU and GPU
 /// nodes. So we exercise it through a CPU node (`multiply`) with a
 /// per-instance override on its `a` port: `natural_range = Some((0, 1024))`.
@@ -102,7 +102,7 @@ fn random_to_wide_range_input_remaps() {
     let random = graph.add_node("random", random_reg.ports.clone(), random_params());
 
     // Clone multiply's ports, then widen the `a` input's natural_range to
-    // simulate wiring random into something like `circle.seed`.
+    // simulate wiring random into something like `shape.seed`.
     let multiply_reg = registry.get("multiply").unwrap();
     let mut multiply_ports = multiply_reg.ports.clone();
     for p in multiply_ports.iter_mut() {
@@ -377,7 +377,7 @@ fn identity_range_is_a_noop() {
 /// Bipolar destination range: `random [0, 1] → [-100, 100]` spans both
 /// halves, verifying the affine remap handles a negative `dst_min`.
 ///
-/// Note: radian-typed ports (`circle.rotation`, `liquify.direction`, etc.)
+/// Note: radian-typed ports (`shape.rotation`, `liquify.direction`, etc.)
 /// deliberately do NOT have a `natural_range` — radians are a unit, not
 /// a normalized signal, and wires like `pen.drawing_angle → rotation`
 /// must preserve them exactly. This test uses an abstract `[-100, 100]`

--- a/docs/brush/architecture.md
+++ b/docs/brush/architecture.md
@@ -126,7 +126,7 @@ job is to put something on the layer (stroke mode) or on the preview mask
 (preview mode). Terminals participate in the stroke *lifecycle* by
 overriding `begin_stroke` / `commit` in addition to per-dab `evaluate_gpu`.
 
-Non-terminal nodes (`stamp`, `circle`, `user_input`, …) don't override the
+Non-terminal nodes (`stamp`, `shape`, `user_input`, …) don't override the
 lifecycle hooks — their default impls are no-ops.
 
 ### `color_output` (paint terminal)
@@ -193,7 +193,7 @@ secretly swaps resources behind a single misleading name.
 |---|---|
 | `encoder` | Command encoder shared across all dabs in a segment |
 | `device`, `queue` | Standard wgpu handles |
-| `dab_pool` | Pre-allocated 512×512 RTs for stamp / circle outputs |
+| `dab_pool` | Pre-allocated 512×512 RTs for stamp / shape outputs |
 | `pipelines` | `BrushPipelines` with shaders + uniform rings |
 | `layer_view`, `layer_texture` | The actual layer.  Warp terminals read/write it; paint terminals use it only at `commit`. |
 | `stroke_scratch_view`, `stroke_scratch_texture` | Stroke-scoped scratch.  `Some` during a stroke, `None` in preview mode. |

--- a/docs/brush/node-system.md
+++ b/docs/brush/node-system.md
@@ -40,7 +40,7 @@ not re-specify them.
 ```rust
 fn canvas_brush() -> PresetBundle {
     let mut b = PresetBuilder::new();
-    b.add_circle(0.4);
+    b.add_shape(0.4);
     b.wire(b.pen, "pressure", b.stamp, "size");
     b.wire(b.paint_color, "color", b.stamp, "color");
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,19 +3,37 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Darkly</title>
+    <title>Darkly - Entropic Editor for Artists</title>
+    <meta name="description" content="Darkly is a GPU-native paint program written in Rust, geared towards digital artists. Runs offline, no login, free and open source forever." />
+    <link rel="canonical" href="https://darkly.art" />
     <link rel="icon" type="image/png" href="./darkly-favicon.png" />
     <link rel="stylesheet" href="/fontawesome/css/all.min.css">
+
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Darkly" />
+    <meta property="og:title" content="Darkly - Entropic Editor for Artists" />
+    <meta property="og:description" content="A GPU-native paint program written in Rust. Runs offline, no login, free and open source forever." />
+    <meta property="og:url" content="https://darkly.art" />
+    <meta property="og:image" content="https://darkly.art/darkly-banner.png" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Darkly - Entropic Editor for Artists" />
+    <meta name="twitter:description" content="A GPU-native paint program written in Rust. Runs offline, no login, free and open source forever." />
+    <meta name="twitter:image" content="https://demo.darkly.art/darkly-banner.png" />
+
     <style>
         html, body { margin: 0; background: #000; color: #666; }
         #boot-splash {
             position: fixed;
             inset: 0;
             display: flex;
+            flex-direction: column;
             align-items: center;
             justify-content: center;
             padding: 2rem;
             box-sizing: border-box;
+            text-align: center;
+            font-family: system-ui, sans-serif;
         }
         #boot-splash img {
             max-width: min(60vw, 600px);
@@ -25,6 +43,9 @@
             opacity: 0.9;
             animation: boot-pulse 1.6s ease-in-out infinite;
         }
+        #boot-splash p { margin: 1.5rem 0 0.5rem; max-width: 40rem; }
+        #boot-splash a { color: #9500ff; text-decoration: none; margin: 0 0.5rem; }
+        #boot-splash a:hover { text-decoration: underline; }
         @keyframes boot-pulse {
             0%, 100% { opacity: 0.55; }
             50%      { opacity: 1; }
@@ -33,8 +54,22 @@
 </head>
 <body class="dark">
     <div id="app">
-        <div id="boot-splash"><img src="./darkly-banner.png" alt="Darkly" /></div>
+        <div id="boot-splash">
+            <img src="./darkly-banner.png" alt="Darkly" />
+            <p>A GPU-native paint program written in Rust, geared towards digital artists.</p>
+            <p>
+                <a href="https://darkly.art">darkly.art</a> ·
+                <a href="https://github.com/darkly-art/darkly">GitHub</a>
+            </p>
+        </div>
     </div>
+    <noscript>
+        <p style="color:#aaa;font-family:system-ui,sans-serif;text-align:center;padding:2rem;">
+            Darkly is a GPU-native paint program that requires JavaScript and WebGPU to run.
+            Learn more at <a href="https://darkly.art" style="color:#9500ff;">darkly.art</a>
+            or visit the <a href="https://github.com/darkly-art/darkly" style="color:#9500ff;">GitHub repo</a>.
+        </p>
+    </noscript>
     <script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Darkly - Entropic Editor for Artists</title>
-    <meta name="description" content="Darkly is a GPU-native paint program written in Rust, geared towards digital artists. Runs offline, no login, free and open source forever." />
+    <meta name="description" content="Darkly is a GPU-native paint program written in Rust, geared towards digital artists." />
     <link rel="canonical" href="https://darkly.art" />
     <link rel="icon" type="image/png" href="./darkly-favicon.png" />
     <link rel="stylesheet" href="/fontawesome/css/all.min.css">
@@ -56,7 +56,7 @@
     <div id="app">
         <div id="boot-splash">
             <img src="./darkly-banner.png" alt="Darkly" />
-            <p>A GPU-native paint program written in Rust, geared towards digital artists.</p>
+            <p>Entropic Editor for Artists</p>
             <p>
                 <a href="https://darkly.art">darkly.art</a> ·
                 <a href="https://github.com/darkly-art/darkly">GitHub</a>

--- a/frontend/src/canvas/CanvasView.svelte
+++ b/frontend/src/canvas/CanvasView.svelte
@@ -184,27 +184,9 @@
         // Prevent browser from synthesising fling/scroll gestures from pen
         // input — touch-action:none only covers touch, not pen (Chromium bug).
         e.preventDefault();
-        // TEMP cursor-bug diagnostic — remove once root cause is identified.
-        console.log('[onPointerDown]', {
-            pointerType: e.pointerType,
-            buttons: e.buttons,
-            pressure: e.pressure,
-            cursorBefore: canvas.style.cursor,
-            toolCursor: inst.toolCursor,
-            navCursor: nav.cursor,
-            activeTool: inst.activeToolId,
-        });
 
-        // Touch: always capture and track for gesture detection.
-        // Touchscreen pens on some Linux/Chromium setups report as 'touch'
-        // rather than 'pen'; force `cursor: none` imperatively here so the
-        // Chromium cursor-snapshot-at-setPointerCapture quirk doesn't leave
-        // the OS pointer stuck following the pen for the whole stroke.
-        // Touchscreens don't use a hover cursor anyway — Svelte's reactive
-        // style:cursor binding will reassert the correct value once capture
-        // ends.
+        // Touch: always capture and track for gesture detection
         if (e.pointerType === 'touch') {
-            canvas.style.cursor = 'none';
             canvas.setPointerCapture(e.pointerId);
             if (nav.onTouchPointerDown(e)) {
                 // Touch consumed by navigation — end any in-progress tool stroke
@@ -233,32 +215,29 @@
         // active tool sees it — unless the tool claimed it.
         if (!claimed && dispatchDrag('canvas', e, { x: pos.x, y: pos.y })) return;
 
+        canvas.setPointerCapture(e.pointerId);
+
         if (!ctx) return;
         tool?.onPointerDown(ctx, e, pos.x, pos.y);
-        // Chromium snapshots the element's CSS cursor at setPointerCapture
-        // time and ignores `style:` updates until capture ends or the
-        // captured pointer crosses the element boundary. Set the cursor
-        // imperatively here — Svelte's batched reactive binding for
-        // style:cursor won't have landed before capture, leaving the OS
-        // pointer stuck visible for the whole stroke. The reactive
-        // binding takes over again after capture ends.
-        canvas.style.cursor = inst.toolCursor ?? nav.cursor;
-        // EXPERIMENT 3 — skip setPointerCapture for pen entirely. If the
-        // visible cursor is Chromium's captured-pen-pointer cursor (locked
-        // at capture time), not calling capture should make it follow CSS
-        // normally. Trade-off: if the pen leaves the canvas mid-stroke,
-        // events stop reaching us until it returns. Acceptable for the
-        // diagnostic; we'll re-introduce capture properly once root cause
-        // is confirmed.
-        if (e.pointerType !== 'pen') {
-            canvas.setPointerCapture(e.pointerId);
-        }
-        inst.requestFrame();
-    }
 
-    function clearPenCursorOverride() {
-        document.documentElement.style.cursor = '';
-        document.body.style.cursor = '';
+        // Chromium/Linux touchscreen-pen quirk: when the pen starts a
+        // stroke AND the OS mouse cursor happens to be over the canvas,
+        // Chromium warps the mouse cursor to the pen position and keeps
+        // it following the pen for the whole stroke. CSS cursor:none on
+        // canvas/body/html doesn't suppress it; only a change to which
+        // element the cursor resolves against does. Drop canvas out of
+        // pointer hit-test for one frame at stroke start so Chromium
+        // re-resolves the cursor to the parent (.canvas-container) and
+        // doesn't latch it to the pen. The captured pen pointer continues
+        // to flow to canvas via setPointerCapture.
+        if (e.pointerType === 'pen') {
+            canvas.style.pointerEvents = 'none';
+            requestAnimationFrame(() => {
+                canvas.style.pointerEvents = '';
+            });
+        }
+
+        inst.requestFrame();
     }
 
     function onPointerMove(e: PointerEvent) {
@@ -294,7 +273,6 @@
 
     function onPointerUp(e: PointerEvent) {
         e.preventDefault();
-        clearPenCursorOverride();
 
         // Touch: clean up gesture state; skip tool dispatch if gesture occurred
         if (e.pointerType === 'touch') {
@@ -317,7 +295,6 @@
 
     function onPointerCancel(e: PointerEvent) {
         e.preventDefault();
-        clearPenCursorOverride();
 
         // Pen/touch can fire pointercancel instead of pointerup (pen lifted
         // out of range, system gesture, browser intervention).  Clean up

--- a/frontend/src/canvas/CanvasView.svelte
+++ b/frontend/src/canvas/CanvasView.svelte
@@ -184,9 +184,27 @@
         // Prevent browser from synthesising fling/scroll gestures from pen
         // input — touch-action:none only covers touch, not pen (Chromium bug).
         e.preventDefault();
+        // TEMP cursor-bug diagnostic — remove once root cause is identified.
+        console.log('[onPointerDown]', {
+            pointerType: e.pointerType,
+            buttons: e.buttons,
+            pressure: e.pressure,
+            cursorBefore: canvas.style.cursor,
+            toolCursor: inst.toolCursor,
+            navCursor: nav.cursor,
+            activeTool: inst.activeToolId,
+        });
 
-        // Touch: always capture and track for gesture detection
+        // Touch: always capture and track for gesture detection.
+        // Touchscreen pens on some Linux/Chromium setups report as 'touch'
+        // rather than 'pen'; force `cursor: none` imperatively here so the
+        // Chromium cursor-snapshot-at-setPointerCapture quirk doesn't leave
+        // the OS pointer stuck following the pen for the whole stroke.
+        // Touchscreens don't use a hover cursor anyway — Svelte's reactive
+        // style:cursor binding will reassert the correct value once capture
+        // ends.
         if (e.pointerType === 'touch') {
+            canvas.style.cursor = 'none';
             canvas.setPointerCapture(e.pointerId);
             if (nav.onTouchPointerDown(e)) {
                 // Touch consumed by navigation — end any in-progress tool stroke
@@ -215,11 +233,32 @@
         // active tool sees it — unless the tool claimed it.
         if (!claimed && dispatchDrag('canvas', e, { x: pos.x, y: pos.y })) return;
 
-        canvas.setPointerCapture(e.pointerId);
-
         if (!ctx) return;
         tool?.onPointerDown(ctx, e, pos.x, pos.y);
+        // Chromium snapshots the element's CSS cursor at setPointerCapture
+        // time and ignores `style:` updates until capture ends or the
+        // captured pointer crosses the element boundary. Set the cursor
+        // imperatively here — Svelte's batched reactive binding for
+        // style:cursor won't have landed before capture, leaving the OS
+        // pointer stuck visible for the whole stroke. The reactive
+        // binding takes over again after capture ends.
+        canvas.style.cursor = inst.toolCursor ?? nav.cursor;
+        // EXPERIMENT 3 — skip setPointerCapture for pen entirely. If the
+        // visible cursor is Chromium's captured-pen-pointer cursor (locked
+        // at capture time), not calling capture should make it follow CSS
+        // normally. Trade-off: if the pen leaves the canvas mid-stroke,
+        // events stop reaching us until it returns. Acceptable for the
+        // diagnostic; we'll re-introduce capture properly once root cause
+        // is confirmed.
+        if (e.pointerType !== 'pen') {
+            canvas.setPointerCapture(e.pointerId);
+        }
         inst.requestFrame();
+    }
+
+    function clearPenCursorOverride() {
+        document.documentElement.style.cursor = '';
+        document.body.style.cursor = '';
     }
 
     function onPointerMove(e: PointerEvent) {
@@ -255,6 +294,7 @@
 
     function onPointerUp(e: PointerEvent) {
         e.preventDefault();
+        clearPenCursorOverride();
 
         // Touch: clean up gesture state; skip tool dispatch if gesture occurred
         if (e.pointerType === 'touch') {
@@ -277,6 +317,7 @@
 
     function onPointerCancel(e: PointerEvent) {
         e.preventDefault();
+        clearPenCursorOverride();
 
         // Pen/touch can fire pointercancel instead of pointerup (pen lifted
         // out of range, system gesture, browser intervention).  Clean up

--- a/frontend/src/canvas/__tests__/pen_cursor_unlatch.test.ts
+++ b/frontend/src/canvas/__tests__/pen_cursor_unlatch.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import canvasViewSource from '../CanvasView.svelte?raw';
+
+// Regression: on Chromium/Linux with a touchscreen pen, when the OS mouse
+// cursor is over the canvas at pen-contact, Chromium warps the mouse
+// cursor to the pen position and keeps it following the pen for the whole
+// stroke. CSS cursor:none on canvas/body/html does not suppress this; nor
+// does dropping setPointerCapture, nor `* { cursor: none !important }`,
+// nor Pointer Lock (which has its own UX issues). The only thing that
+// breaks it is changing which element the cursor's hit-test resolves to:
+// briefly setting `canvas.style.pointerEvents = 'none'` for one frame at
+// pen pointerdown forces Chromium to re-resolve the cursor against the
+// parent (.canvas-container). The captured pen pointer continues to flow
+// to canvas via setPointerCapture, so the stroke is unaffected.
+//
+// This test pins the unlatch step. It fails if a future refactor removes
+// the pointer-events toggle, omits the rAF restore, or moves the toggle
+// outside the pen branch.
+
+function onPointerDownBody(): string {
+    const match = canvasViewSource.match(/function onPointerDown\([\s\S]*?\n {4}\}\n/);
+    if (!match) throw new Error('onPointerDown function not found in CanvasView.svelte');
+    return match[0];
+}
+
+describe('pen cursor unlatch on stroke start', () => {
+    it("sets canvas.style.pointerEvents = 'none' in the pen branch", () => {
+        const body = onPointerDownBody();
+        // The pen branch is `if (e.pointerType === 'pen') { ... }` and must
+        // contain the pointer-events toggle.
+        const penBranch = body.match(
+            /if \(e\.pointerType === 'pen'\) \{[\s\S]*?\n {8}\}/,
+        );
+        expect(penBranch, "pen branch in onPointerDown").not.toBeNull();
+        const pb = penBranch![0];
+
+        expect(pb, "drops canvas out of hit-test").toMatch(
+            /canvas\.style\.pointerEvents\s*=\s*['"]none['"]/,
+        );
+        expect(pb, "restores canvas hit-test on the next frame")
+            .toMatch(/requestAnimationFrame\(/);
+        expect(pb, "restore sets pointerEvents back to ''")
+            .toMatch(/canvas\.style\.pointerEvents\s*=\s*['"]['"]/);
+    });
+
+    it('does NOT apply the unlatch to mouse or touch input', () => {
+        const body = onPointerDownBody();
+        // Only one pointerEvents = 'none' assignment, and it must be inside
+        // the pen branch. Mouse and touch don't trigger Chromium's
+        // pen-cursor-warp behavior, so they must not be subject to the
+        // toggle (which would briefly disable hit-test for non-pen drags
+        // and break their cursor / selection feedback).
+        const matches = body.match(/canvas\.style\.pointerEvents\s*=\s*['"]none['"]/g);
+        expect(matches?.length, "exactly one pointer-events:none assignment")
+            .toBe(1);
+    });
+});

--- a/frontend/src/state/brush_graph.svelte.ts
+++ b/frontend/src/state/brush_graph.svelte.ts
@@ -57,6 +57,7 @@ export interface NodeTypeInfo {
     type_id: string;
     category: string;
     display_name: string;
+    description: string;
     ports: PortDef[];
     params: any[];
     is_gpu: boolean;

--- a/frontend/src/state/brush_graph.svelte.ts
+++ b/frontend/src/state/brush_graph.svelte.ts
@@ -134,6 +134,13 @@ class BrushGraphState {
     /** Whether the brush builder panel is open. */
     isOpen = $state(false);
 
+    /** Whether the brush builder panel is expanded to fill the window. The
+     *  fullscreen surface is the whole bottom area (tool-options strip +
+     *  builder), so the paint tool-options bar stays pinned at the top while
+     *  the builder fills the space below. Reset to `false` when the panel
+     *  collapses. */
+    fullscreen = $state(false);
+
     /** Node currently being dragged (for drag-to-connect). */
     draggingFrom = $state<{ node: number; port: string; dir: 'Input' | 'Output' } | null>(null);
 

--- a/frontend/src/state/brush_graph.svelte.ts
+++ b/frontend/src/state/brush_graph.svelte.ts
@@ -74,12 +74,15 @@ export interface BrushInfo {
 
 export type ExposedValue =
     | { kind: 'scalar'; value: number; min: number; max: number; default: number; unitType: string }
+    | { kind: 'bool'; value: boolean }
     // Future: | { kind: 'int'; value: number; min: number; max: number }
-    // Future: | { kind: 'bool'; value: boolean }
     ;
 
 
 export interface ExposedPortInfo {
+    /** `"<node_id>.<port_name>"` — passed back to setExposedPortMeta /
+     *  reorderExposedPort to address the same entry. */
+    key: string;
     nodeId: number;
     portName: string;
     label: string;
@@ -367,10 +370,42 @@ class BrushGraphState {
         }
     }
 
-    /** Toggle whether a port is exposed in the brush properties panel. */
-    togglePortExposed(nodeId: number, portName: string, exposed: boolean) {
+    /** Append a brush-bar entry for an input port. Idempotent. */
+    exposePort(nodeId: number, portName: string) {
         if (!app.handle) return;
-        this.applyResult(app.handle.brush_graph_set_port_exposed(nodeId, portName, exposed));
+        this.applyResult(app.handle.brush_graph_expose_port(nodeId, portName));
+    }
+
+    /** Drop a brush-bar entry. Idempotent. */
+    unexposePort(nodeId: number, portName: string) {
+        if (!app.handle) return;
+        this.applyResult(app.handle.brush_graph_unexpose_port(nodeId, portName));
+    }
+
+    /** Returns true when the named input port has a live brush-bar entry. */
+    isPortExposed(nodeId: number, portName: string): boolean {
+        return this.exposedPorts.some(
+            (p) => p.nodeId === nodeId && p.portName === portName,
+        );
+    }
+
+    /** Overwrite a brush-bar entry's label / description / icon. */
+    setExposedPortMeta(
+        key: string,
+        label: string,
+        description: string,
+        icon: string,
+    ) {
+        if (!app.handle) return;
+        this.applyResult(
+            app.handle.brush_graph_set_exposed_port_meta(key, label, description, icon),
+        );
+    }
+
+    /** Move a brush-bar entry to a target index in the display order. */
+    reorderExposedPort(key: string, newIndex: number) {
+        if (!app.handle) return;
+        this.applyResult(app.handle.brush_graph_reorder_exposed_port(key, newIndex));
     }
 
     /** Load a brush by name. */

--- a/frontend/src/tools/brush.svelte.ts
+++ b/frontend/src/tools/brush.svelte.ts
@@ -198,6 +198,9 @@ export const brushTool: Tool = {
     },
 
     onDeactivate(ctx) {
+        // Leaving the brush tool drops the builder's fullscreen mode so the
+        // pinned bottom-area overlay can't outlive the panel that owns it.
+        brushGraph.fullscreen = false;
         ctx.handle.clear_overlay();
         // Reset engine blend mode so a future paint-capable tool (or a
         // direct WASM call) doesn't inherit our erase state.

--- a/frontend/src/tools/brush.svelte.ts
+++ b/frontend/src/tools/brush.svelte.ts
@@ -33,7 +33,6 @@ const LARGE_ON_SCREEN = 40;
 
 interface BrushCursorPreviewInfo {
     halfExtent: [number, number];
-    rotation: number;
 }
 
 /** Scale strength with on-screen stamp size: tiny stamps get more contrast
@@ -118,7 +117,7 @@ export function pushHoverOverlay(handle: any, pose: PenPose, cx: number, cy: num
             FLAG_CANVAS_SPACE | FLAG_SOFT_CONTRAST,
             [cx, cy],
             info.halfExtent,
-            { modeParam: previewStrength(info.halfExtent), rotation: info.rotation },
+            { modeParam: previewStrength(info.halfExtent) },
         ),
     ]);
     lastHover = { cx, cy, pose };

--- a/frontend/src/ui/BrushBuilderPanel.svelte
+++ b/frontend/src/ui/BrushBuilderPanel.svelte
@@ -26,9 +26,15 @@
 </script>
 
 {#if brushGraph.isOpen}
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div class="resize-handle" onpointerdown={handleResizeStart}></div>
-    <div class="builder-panel" style="height: {builderHeight}vh">
+    {#if !brushGraph.fullscreen}
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div class="resize-handle" onpointerdown={handleResizeStart}></div>
+    {/if}
+    <div
+        class="builder-panel"
+        class:fullscreen={brushGraph.fullscreen}
+        style={brushGraph.fullscreen ? '' : `height: ${builderHeight}vh`}
+    >
         <BrushBuilder />
     </div>
 {/if}
@@ -49,5 +55,14 @@
     .builder-panel {
         min-height: 100px;
         border-bottom: 1px solid var(--bg-hover);
+    }
+
+    /* In fullscreen the bottom-area is pinned to the window (see
+     * ToolOptionsBar); the builder fills everything below the tool-options
+     * strip rather than a fixed vh height. */
+    .builder-panel.fullscreen {
+        flex: 1;
+        min-height: 0;
+        border-bottom: none;
     }
 </style>

--- a/frontend/src/ui/BrushOptions.svelte
+++ b/frontend/src/ui/BrushOptions.svelte
@@ -18,6 +18,9 @@
     function toggleBuilder() {
         ensureInit();
         brushGraph.isOpen = !brushGraph.isOpen;
+        // Leaving the builder also leaves fullscreen — otherwise reopening
+        // would silently spring back to a window-filling panel.
+        if (!brushGraph.isOpen) brushGraph.fullscreen = false;
     }
 
     function selectBrush(brush: BrushInfo) {

--- a/frontend/src/ui/BrushOptions.svelte
+++ b/frontend/src/ui/BrushOptions.svelte
@@ -31,6 +31,14 @@
         brushGraph.setExposedPortValue(nodeId, portName, displayValue);
     }
 
+    /** Flip a Bool exposed port — toggles the port's f32 default between 0 and 1
+     *  via the standard scalar setter, since Bool is encoded as `default >= 0.5`. */
+    function handleExposedBool(nodeId: number, portName: string, current: boolean) {
+        const next = current ? 0 : 1;
+        brushGraph.setPortDefaultLocal(nodeId, portName, next);
+        brushGraph.setExposedPortValue(nodeId, portName, next);
+    }
+
     /** Format an exposed scalar value based on its unit type. */
     function formatExposedValue(unitType: string): (v: number) => string {
         switch (unitType) {
@@ -109,6 +117,17 @@
                     default={d.default}
                     formatValue={formatExposedValue(d.unitType)}
                     onChange={(v) => handleExposedPort(port.nodeId, port.portName, v)}
+                    title={port.description || undefined}
+                />
+            {:else if port.data.kind === 'bool'}
+                {@const d = port.data}
+                <Scrub
+                    mode="toggle"
+                    icon={port.icon || undefined}
+                    label={port.label}
+                    valueLabel={d.value ? 'On' : 'Off'}
+                    active={d.value}
+                    onToggle={() => handleExposedBool(port.nodeId, port.portName, d.value)}
                     title={port.description || undefined}
                 />
             {/if}

--- a/frontend/src/ui/Modal.svelte
+++ b/frontend/src/ui/Modal.svelte
@@ -35,12 +35,24 @@
         // sits inside. A click whose target is the dialog itself == backdrop.
         if (e.target === dialogEl) open = false;
     }
+
+    function onKeydown(e: KeyboardEvent) {
+        // The browser closes the dialog on Escape (we still get the
+        // `close` event), but the KeyboardEvent itself keeps bubbling
+        // and triggers any other Escape-bound handlers — collapsing the
+        // brush builder, deselecting a layer, exiting a tool, etc. Stop
+        // the bubble so dismissing the modal stays a modal-only action.
+        if (e.key === 'Escape') {
+            e.stopPropagation();
+        }
+    }
 </script>
 
 <dialog
     bind:this={dialogEl}
     onclose={onClose}
     onclick={onBackdropClick}
+    onkeydown={onKeydown}
     class="modal size-{size}"
     class:bare
 >

--- a/frontend/src/ui/Modal.svelte
+++ b/frontend/src/ui/Modal.svelte
@@ -37,14 +37,13 @@
     }
 
     function onKeydown(e: KeyboardEvent) {
-        // The browser closes the dialog on Escape (we still get the
-        // `close` event), but the KeyboardEvent itself keeps bubbling
-        // and triggers any other Escape-bound handlers — collapsing the
-        // brush builder, deselecting a layer, exiting a tool, etc. Stop
-        // the bubble so dismissing the modal stays a modal-only action.
-        if (e.key === 'Escape') {
-            e.stopPropagation();
-        }
+        // Stop every keydown inside the modal from bubbling to the
+        // window-level hotkey handlers (pan-tool space, brush-builder
+        // Escape, tool shortcuts, etc.). Without this, typing a space
+        // into a text input fires the pan-tool toggle and the input
+        // never sees the character. The dialog's own browser-default
+        // Escape handling still runs (it doesn't depend on bubbling).
+        e.stopPropagation();
     }
 </script>
 

--- a/frontend/src/ui/ToolOptionsBar.svelte
+++ b/frontend/src/ui/ToolOptionsBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { app } from '../state/app.svelte';
     import { toolRegistry } from '../tools/registry';
+    import { brushGraph } from '../state/brush_graph.svelte';
 
     // The strip itself is always mounted — only the content inside (and
     // any optional panel above) varies per tool. Keeping the same DOM
@@ -10,7 +11,7 @@
     let Panel = $derived(tool?.panelComponent);
 </script>
 
-<div class="bottom-area">
+<div class="bottom-area" class:fullscreen={brushGraph.fullscreen}>
     <div class="tool-options">
         {#if Options}
             <Options />
@@ -29,6 +30,17 @@
         display: flex;
         flex-direction: column;
         flex-shrink: 0;
+    }
+
+    /* Fullscreen brush builder: pin the whole bottom area to the window so
+     * the tool-options strip stays at the top and the builder fills the
+     * space below it. The builder panel switches to flex:1 in this mode
+     * (see BrushBuilderPanel). */
+    .bottom-area.fullscreen {
+        position: fixed;
+        inset: 0;
+        z-index: 9999;
+        background: var(--bg);
     }
 
     .tool-options {

--- a/frontend/src/ui/brush_builder/AddNodeMenu.svelte
+++ b/frontend/src/ui/brush_builder/AddNodeMenu.svelte
@@ -234,7 +234,7 @@
                         <button
                             class="leaf"
                             onclick={() => pick(nt.type_id)}
-                            title={nt.type_id}
+                            title={nt.description || nt.display_name}
                         >
                             <span class="leaf-name">{nt.display_name}</span>
                             <span class="leaf-cat">{CATEGORY_LABELS[nt.category] ?? nt.category}</span>
@@ -263,7 +263,7 @@
                                     <button
                                         class="leaf"
                                         onclick={() => pick(nt.type_id)}
-                                        title={nt.type_id}
+                                        title={nt.description || nt.display_name}
                                     >
                                         <span class="leaf-name">{nt.display_name}</span>
                                     </button>

--- a/frontend/src/ui/brush_builder/BrushBarEntryModal.svelte
+++ b/frontend/src/ui/brush_builder/BrushBarEntryModal.svelte
@@ -83,17 +83,24 @@
             </label>
             <label class="field">
                 <span class="field-label">Icon</span>
-                <input
-                    type="text"
-                    class="text-input"
-                    bind:value={iconInput}
-                    placeholder="fa-solid fa-circle"
-                    oninput={validateIcon}
-                />
+                <div class="icon-field-row">
+                    <span class="icon-preview" class:placeholder={!iconInput || !!iconError}>
+                        {#if iconInput && !iconError}
+                            <i class={iconInput}></i>
+                        {:else}
+                            <i class="fa-regular fa-square"></i>
+                        {/if}
+                    </span>
+                    <input
+                        type="text"
+                        class="text-input"
+                        bind:value={iconInput}
+                        placeholder="fa-solid fa-circle"
+                        oninput={validateIcon}
+                    />
+                </div>
                 {#if iconError}
                     <span class="icon-error">{iconError}</span>
-                {:else if iconInput}
-                    <span class="icon-preview"><i class={iconInput}></i></span>
                 {/if}
             </label>
             <footer class="actions">
@@ -146,9 +153,28 @@
         font-size: 11px;
         color: var(--error, #d44);
     }
+    .icon-field-row {
+        display: flex;
+        align-items: stretch;
+        gap: 8px;
+    }
+    .icon-field-row .text-input {
+        flex: 1;
+    }
     .icon-preview {
-        font-size: 18px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        font-size: 16px;
         color: var(--text);
+        background: var(--bg);
+        border: 1px solid var(--bg-hover);
+        border-radius: 4px;
+        flex-shrink: 0;
+    }
+    .icon-preview.placeholder {
+        color: var(--text-muted);
     }
     .actions {
         display: flex;

--- a/frontend/src/ui/brush_builder/BrushBarEntryModal.svelte
+++ b/frontend/src/ui/brush_builder/BrushBarEntryModal.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+    import Modal from '../Modal.svelte';
+    import { brushGraph, type ExposedPortInfo } from '../../state/brush_graph.svelte';
+
+    type Props = {
+        open: boolean;
+        entry: ExposedPortInfo | null;
+    };
+
+    let { open = $bindable(false), entry }: Props = $props();
+
+    let labelInput = $state('');
+    let descriptionInput = $state('');
+    let iconInput = $state('');
+    let iconError = $state('');
+
+    /** Same alphabet as Graph::set_exposed_port_meta — letters, digits,
+     *  hyphens, spaces. Bind into a Svelte `class={...}` attribute only
+     *  (never `{@html ...}`), so even if a string slipped through the
+     *  filter the engine would have rejected it. */
+    const ICON_SAFE = /^[a-zA-Z0-9\- ]*$/;
+
+    /** Re-seed the inputs whenever the modal opens for a fresh entry —
+     *  the engine emits the current effective values (registration
+     *  fallbacks applied) so the placeholders/values match what the
+     *  brush user actually sees. */
+    $effect(() => {
+        if (open && entry) {
+            labelInput = entry.label;
+            descriptionInput = entry.description;
+            iconInput = entry.icon;
+            iconError = '';
+        }
+    });
+
+    function validateIcon(): boolean {
+        if (!ICON_SAFE.test(iconInput)) {
+            iconError =
+                "Icon must only contain letters, digits, hyphens, and spaces (e.g. 'fa-solid fa-circle').";
+            return false;
+        }
+        iconError = '';
+        return true;
+    }
+
+    function onSave() {
+        if (!entry) return;
+        if (!validateIcon()) return;
+        brushGraph.setExposedPortMeta(
+            entry.key,
+            labelInput,
+            descriptionInput,
+            iconInput,
+        );
+        open = false;
+    }
+
+    function onCancel() {
+        open = false;
+    }
+</script>
+
+<Modal bind:open size="sm" title="Brush bar entry">
+    {#if entry}
+        <form class="entry-form" onsubmit={(e) => { e.preventDefault(); onSave(); }}>
+            <label class="field">
+                <span class="field-label">Label</span>
+                <input
+                    type="text"
+                    class="text-input"
+                    bind:value={labelInput}
+                    placeholder={entry.portName}
+                />
+            </label>
+            <label class="field">
+                <span class="field-label">Description</span>
+                <textarea
+                    class="text-input description"
+                    bind:value={descriptionInput}
+                    rows="4"
+                    placeholder="Shown as a tooltip to the brush user."
+                ></textarea>
+            </label>
+            <label class="field">
+                <span class="field-label">Icon</span>
+                <input
+                    type="text"
+                    class="text-input"
+                    bind:value={iconInput}
+                    placeholder="fa-solid fa-circle"
+                    oninput={validateIcon}
+                />
+                {#if iconError}
+                    <span class="icon-error">{iconError}</span>
+                {:else if iconInput}
+                    <span class="icon-preview"><i class={iconInput}></i></span>
+                {/if}
+            </label>
+            <footer class="actions">
+                <button type="button" class="btn" onclick={onCancel}>Cancel</button>
+                <button type="submit" class="btn primary">Save</button>
+            </footer>
+        </form>
+    {/if}
+</Modal>
+
+<style>
+    .entry-form {
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+    }
+    .field {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+    .field-label {
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+    }
+    .text-input {
+        width: 100%;
+        padding: 8px 10px;
+        font-size: 13px;
+        background: var(--bg);
+        color: var(--text);
+        border: 1px solid var(--bg-hover);
+        border-radius: 4px;
+        outline: none;
+        font-family: inherit;
+        box-sizing: border-box;
+    }
+    .text-input:focus {
+        border-color: var(--accent);
+    }
+    .text-input.description {
+        resize: vertical;
+        min-height: 78px;
+        line-height: 1.4;
+    }
+    .icon-error {
+        font-size: 11px;
+        color: var(--error, #d44);
+    }
+    .icon-preview {
+        font-size: 18px;
+        color: var(--text);
+    }
+    .actions {
+        display: flex;
+        gap: 8px;
+        justify-content: flex-end;
+        margin-top: 4px;
+    }
+    .btn {
+        padding: 7px 14px;
+        font-size: 13px;
+        background: var(--bg);
+        color: var(--text);
+        border: 1px solid var(--bg-hover);
+        border-radius: 4px;
+        cursor: pointer;
+        font-family: inherit;
+    }
+    .btn:hover {
+        background: var(--bg-hover);
+    }
+    .btn.primary {
+        background: var(--accent);
+        color: var(--bg);
+        border-color: var(--accent);
+    }
+    .btn.primary:hover {
+        filter: brightness(1.08);
+    }
+</style>

--- a/frontend/src/ui/brush_builder/BrushBarNode.svelte
+++ b/frontend/src/ui/brush_builder/BrushBarNode.svelte
@@ -1,0 +1,242 @@
+<script lang="ts">
+    import { getContext } from 'svelte';
+    import { brushGraph, type ExposedPortInfo } from '../../state/brush_graph.svelte';
+    import BrushBarEntryModal from './BrushBarEntryModal.svelte';
+    import type { NodeCanvasContext } from './NodeCanvas.svelte';
+
+    // Position is graph-space — the brush bar lives on the canvas
+    // alongside the other nodes, panning and zooming with them. Default
+    // sits a comfortable margin above and to the left of the origin so
+    // the auto-laid-out brush graph doesn't overlap it on first open.
+    // Component-local: not persisted across reloads.
+    let pos = $state({ x: -360, y: -40 });
+    const { coords } = getContext<NodeCanvasContext>('node-canvas');
+
+    // Drag-move (whole-node) state.
+    let movingNode = false;
+    let moveStart = { px: 0, py: 0, x: 0, y: 0 };
+
+    function startMove(e: PointerEvent) {
+        // Ignore drag-init when the gesture started on an interactive
+        // child (row drag handle, edit button, etc.).
+        const target = e.target as HTMLElement;
+        if (target.closest('.entry-row, button, input, textarea')) return;
+        movingNode = true;
+        moveStart = { px: e.clientX, py: e.clientY, x: pos.x, y: pos.y };
+        (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+        e.preventDefault();
+        e.stopPropagation();
+    }
+    function moveNode(e: PointerEvent) {
+        if (!movingNode) return;
+        // Convert client-px delta to graph-units so the node moves with
+        // the cursor at any zoom level.
+        const d = coords.clientDeltaToGraph(
+            e.clientX - moveStart.px,
+            e.clientY - moveStart.py,
+        );
+        pos = { x: moveStart.x + d.x, y: moveStart.y + d.y };
+    }
+    function endMove(e: PointerEvent) {
+        if (!movingNode) return;
+        movingNode = false;
+        (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+    }
+
+    // Drag-reorder state for rows.
+    let dragKey = $state<string | null>(null);
+    let dropIndicator = $state<{ index: number; pos: 'above' | 'below' } | null>(null);
+
+    function onRowDragStart(e: DragEvent, port: ExposedPortInfo) {
+        dragKey = port.key;
+        if (e.dataTransfer) {
+            e.dataTransfer.effectAllowed = 'move';
+            e.dataTransfer.setData('text/plain', port.key);
+        }
+    }
+    function onRowDragOver(e: DragEvent, idx: number) {
+        if (dragKey === null) return;
+        e.preventDefault();
+        if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+        const ratio = (e.clientY - rect.top) / rect.height;
+        dropIndicator = { index: idx, pos: ratio < 0.5 ? 'above' : 'below' };
+    }
+    function onRowDragLeave() {
+        // Don't reset on leave — the next dragover wins.
+    }
+    function onRowDrop(e: DragEvent) {
+        e.preventDefault();
+        if (dragKey === null || !dropIndicator) {
+            dragKey = null;
+            dropIndicator = null;
+            return;
+        }
+        // Compute the target index: insertion point above/below the
+        // hovered row. Then collapse to a stable index for the engine
+        // call (which moves the entry to that position).
+        let target = dropIndicator.index;
+        if (dropIndicator.pos === 'below') target += 1;
+        // Account for the dragged entry's own removal from earlier in
+        // the list — when we move forward past our origin, the target
+        // shifts back by one.
+        const fromIdx = brushGraph.exposedPorts.findIndex((p) => p.key === dragKey);
+        if (fromIdx >= 0 && fromIdx < target) target -= 1;
+        if (target < 0) target = 0;
+        const last = brushGraph.exposedPorts.length - 1;
+        if (target > last) target = last;
+        if (target !== fromIdx) {
+            brushGraph.reorderExposedPort(dragKey, target);
+        }
+        dragKey = null;
+        dropIndicator = null;
+    }
+    function onRowDragEnd() {
+        dragKey = null;
+        dropIndicator = null;
+    }
+
+    // Edit modal state.
+    let modalOpen = $state(false);
+    let modalEntry = $state<ExposedPortInfo | null>(null);
+    function openEditor(port: ExposedPortInfo) {
+        modalEntry = port;
+        modalOpen = true;
+    }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+    class="brush-bar-node"
+    style="transform: translate({pos.x}px, {pos.y}px);"
+    onpointerdown={startMove}
+    onpointermove={moveNode}
+    onpointerup={endMove}
+    onlostpointercapture={endMove}
+>
+    <header class="header">
+        <i class="fa-solid fa-sliders header-icon"></i>
+        <span class="title">Brush Bar</span>
+    </header>
+    <div class="body">
+        {#if brushGraph.exposedPorts.length === 0}
+            <p class="empty">
+                Click the <i class="fa-solid fa-eye"></i> icon on any port to add it here.
+            </p>
+        {:else}
+            <ul class="rows" ondragend={onRowDragEnd}>
+                {#each brushGraph.exposedPorts as port, idx (port.key)}
+                    <!-- svelte-ignore a11y_click_events_have_key_events -->
+                    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+                    <li
+                        class="entry-row"
+                        class:drag-above={dropIndicator?.index === idx && dropIndicator?.pos === 'above'}
+                        class:drag-below={dropIndicator?.index === idx && dropIndicator?.pos === 'below'}
+                        draggable="true"
+                        ondragstart={(e) => onRowDragStart(e, port)}
+                        ondragover={(e) => onRowDragOver(e, idx)}
+                        ondragleave={onRowDragLeave}
+                        ondrop={onRowDrop}
+                        onclick={() => openEditor(port)}
+                    >
+                        <span class="row-grip" aria-hidden="true">
+                            <i class="fa-solid fa-grip-vertical"></i>
+                        </span>
+                        {#if port.icon}
+                            <span class="row-icon"><i class={port.icon}></i></span>
+                        {/if}
+                        <span class="row-label">{port.label}</span>
+                    </li>
+                {/each}
+            </ul>
+        {/if}
+    </div>
+</div>
+
+<BrushBarEntryModal bind:open={modalOpen} entry={modalEntry} />
+
+<style>
+    .brush-bar-node {
+        position: absolute;
+        top: 0;
+        left: 0;
+        z-index: 6;
+        min-width: 180px;
+        max-width: 260px;
+        background: var(--bg-active);
+        color: var(--text);
+        border: 1px solid var(--bg-hover);
+        border-radius: 6px;
+        box-shadow: 0 6px 18px rgba(0, 0, 0, 0.35);
+        font-size: 11px;
+        user-select: none;
+        cursor: move;
+    }
+    .header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 10px;
+        border-bottom: 1px solid var(--bg-hover);
+        font-size: 12px;
+        font-weight: 600;
+    }
+    .header-icon {
+        color: var(--accent);
+    }
+    .body {
+        padding: 6px;
+        cursor: default;
+    }
+    .empty {
+        margin: 0;
+        padding: 6px 4px;
+        color: var(--text-muted);
+        font-size: 11px;
+        line-height: 1.4;
+    }
+    .rows {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+    }
+    .entry-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 5px 6px;
+        background: color-mix(in srgb, var(--bg) 80%, transparent);
+        border: 1px solid transparent;
+        border-radius: 4px;
+        cursor: grab;
+    }
+    .entry-row:hover {
+        background: color-mix(in srgb, var(--bg-hover) 60%, transparent);
+        border-color: var(--bg-hover);
+    }
+    .entry-row.drag-above {
+        border-top-color: var(--accent);
+    }
+    .entry-row.drag-below {
+        border-bottom-color: var(--accent);
+    }
+    .row-grip {
+        color: var(--text-muted);
+        cursor: grab;
+        font-size: 10px;
+    }
+    .row-icon {
+        color: var(--text-muted);
+        width: 14px;
+        text-align: center;
+    }
+    .row-label {
+        flex: 1;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+</style>

--- a/frontend/src/ui/brush_builder/BrushBarNode.svelte
+++ b/frontend/src/ui/brush_builder/BrushBarNode.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
     import { getContext } from 'svelte';
+    import { flip } from 'svelte/animate';
+    import { cubicOut } from 'svelte/easing';
     import { brushGraph, type ExposedPortInfo } from '../../state/brush_graph.svelte';
     import BrushBarEntryModal from './BrushBarEntryModal.svelte';
     import type { NodeCanvasContext } from './NodeCanvas.svelte';
@@ -43,57 +45,88 @@
         (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
     }
 
-    // Drag-reorder state for rows.
+    // Drag-reorder state. `liveOrder` shadows the engine's port list
+    // during a drag so the rows can shuffle in real time on every
+    // `dragover` — `animate:flip` rides those reactive reorders and
+    // slides the rows past the cursor. On drop we commit the final
+    // index to the engine in one call; on cancel/escape we just drop
+    // the shadow and revert to whatever the engine still says.
     let dragKey = $state<string | null>(null);
-    let dropIndicator = $state<{ index: number; pos: 'above' | 'below' } | null>(null);
+    let liveOrder = $state<ExposedPortInfo[] | null>(null);
+
+    /** Rows the brush bar actually renders — the live drag shadow when
+     *  a drag is in flight, otherwise the engine's order. */
+    let displayPorts = $derived(liveOrder ?? brushGraph.exposedPorts);
 
     function onRowDragStart(e: DragEvent, port: ExposedPortInfo) {
         dragKey = port.key;
+        // Snapshot the current order as a mutable shadow we'll
+        // splice the dragged entry through on every dragover.
+        liveOrder = [...brushGraph.exposedPorts];
         if (e.dataTransfer) {
             e.dataTransfer.effectAllowed = 'move';
             e.dataTransfer.setData('text/plain', port.key);
         }
     }
-    function onRowDragOver(e: DragEvent, idx: number) {
-        if (dragKey === null) return;
+
+    function onRowDragOver(e: DragEvent, hoverIdx: number) {
+        if (dragKey === null || !liveOrder) return;
         e.preventDefault();
+        e.stopPropagation();
         if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+
         const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-        const ratio = (e.clientY - rect.top) / rect.height;
-        dropIndicator = { index: idx, pos: ratio < 0.5 ? 'above' : 'below' };
+        const insertBelow = (e.clientY - rect.top) / rect.height >= 0.5;
+
+        const fromIdx = liveOrder.findIndex((p) => p.key === dragKey);
+        if (fromIdx === -1) return;
+
+        let target = hoverIdx + (insertBelow ? 1 : 0);
+        if (fromIdx < target) target -= 1;
+        target = Math.max(0, Math.min(liveOrder.length - 1, target));
+        if (target === fromIdx) return;
+
+        // Reassign with a fresh array so Svelte's keyed-each diff
+        // notices the reorder and animate:flip can play.
+        const next = liveOrder.slice();
+        const [moved] = next.splice(fromIdx, 1);
+        next.splice(target, 0, moved);
+        liveOrder = next;
     }
+
     function onRowDragLeave() {
-        // Don't reset on leave — the next dragover wins.
+        // No-op — leaving one row to enter another is fine; the next
+        // dragover sets the new target. Leaving the whole list is
+        // handled by dragend.
     }
+
     function onRowDrop(e: DragEvent) {
         e.preventDefault();
-        if (dragKey === null || !dropIndicator) {
-            dragKey = null;
-            dropIndicator = null;
-            return;
-        }
-        // Compute the target index: insertion point above/below the
-        // hovered row. Then collapse to a stable index for the engine
-        // call (which moves the entry to that position).
-        let target = dropIndicator.index;
-        if (dropIndicator.pos === 'below') target += 1;
-        // Account for the dragged entry's own removal from earlier in
-        // the list — when we move forward past our origin, the target
-        // shifts back by one.
-        const fromIdx = brushGraph.exposedPorts.findIndex((p) => p.key === dragKey);
-        if (fromIdx >= 0 && fromIdx < target) target -= 1;
-        if (target < 0) target = 0;
-        const last = brushGraph.exposedPorts.length - 1;
-        if (target > last) target = last;
-        if (target !== fromIdx) {
-            brushGraph.reorderExposedPort(dragKey, target);
-        }
-        dragKey = null;
-        dropIndicator = null;
+        e.stopPropagation();
+        commitDrag();
     }
+
     function onRowDragEnd() {
+        // Drop fired? We've already committed. Drop didn't fire (drag
+        // ended outside any row or via Escape)? Discard the shadow.
+        commitDrag();
+    }
+
+    function commitDrag() {
+        const key = dragKey;
+        const order = liveOrder;
+        if (key !== null && order) {
+            const finalIdx = order.findIndex((p) => p.key === key);
+            const engineIdx = brushGraph.exposedPorts.findIndex((p) => p.key === key);
+            if (finalIdx !== -1 && finalIdx !== engineIdx) {
+                // Sync engine state synchronously; the resulting engine
+                // order will match liveOrder, so clearing the shadow
+                // below doesn't flash the row back to its old slot.
+                brushGraph.reorderExposedPort(key, finalIdx);
+            }
+        }
         dragKey = null;
-        dropIndicator = null;
+        liveOrder = null;
     }
 
     // Edit modal state.
@@ -125,19 +158,16 @@
             </p>
         {:else}
             <ul class="rows" ondragend={onRowDragEnd}>
-                {#each brushGraph.exposedPorts as port, idx (port.key)}
-                    <!-- svelte-ignore a11y_click_events_have_key_events -->
-                    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+                {#each displayPorts as port, idx (port.key)}
                     <li
                         class="entry-row"
-                        class:drag-above={dropIndicator?.index === idx && dropIndicator?.pos === 'above'}
-                        class:drag-below={dropIndicator?.index === idx && dropIndicator?.pos === 'below'}
+                        class:dragging={dragKey === port.key}
+                        animate:flip={{ duration: 100, easing: cubicOut }}
                         draggable="true"
                         ondragstart={(e) => onRowDragStart(e, port)}
                         ondragover={(e) => onRowDragOver(e, idx)}
                         ondragleave={onRowDragLeave}
                         ondrop={onRowDrop}
-                        onclick={() => openEditor(port)}
                     >
                         <span class="row-grip" aria-hidden="true">
                             <i class="fa-solid fa-grip-vertical"></i>
@@ -146,6 +176,14 @@
                             <span class="row-icon"><i class={port.icon}></i></span>
                         {/if}
                         <span class="row-label">{port.label}</span>
+                        <button
+                            class="row-edit"
+                            title="Edit label, description, and icon"
+                            onclick={(e) => { e.stopPropagation(); openEditor(port); }}
+                            ondragstart={(e) => e.preventDefault()}
+                        >
+                            <i class="fa-solid fa-pen"></i>
+                        </button>
                     </li>
                 {/each}
             </ul>
@@ -217,11 +255,9 @@
         background: color-mix(in srgb, var(--bg-hover) 60%, transparent);
         border-color: var(--bg-hover);
     }
-    .entry-row.drag-above {
-        border-top-color: var(--accent);
-    }
-    .entry-row.drag-below {
-        border-bottom-color: var(--accent);
+    .entry-row.dragging {
+        opacity: 0.55;
+        border-color: var(--accent);
     }
     .row-grip {
         color: var(--text-muted);
@@ -238,5 +274,24 @@
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
+    }
+    .row-edit {
+        background: none;
+        border: none;
+        color: var(--text-muted);
+        cursor: pointer;
+        font-size: 10px;
+        padding: 2px 4px;
+        border-radius: 3px;
+        opacity: 0;
+        transition: opacity 0.1s, color 0.1s;
+    }
+    .entry-row:hover .row-edit {
+        opacity: 0.8;
+    }
+    .row-edit:hover {
+        color: var(--text);
+        background: color-mix(in srgb, var(--accent) 18%, transparent);
+        opacity: 1;
     }
 </style>

--- a/frontend/src/ui/brush_builder/BrushBuilder.svelte
+++ b/frontend/src/ui/brush_builder/BrushBuilder.svelte
@@ -122,8 +122,6 @@
         brushGraph.autoLayout(sizes);
     }
 
-    let fullscreen = $state(false);
-
     /** Brush preview visibility. Persisted via the unified config store
      *  (`ui.brushBuilder.previewVisible` — declared as `Hidden` in the Rust
      *  schema so it's stored but not exposed in the Settings modal). */
@@ -197,15 +195,15 @@
     }
 
     function onKeydown(e: KeyboardEvent) {
-        if (e.key === 'Escape' && fullscreen) {
-            fullscreen = false;
+        if (e.key === 'Escape' && brushGraph.fullscreen) {
+            brushGraph.fullscreen = false;
         }
     }
 </script>
 
 <svelte:window on:keydown={onKeydown} />
 
-<div class="brush-builder" class:fullscreen>
+<div class="brush-builder">
     <div class="canvas-wrapper">
         <NodeCanvas onaddrequest={openMenuAtCursor} />
         <div class="preview-dock">
@@ -243,10 +241,10 @@
         </div>
         <button
             class="fullscreen-btn"
-            onclick={() => fullscreen = !fullscreen}
-            title={fullscreen ? "Exit fullscreen" : "Fullscreen"}
+            onclick={() => brushGraph.fullscreen = !brushGraph.fullscreen}
+            title={brushGraph.fullscreen ? "Exit fullscreen" : "Fullscreen"}
         >
-            <i class={fullscreen ? 'fa-solid fa-compress' : 'fa-solid fa-expand'}></i>
+            <i class={brushGraph.fullscreen ? 'fa-solid fa-compress' : 'fa-solid fa-expand'}></i>
         </button>
     </div>
 
@@ -447,13 +445,5 @@
     .fullscreen-btn:hover {
         background: var(--accent);
         color: var(--text);
-    }
-    .brush-builder.fullscreen {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100vw;
-        height: 100vh;
-        z-index: 9999;
     }
 </style>

--- a/frontend/src/ui/brush_builder/NodeCanvas.svelte
+++ b/frontend/src/ui/brush_builder/NodeCanvas.svelte
@@ -5,6 +5,7 @@
     import { isModEvent } from '../../actions/mods';
     import NodeWidget from './NodeWidget.svelte';
     import WireRenderer from './WireRenderer.svelte';
+    import BrushBarNode from './BrushBarNode.svelte';
     import { createGraphCoords, type GraphCoords } from './coords';
 
     interface Props {
@@ -368,6 +369,10 @@
         {#each brushGraph.nodeList as node (node.id)}
             <NodeWidget {node} />
         {/each}
+        <!-- Brush Bar lives in graph-space alongside the nodes — pans
+             and zooms with them; the author drags it around like any
+             other node. -->
+        <BrushBarNode />
     </div>
 </div>
 

--- a/frontend/src/ui/brush_builder/NodePalette.svelte
+++ b/frontend/src/ui/brush_builder/NodePalette.svelte
@@ -39,7 +39,7 @@
                         <button
                             class="node-type-btn"
                             onclick={() => { onaddnode(nt.type_id); isOpen = false; }}
-                            title={nt.type_id}
+                            title={nt.description || nt.display_name}
                         >
                             {nt.display_name}
                         </button>

--- a/frontend/src/ui/brush_builder/PortWidget.svelte
+++ b/frontend/src/ui/brush_builder/PortWidget.svelte
@@ -169,14 +169,19 @@
     }
 
     /** Whether this port can be exposed in the brush bar. */
-    const EXPOSABLE_TYPES = new Set(['Scalar']);
+    const EXPOSABLE_TYPES = new Set(['Scalar', 'Bool']);
     let canExpose = $derived(
         port.dir === 'Input' && !connected && EXPOSABLE_TYPES.has(port.wire_type)
     );
+    let isExposed = $derived(brushGraph.isPortExposed(nodeId, port.name));
 
     function toggleExposed(e: MouseEvent) {
         e.stopPropagation();
-        brushGraph.togglePortExposed(nodeId, port.name, !port.exposed);
+        if (isExposed) {
+            brushGraph.unexposePort(nodeId, port.name);
+        } else {
+            brushGraph.exposePort(nodeId, port.name);
+        }
     }
 
     let sliderPercent = $derived(
@@ -244,7 +249,7 @@
 <div
     class="port-row"
     class:port-right={side === 'right'}
-    title={regPort?.description || port.description || ''}
+    title={regPort?.description || ''}
 >
     <div
         class="port-dot"
@@ -291,13 +296,13 @@
             </div>
         {/if}
     {:else}
-        <span class="port-label">{port.name}</span>
+        <span class="port-label">{regPort?.label || port.name}</span>
     {/if}
     {#if canExpose}
         <button
             class="expose-toggle"
-            class:exposed={port.exposed}
-            title={port.exposed ? 'Hide from brush bar' : 'Expose in brush bar'}
+            class:exposed={isExposed}
+            title={isExposed ? 'Hide from brush bar' : 'Expose in brush bar'}
             onclick={toggleExposed}
         >
             <i class="fa-solid fa-eye"></i>

--- a/frontend/src/ui/settings/widgets/BoolToggle.svelte
+++ b/frontend/src/ui/settings/widgets/BoolToggle.svelte
@@ -13,8 +13,17 @@
         display: inline-flex;
         align-items: center;
         cursor: pointer;
+        /* Contain the hidden checkbox. Without a positioned ancestor here,
+         * `position: absolute` escapes all the way up to the modal's
+         * `position: fixed` dialog, pinning the checkbox at a viewport
+         * position that ignores the settings list's scroll offset. Clicking
+         * a toggle you had to scroll to then focuses an off-screen checkbox,
+         * and the browser scrolls it into view — yanking the modal contents
+         * up by the scroll distance. Anchoring it to the visible toggle
+         * makes the focus scroll-into-view a no-op. */
+        position: relative;
     }
-    input { position: absolute; opacity: 0; pointer-events: none; }
+    input { position: absolute; top: 0; left: 0; opacity: 0; pointer-events: none; }
     .track {
         width: 36px;
         height: 20px;

--- a/frontend/wasm/src/api.rs
+++ b/frontend/wasm/src/api.rs
@@ -1998,18 +1998,47 @@ impl DarklyHandle {
         ))
     }
 
-    pub fn brush_graph_set_port_exposed(
+    pub fn brush_graph_expose_port(&self, node_id: u32, port_name: &str) -> JsValue {
+        self.flush_if_needed();
+        graph_result(
+            self.engine
+                .borrow_mut()
+                .brush_graph_expose_port(node_id as u64, port_name),
+        )
+    }
+
+    pub fn brush_graph_unexpose_port(&self, node_id: u32, port_name: &str) -> JsValue {
+        self.flush_if_needed();
+        graph_result(
+            self.engine
+                .borrow_mut()
+                .brush_graph_unexpose_port(node_id as u64, port_name),
+        )
+    }
+
+    pub fn brush_graph_set_exposed_port_meta(
         &self,
-        node_id: u32,
-        port_name: &str,
-        exposed: bool,
+        key: &str,
+        label: &str,
+        description: &str,
+        icon: &str,
     ) -> JsValue {
         self.flush_if_needed();
-        graph_result(self.engine.borrow_mut().brush_graph_set_port_exposed(
-            node_id as u64,
-            port_name,
-            exposed,
+        graph_result(self.engine.borrow_mut().brush_graph_set_exposed_port_meta(
+            key,
+            label.to_string(),
+            description.to_string(),
+            icon.to_string(),
         ))
+    }
+
+    pub fn brush_graph_reorder_exposed_port(&self, key: &str, new_index: u32) -> JsValue {
+        self.flush_if_needed();
+        graph_result(
+            self.engine
+                .borrow_mut()
+                .brush_graph_reorder_exposed_port(key, new_index),
+        )
     }
 
     pub fn brush_list(&self) -> String {

--- a/frontend/wasm/src/api.rs
+++ b/frontend/wasm/src/api.rs
@@ -2215,20 +2215,18 @@ fn js_f32_quad(obj: &JsValue, key: &str) -> Option<[f32; 4]> {
     ])
 }
 
-/// Serialize `engine.brush_cursor_preview_info()` as a JS `{ halfExtent, rotation }`
+/// Serialize `engine.brush_cursor_preview_info()` as a JS `{ halfExtent }`
 /// POJO, or `null` when the active graph has no preview source.
 fn brush_cursor_preview_info_as_js(engine: &DarklyEngine) -> JsValue {
     #[derive(serde::Serialize)]
     struct Info {
         #[serde(rename = "halfExtent")]
         half_extent: [f32; 2],
-        rotation: f32,
     }
     match engine.brush_cursor_preview_info() {
         Some(info) => {
             let payload = Info {
                 half_extent: info.half_extent_canvas_px,
-                rotation: info.rotation_rad,
             };
             serde_wasm_bindgen::to_value(&payload).unwrap_or(JsValue::NULL)
         }

--- a/shaders/brush/_shape.wgsl
+++ b/shaders/brush/_shape.wgsl
@@ -1,19 +1,18 @@
 // Procedural `r(θ)` shape prelude — shared by compute-path brushes that
-// stamp the same family of polar-radius silhouettes the `circle` fragment
+// stamp the same family of polar-radius silhouettes the `shape` fragment
 // node produces.
 //
 // Functions here are parameterised on a `ShapeParams` struct so the same
 // math can be reused by multiple terminals without a tight coupling to a
-// shader-global `u` (the way `shaders/brush/circle.wgsl` does it). The
-// terminal that includes this prelude is responsible for building a
-// `ShapeParams` for each dab (typically from its own dab record).
+// shader-global `u`. The terminal that includes this prelude is
+// responsible for building a `ShapeParams` for each dab (typically from
+// its own dab record).
 //
-// **Bit-exact parity with `crates/darkly/src/brush/nodes/circle.rs`** is
+// **Bit-exact parity with `crates/darkly/src/brush/nodes/shape.rs`** is
 // load-bearing — the CPU-side `integrate_centroid` walks the same `r(θ)`
-// at a finer resolution, and the centroid alignment test in
-// `tests/circle_node.rs` catches drift as a per-pixel mismatch. Keep the
-// `hash1d` / `fbm_1d` / `r_sine` / `r_perlin` / `r_superformula` formulas
-// here byte-equivalent to `circle.wgsl` and `circle.rs`.
+// at a finer resolution, and per-pixel render tests catch drift as a
+// mismatch. Keep the `hash1d` / `fbm_1d` / `r_sine` / `r_perlin` /
+// `r_superformula` formulas here byte-equivalent to `shape.rs`.
 //
 // Include via `concat!()` at the consumer site:
 //
@@ -30,14 +29,14 @@
 // inlines its own copy. Coverage *math* is per-terminal; *radius* math is
 // shared.
 //
-// Credits — same as `circle.wgsl`:
+// Credits:
 //   - Gielis superformula: Johan Gielis, AJB 90(3), 2003.
 //   - 1D value-noise / fBm fundamentals: Ken Perlin; Inigo Quilez
 //     (https://iquilezles.org/articles/morenoise/).
 
 struct ShapeParams {
     /// 0 = sine harmonic, 1 = periodic 1D Perlin fBm, 2 = Gielis
-    /// superformula. Matches `ALGO_*` constants in `nodes/circle.rs`.
+    /// superformula. Matches `ALGO_*` constants in `nodes/shape.rs`.
     algorithm: u32,
     /// Modulation strength on top of the unit-radius reference disc.
     amplitude: f32,
@@ -47,7 +46,7 @@ struct ShapeParams {
     /// Subtracted from `θ` so positive values rotate clockwise in
     /// screen-y-down space, matching `pen.drawing_angle`'s
     /// `atan2(dy, dx)` convention — wiring drawing_angle into the
-    /// circle node's rotation port orients the shape along the stroke.
+    /// shape node's rotation port orients the silhouette along the stroke.
     rotation: f32,
     /// Perlin fBm amplitude falloff per octave.
     persistence: f32,
@@ -63,8 +62,8 @@ struct ShapeParams {
 
 const SHAPE_TAU: f32 = 6.28318530717958647692;
 
-/// Integer bit-mix hash — bit-identical to `hash1d` in `circle.rs` and
-/// `circle.wgsl`. We avoid `fract(sin(x*K)*M)` because `sin` precision
+/// Integer bit-mix hash — bit-identical to `hash1d` in `shape.rs`.
+/// We avoid `fract(sin(x*K)*M)` because `sin` precision
 /// differs between CPU and GPU and the `*43758` amplification turns
 /// sub-ULP drift into a totally different noise array — which the
 /// centroid alignment test would flag.
@@ -80,7 +79,7 @@ fn shape_hash1d(x: f32, seed: f32) -> f32 {
     return f32(h) / 4294967295.0;
 }
 
-/// Periodic 1D value-noise fBm — mirrors `fbm_1d` in `circle.rs`.
+/// Periodic 1D value-noise fBm — mirrors `fbm_1d` in `shape.rs`.
 fn shape_fbm_1d(t: f32, p: ShapeParams) -> f32 {
     var sum: f32 = 0.0;
     var norm: f32 = 0.0;
@@ -132,7 +131,7 @@ fn shape_r_superformula(p: ShapeParams, theta: f32) -> f32 {
 
 /// Polar radius `r(θ)` in the shape's natural units (unmodulated disc has
 /// `r = 1`). Branches on `p.algorithm`. Same dispatch table as
-/// `circle.rs::r_theta` and `circle.wgsl::r_theta`.
+/// `shape.rs::r_theta`.
 fn shape_r_theta(p: ShapeParams, theta: f32) -> f32 {
     let phased = theta - p.rotation;
     switch p.algorithm {


### PR DESCRIPTION
## Summary

Adds two coordinated brush-builder features:

1. **Switch node** — a static-controlled 2-way mux that sits inline on any wire. Wire only `in_0_X` and it's a gate (downstream falls back to its own port default when toggled off); wire both sides and it's a real switch. The boolean `select` is an input port (exposable to the brush user as a toggle in BrushOptions), not a `ParamDef`.

2. **Brush Bar node + centralized exposed-port state** — the brush builder canvas grows a draggable "Brush Bar" node that lists every exposed port in display order. Drag rows to reorder them; click a row to open a themed modal with **single-line Label**, **multiline Description textarea**, and **Icon** field. Per-instance label/description/icon overrides moved off `PortDef` and into a single ordered `Graph::exposed_ports` dict, keyed `"<node_id>.<port>"` — insertion order is the brush-bar order.

Pre-release format break (no migration shim, per CLAUDE.md). All built-in brush YAML files updated to the new top-level `exposed_ports:` shape.

## What's in this branch

### Switch node

- [crates/darkly/src/brush/nodes/switch.rs](crates/darkly/src/brush/nodes/switch.rs) — `type_id = "switch"`, five `(in_0_X, in_1_X, out_X)` triplets per `BrushWireType`, plus a Bool `select` input port (default 0).
- Pre-compile graph rewrite `apply_to`: for every switch whose `select` is *unconnected*, splices the chosen upstream through to all downstreams of `out_X` and removes the switch. If the chosen input has no upstream, the wire is dropped and downstream falls back to its own declared default. Switches with `select` dynamically wired are left in place; the WGSL compile rejects them with a clear error in v1.
- Threaded into [crates/darkly/src/brush/mod.rs](crates/darkly/src/brush/mod.rs)'s `compile_graph` and `validate_graph_json` on a throwaway graph clone, so the persisted graph still carries the switch through save/load and undo.

### Centralized exposed-port state

- [crates/darkly/src/nodegraph/graph.rs](crates/darkly/src/nodegraph/graph.rs) — `Graph::exposed_ports: IndexMap<String, ExposedPortMeta>` (using `indexmap` for round-trip-safe insertion order). New methods `expose_port`, `unexpose_port`, `is_port_exposed`, `set_exposed_port_meta`, `reorder_exposed_port`. `add_node` auto-seeds entries from every registration-`.exposed()` input port; `remove_node` drops every entry referencing the removed node. New `GraphError` variants `ExposedPortNotFound` and `InvalidIcon`. Removed the prior `set_port_exposed` / `set_port_label` / `set_port_description` per-instance setters.
- [crates/darkly/src/engine/brush_graph.rs](crates/darkly/src/engine/brush_graph.rs) — `brush_exposed_ports` rewritten to iterate the dict in order; each `ExposedPortInfo` carries `key` so the frontend addresses entries by it. Engine surface: `brush_graph_expose_port`, `brush_graph_unexpose_port`, `brush_graph_set_exposed_port_meta`, `brush_graph_reorder_exposed_port`. `ExposedValue::Bool` variant added so Bool ports (like Switch's `select`) can drive a toggle in BrushOptions.
- [crates/darkly/src/brush/portable.rs](crates/darkly/src/brush/portable.rs) — `PortableBrush.exposed_ports` carries the dict at the top level; `PortableNode.exposed` field removed. Round-trip preserves order and per-entry meta.
- [crates/darkly/src/brush/mod.rs](crates/darkly/src/brush/mod.rs) — `reset_exposed_scrubs` still consults the registration's `.exposed()` flag (the canonical "user-tunable" hint), so author-added exposures stay at brush-author-configured defaults in dab thumbnails.
- All 9 built-in YAML brushes migrated to the new top-level `exposed_ports:` map.

### XSS hardening on icons

- Engine: `Graph::set_exposed_port_meta` rejects icon strings outside `[a-zA-Z0-9- ]` (the FontAwesome-class alphabet); returns `GraphError::InvalidIcon`.
- Frontend: same regex mirrors in `BrushBarEntryModal` for inline validation; icons render exclusively as `<i class={port.icon}></i>` (Svelte attribute escaping), never via `{@html …}` or `innerHTML`.

### WASM bridge

- [frontend/wasm/src/api.rs](frontend/wasm/src/api.rs) — `brush_graph_expose_port`, `brush_graph_unexpose_port`, `brush_graph_set_exposed_port_meta`, `brush_graph_reorder_exposed_port`.

### Frontend

- [frontend/src/state/brush_graph.svelte.ts](frontend/src/state/brush_graph.svelte.ts) — `exposePort`, `unexposePort`, `isPortExposed`, `setExposedPortMeta`, `reorderExposedPort`; `ExposedPortInfo` and `ExposedValue` gain `key` / Bool variants.
- [frontend/src/ui/brush_builder/BrushBarNode.svelte](frontend/src/ui/brush_builder/BrushBarNode.svelte) (new) — renders inside the graph's pan/zoom layer, lives at graph-space `(-360, -40)` by default, drag-to-move with `clientDeltaToGraph` for zoom-aware tracking. Rows are HTML5-draggable (modeled on `LayerItem.svelte`'s pattern); empty-state hint when no entries exist.
- [frontend/src/ui/brush_builder/BrushBarEntryModal.svelte](frontend/src/ui/brush_builder/BrushBarEntryModal.svelte) (new) — wraps `Modal.svelte` size `sm`. Label input + `<textarea rows="4">` description + icon input with live `<i class={icon}>` preview and inline regex validation.
- [frontend/src/ui/brush_builder/NodeCanvas.svelte](frontend/src/ui/brush_builder/NodeCanvas.svelte) — `<BrushBarNode />` rendered inside `.node-layer`.
- [frontend/src/ui/brush_builder/PortWidget.svelte](frontend/src/ui/brush_builder/PortWidget.svelte) — eye toggle now drives `exposePort`/`unexposePort` against the new dict and reads `isPortExposed`; `EXPOSABLE_TYPES` includes `Bool`.
- [frontend/src/ui/BrushOptions.svelte](frontend/src/ui/BrushOptions.svelte) — renders `ExposedValue::Bool` as a `Scrub mode="toggle"` modeled on the existing Erase toggle.

### Housekeeping (from earlier commits on the branch)

- [README.md](README.md), [frontend/index.html](frontend/index.html) updates.
- [.github/dependabot.yml](.github/dependabot.yml) and [.github/workflows/ci.yml](.github/workflows/ci.yml) — dependabot target-branch fix.

## Tests

- **`graph.rs`**: `expose_then_unexpose_round_trips`, `expose_port_rejects_output_port`, `add_node_seeds_exposed_from_registration_flag`, `remove_node_drops_exposed_entries`, `reorder_moves_entry_to_target_index`, `set_meta_rejects_unsafe_icon` (XSS regression), `exposed_ports_round_trip_preserves_order`.
- **`switch.rs`**: `enabled_default_splices_through`, `disabled_drops_wire_so_downstream_uses_default`, `mux_mode_routes_chosen_input_and_drops_unchosen`, `dynamic_select_leaves_switch_in_place`.
- **`portable.rs`**: `port_overrides_survive` updated to assert per-entry meta (label / description / icon) survives YAML round trip.
- **`brush_picker_backend.rs`**: `size_scrub_does_not_change_active_dab_pixels` updated to use `brush_graph_unexpose_port` for the topology-version assertion.

Full lint pipeline green: fmt / clippy native / clippy wasm / cargo test --workspace (375 lib + integration) / wasm-pack release / tsc --noEmit / vite build / vitest (129).

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `RUSTFLAGS="-D warnings" cargo clippy --workspace --all-targets --exclude darkly-wasm --features darkly/testing -- -D warnings`
- [ ] `RUSTFLAGS="-D warnings" cargo clippy -p darkly-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings`
- [ ] `cargo test --workspace --exclude darkly-wasm --features darkly/testing -- --test-threads=1`
- [ ] `(cd frontend/wasm && wasm-pack build --release --target web --out-dir pkg)`
- [ ] `(cd frontend && npx tsc --noEmit && npm run build && npm test)`
- [ ] Manual — Brush Bar:
  - Open brush builder. Confirm the Brush Bar node sits in the canvas to the left of the auto-laid-out graph; pan/zoom moves it together with the other nodes.
  - Drag it to a new position; toggle the builder closed/open — position resets to default (intentional v1 behavior).
  - Click the eye on `paint.size` — new entry appears at the end. Reorder it by dragging within the Brush Bar.
  - Click an entry → modal opens. Set Label="Brush Size", Description="Diameter of the brush in pixels", Icon="fa-solid fa-circle". Save. BrushOptions reflects the new label, icon, and tooltip in display order.
  - Save the brush, reload — entries, meta, and order round-trip.
- [ ] Manual — Switch:
  - Drop a Switch between `paint_color` and `stamp.color`, wiring only `in_0_vec4`. Expose `select`. Confirm BrushOptions shows a Bool toggle.
  - Toggle off → stamp uses its declared default color. Toggle on → the wired color flows through.
  - Wire a second color into `in_1_vec4` (mux mode) — toggling swaps between the two.
- [ ] XSS sanity: in the icon field type `<script>x` — inline validation surfaces an error and Save is a no-op; engine would have rejected anyway.

## Known limitations

- Toggling a Switch's `select` at paint time doesn't add/remove other exposed scrubs.
- Vec4 / Vec2 / Int exposable widgets aren't built yet; entries for those types render no widget.
- Dynamic `Switch.select` wiring is rejected at compile.
- Brush Bar node position is session-local (resets to default on reload).
