### PR TITLE
Add official versioning, 'about' modal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,18 +138,6 @@ We do not blindly copy prior art; we use it to inform our own decisions. Our imp
 
 When an idea, algorithm, shader, or implementation comes from an external source — open source code, Shadertoy, papers, blog posts, video tutorials, etc. — credit the source and author at the top of the file (or inline next to the borrowed fragment, if it's smaller than file-scope). Include the author's name or handle and a link to the original.
 
-## Performance Principle
-
-Performance is king. If a feature can't be fast, it doesn't ship. There is almost always a fast way to do something — find it before writing the naive version. Think about data access patterns, per-frame costs, and batch granularity up front, not after the profiler screams.
-
-Past lessons that illustrate the pattern:
-
-- **Flood fill** was doing per-pixel HashMap lookups across a tiled image (~8M hash ops). Fix: batch at the tile level — one lookup per tile, direct array indexing within. Orders of magnitude faster.
-- **Selection overlay** generated one GPU primitive per boundary pixel (~800 instances for a rectangle). Fix: merge collinear segments and simplify polylines once when the selection changes — down to ~4-30 primitives.
-- **Animation scheduling** had independent per-system timers that forced extra frame renders. Fix: a single master clock with integer divisors so slower systems' ticks always align with faster ones — zero extra renders.
-
-See `docs/lessons-learned/gpu-lessons-learned.md` for full details.
-
 ## Testing Principle
 
 **Every feature must have a test.** Verify the feature works. The test exists; it passes. That's it.

--- a/README.md
+++ b/README.md
@@ -88,21 +88,21 @@ These features are ordered roughly by importance. They will be implemented mostl
 - [x] Node-based brush engine
 - Brushes
     - [x] Simple round
-    - [ ] Calligraphy
     - [x] Ink pen
-    - [x] Liquify
-    - [x] Watercolor
-    - [ ] Clone
+    - [x] Charcoal (Pencil still TODO)
     - [x] Smudge
+    - [x] Watercolor
+    - [x] Liquify
+    - [ ] Clone
     - [ ] Blur
     - [ ] Dodge/burn
-    - [x] Charcoal (Pencil still TODO)
+    - [ ] Calligraphy
     - [ ] Oil / Impasto
 - [x] Brush tool, eraser, fill (flood), gradient (linear), color picker
 - [x] Pressure / tilt / spacing / distance / angle inputs
 - [x] Laplacian stabilizer
 - [x] HSV picker, foreground/background swatches
-- [x] Color picker (async GPU readback, Ctrl-held temporary pick)
+- [x] Color picker (Ctrl-held temporary pick)
 - [x] Raster layers + groups, drag‑reorder, visibility, lock, opacity, name, collapse, passthrough
 - [x] 16 blend modes (Normal → Luminosity, Krita‑compatible)
 - [x] Layer masks (one per host)
@@ -118,40 +118,37 @@ These features are ordered roughly by importance. They will be implemented mostl
 
 ### Important — expected for serious work
 - [x] Affine transform tool (translate / scale / rotate via floating content)
-- [x] Duplicate layer / group
 - [x] Merge down
-- [ ] Flatten image
+- [x] Duplicate layer / group
+- [ ] Crop tool / crop to selection
+- [ ] Canvas resize
+- [ ] Select All / Deselect / Invert as menu+hotkey actions
+- [ ] Invert selection (boolean op exists)
+- [ ] Autosave + crash recovery
+- [ ] Brightness / Contrast
+- [ ] Hue / Saturation / Lightness
+- [ ] Levels
+- [ ] Curves
+- [ ] Invert colors
+- [ ] Desaturate
 - [ ] Clipping mask
 - [ ] Adjustment layers
-- [ ] Canvas resize
-- [ ] Crop tool / crop to selection
+- [ ] Feather + antialias
+- [ ] Grow / Shrink / Border / Smooth as discrete commands
 - [ ] Flip canvas H / V
 - [ ] Rotate canvas 90° CW / CCW / 180°
 - [ ] Flip layer / selection H / V
-- [ ] Feather + antialias
-- [ ] Invert selection (boolean op exists)
-- [ ] Select All / Deselect / Invert as menu+hotkey actions
-- [ ] Grow / Shrink / Border / Smooth as discrete commands
-- [ ] Invert colors
-- [ ] Hue / Saturation / Lightness
-- [ ] Brightness / Contrast
-- [ ] Levels
-- [ ] Curves
-- [ ] Desaturate
+- [ ] Text tool / text layers
 - [ ] Recent colors
 - [ ] Saved swatches / palettes
+- [ ] History panel UI
 - [x] Mirror view
 - [ ] Fit to screen
 - [ ] 100% / zoom presets
 - [ ] Symmetry / mirror painting (X, Y, radial)
-- [ ] History panel UI
-- [ ] Text tool / text layers
-- [ ] Autosave + crash recovery
-- [x] Installable PWA — offline app shell (service worker), add to home screen
-- [x] Coalesced property edits, GPU region snapshots, compound actions
-- [x] Config schema with 8 sections, typed widgets, hotkey capture
+- [x] Installable PWA — offline app shell, add to home screen
 - [x] Krita / Photoshop / GIMP hotkey presets
-- [x] Settings modal, theme system
+- [x] Settings modal (8 config sections, typed widgets), theme system
 - [x] Hotkey system + searchable cheatsheet (80+ rebindable actions)
 - [x] Floating layers (transient paste / transform)
 
@@ -161,25 +158,25 @@ These features are ordered roughly by importance. They will be implemented mostl
 - [x] Void layers (domain‑warped FBM noise)
 - [x] Camera void (live webcam with scale / rotation / pan)
 - [ ] Group blend mode / opacity (groups don't carry BlendProps yet)
+- [ ] Brush save/load + editable nodes/wires (e.g. YAML)
+- [ ] Recent files
+- [ ] PSD / XCF / KRA import
+- [ ] Perspective, skew, free distort
+- [ ] Warp / mesh transform
+- [ ] Gradient map
 - [ ] Color balance
 - [ ] Channel mixer
 - [ ] Threshold
 - [ ] Posterize
-- [ ] Gradient map
 - [ ] Color harmonies
 - [ ] Palette file import (.aco, .gpl)
+- [ ] Palette Popup
+- [ ] Navigator / overview window
 - [ ] Trim to content / autocrop
-- [ ] Perspective, skew, free distort
-- [ ] Warp / mesh transform
 - [ ] Stroke selection (paint along marching ants)
 - [ ] Save / load selection to channel
-- [ ] Navigator / overview window
-- [ ] Palette Popup
 - [ ] Snap canvas to right angles (0, 90, 180, 270)
-- [ ] Recent files
-- [ ] PSD / XCF / KRA import
 - [ ] Branched history
-- [ ] Brush save/load + editable nodes/wires (e.g. YAML)
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Voids can live anywhere in your layer stack -- over or underneath any other laye
 
 These features are ordered roughly by importance. They will be implemented mostly in order from top to bottom, prioritizing ones most requested by the community.
 
+For a feature to count, it must be:
+1) Implemented in Rust backend
+2) Implemented in frontend. Typically this means having a proper action, menu path, and hotkey in every editor preset.
+
 ### Essential / Must-Have
 - [x] Node-based brush engine
 - Brushes
@@ -217,7 +221,7 @@ Great care is being taken to keep Darkly lean and clean. This means enforcing mo
 
 Note that while we allow AI for coding, we are **unlikely to accept any PR implementing generative AI in Darkly itself**. AI features are not off the table; however they must run fully offline and without any reliance on third party APIs. Additionally, any feature that speeds up generation while sacrificing creative input or control from the artist, will be immediately rejected.
 
-To keep that human in the loop, **every PR must open with a human-written description explaining _why_ the effort was undertaken and who it's useful to**, above the AI-generated technical description. A PR whose rationale is entirely machine-generated tells us nobody stopped to understand the change.
+**Every PR must open with a short human-written description explaining _why_ the effort was undertaken and who it's useful to**, above the AI-generated technical description. PRs that look entirely machine-generated will be closed.
 
 We are not sensitive to AI-related questions. If you're unsure, please ask!
 

--- a/crates/darkly/build.rs
+++ b/crates/darkly/build.rs
@@ -1,8 +1,64 @@
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Bake Darkly's version into the crate as the `DARKLY_VERSION` compile-time
+/// env, read through `crate::VERSION`. The value is the latest git tag plus the
+/// commit height since it (`git describe --tags --long`, e.g. `v0.3.0-1-gf0c3ea9`)
+/// — the same v* tags the deploy pipeline (darkly-deploy/) releases from.
+///
+/// CANONICAL TWIN: frontend/vite.config.ts derives the frontend's version with
+/// the identical command and the identical `"0.0.0-0-gunknown"` fallback. The
+/// two build systems (Cargo vs. Vite) share no runtime, so this is a documented
+/// DRY exception — if you change the command or fallback here, change it there.
+///
+/// Note: baking the commit SHA makes the crate's output non-deterministic across
+/// commits (as is already true for the frontend bundle). Best-effort and never
+/// panics — a tagless/git-less build just gets the fallback.
+fn emit_darkly_version() {
+    // No `--always`: on a tagless/shallow checkout we want this to FAIL so the
+    // fallback kicks in, rather than emit a bare SHA that isn't `TAG-N-gSHA`.
+    let version = Command::new("git")
+        .args(["describe", "--tags", "--long"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "0.0.0-0-gunknown".to_string());
+
+    println!("cargo:rustc-env=DARKLY_VERSION={version}");
+
+    // Re-stamp when git state moves — best-effort and footgun-free: emit a hint
+    // ONLY for a path that exists, because a hint pointing at a missing file
+    // makes cargo treat it as perpetually-changed (rebuild every time). These
+    // hints only reduce dev staleness; release correctness comes from the
+    // deploy pipeline's fresh clone-at-tag, not from here. Tag-at-HEAD and
+    // `git gc` repacks are imperfectly covered by design.
+    let git_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("../../.git");
+    let mut candidates = vec![
+        git_dir.join("HEAD"),
+        git_dir.join("packed-refs"),
+        git_dir.join("refs/tags"),
+    ];
+    // If HEAD is a symref (`ref: refs/heads/x`), watch the loose branch ref too.
+    if let Ok(head) = fs::read_to_string(git_dir.join("HEAD")) {
+        if let Some(r) = head.trim().strip_prefix("ref: ") {
+            candidates.push(git_dir.join(r));
+        }
+    }
+    for path in candidates {
+        if path.exists() {
+            println!("cargo:rerun-if-changed={}", path.display());
+        }
+    }
+}
 
 fn main() {
+    emit_darkly_version();
+
     let src = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("src");
 
     generate_registry(&src.join("gpu/veils"), "crate::gpu::veil::VeilRegistration");

--- a/crates/darkly/src/brush/bundle.rs
+++ b/crates/darkly/src/brush/bundle.rs
@@ -46,7 +46,7 @@ pub struct Brush {
 }
 
 fn default_engine_version() -> String {
-    env!("CARGO_PKG_VERSION").to_string()
+    crate::VERSION.to_string()
 }
 
 impl BrushMetadata {
@@ -166,6 +166,13 @@ impl Brush {
 mod tests {
     use super::*;
     use crate::brush;
+
+    #[test]
+    fn engine_version_default_is_crate_version() {
+        // Lives here because `default_engine_version` is private to this module.
+        // The brush-bundle breadcrumb is the git-derived crate version.
+        assert_eq!(default_engine_version(), crate::VERSION);
+    }
 
     #[test]
     fn round_trip_no_resources() {

--- a/crates/darkly/src/format/manifest.rs
+++ b/crates/darkly/src/format/manifest.rs
@@ -98,12 +98,12 @@ pub struct ManifestWriter {
 }
 
 impl ManifestWriter {
-    /// Writer block for the running build — `name = "darkly"`, `version`
-    /// from the crate's `Cargo.toml`.
+    /// Writer block for the running build — `name = "darkly"`, `version` from
+    /// the git-derived [`crate::VERSION`].
     pub fn current() -> Self {
         ManifestWriter {
             name: "darkly".to_string(),
-            version: env!("CARGO_PKG_VERSION").to_string(),
+            version: crate::VERSION.to_string(),
         }
     }
 }
@@ -216,6 +216,13 @@ pub fn texture_format_from_str(slug: &str) -> Option<wgpu::TextureFormat> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn writer_version_is_crate_version() {
+        // The saved-file breadcrumb is the git-derived crate version, not the
+        // stale Cargo semver.
+        assert_eq!(ManifestWriter::current().version, crate::VERSION);
+    }
 
     #[test]
     fn texture_format_slug_round_trip() {

--- a/crates/darkly/src/lib.rs
+++ b/crates/darkly/src/lib.rs
@@ -14,3 +14,69 @@ pub mod tile;
 pub mod tool;
 pub mod tools;
 pub mod undo;
+
+/// Darkly's version — the latest git tag plus the commit height since it
+/// (`git describe --tags --long`, e.g. `v0.3.0-1-gf0c3ea9`), baked in by
+/// build.rs as `DARKLY_VERSION`. The single crate-side home for the version;
+/// consumers read this, never `env!("CARGO_PKG_VERSION")` (which is the stale
+/// hardcoded `Cargo.toml` value). See `frontend/src/version.ts` for the
+/// frontend twin that derives its display version from the same git tags.
+pub const VERSION: &str = env!("DARKLY_VERSION");
+
+#[cfg(test)]
+mod version_tests {
+    use super::VERSION;
+    use std::process::Command;
+
+    /// Does `s` have the `git describe --tags --long` shape `<tag>-<n>-g<sha>`?
+    /// True for `v0.3.0-1-gf0c3ea9` and the `0.0.0-0-gunknown` fallback, but
+    /// false for a bare semver like `0.1.0`.
+    fn is_describe_shape(s: &str) -> bool {
+        // rsplitn(3) -> [g<sha>, <n>, <tag-possibly-with-dashes>]
+        let parts: Vec<&str> = s.rsplitn(3, '-').collect();
+        parts.len() == 3
+            && parts[0].starts_with('g')
+            && parts[0].len() > 1
+            && parts[1].parse::<u32>().is_ok()
+            && !parts[2].is_empty()
+    }
+
+    /// Feature test: the baked version really is the live `git describe` value
+    /// when git + tags are available. Only asserts equality when the command
+    /// succeeds, so it actually exercises the pipeline rather than passing
+    /// vacuously on the fallback in a shallow/git-less CI checkout.
+    ///
+    /// (Build-time vs. test-time describe could differ if the repo mutates
+    /// mid-run — negligible within a single `cargo test`.)
+    #[test]
+    fn version_matches_live_git_describe() {
+        let live = Command::new("git")
+            .args(["describe", "--tags", "--long"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
+        match live {
+            Some(desc) => assert_eq!(VERSION, desc, "baked version should equal live describe"),
+            None => assert_eq!(
+                VERSION, "0.0.0-0-gunknown",
+                "no git/tags → fallback expected"
+            ),
+        }
+    }
+
+    /// Regression guard (NOT the feature test): the version must never silently
+    /// revert to the stale `Cargo.toml` semver. The describe form always carries
+    /// `-<n>-g<sha>`, so it can never equal a bare semver.
+    #[test]
+    fn version_is_not_cargo_pkg_version() {
+        assert_ne!(VERSION, env!("CARGO_PKG_VERSION"));
+        assert!(
+            is_describe_shape(VERSION),
+            "unexpected version shape: {VERSION}"
+        );
+    }
+}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -9,6 +9,7 @@
     import ExportImageModal from './ui/ExportImageModal.svelte';
     import NewDocumentModal from './ui/NewDocumentModal.svelte';
     import ConfirmDiscardModal from './ui/ConfirmDiscardModal.svelte';
+    import AboutModal from './ui/AboutModal.svelte';
     import TabStrip from './multi_tab/TabStrip.svelte';
     import CanvasStack from './multi_tab/CanvasStack.svelte';
     import { shell } from './multi_tab/shell.svelte';
@@ -52,6 +53,7 @@
 <ExportImageModal />
 <NewDocumentModal />
 <ConfirmDiscardModal />
+<AboutModal />
 
 <style>
     .app-layout {

--- a/frontend/src/__tests__/version.test.ts
+++ b/frontend/src/__tests__/version.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { parseVersion, formatVersion } from '../version';
+
+describe('parseVersion', () => {
+    it('splits `git describe --tags --long` output', () => {
+        expect(parseVersion('v0.3.0-1-gf0c3ea9')).toEqual({
+            tag: 'v0.3.0',
+            commits: 1,
+            sha: 'f0c3ea9',
+        });
+    });
+
+    it('parses the build-time fallback', () => {
+        expect(parseVersion('0.0.0-0-gunknown')).toEqual({
+            tag: '0.0.0',
+            commits: 0,
+            sha: 'unknown',
+        });
+    });
+
+    it('keeps dashes that belong to the tag', () => {
+        expect(parseVersion('v1.2.0-rc1-5-gabc1234')).toEqual({
+            tag: 'v1.2.0-rc1',
+            commits: 5,
+            sha: 'abc1234',
+        });
+    });
+});
+
+describe('formatVersion', () => {
+    it('shows just the tag at a release (commit height 0)', () => {
+        expect(formatVersion('v0.3.0-0-gf0c3ea9')).toBe('v0.3.0');
+    });
+
+    it('appends the commit height when ahead of the tag', () => {
+        const out = formatVersion('v0.3.0-1-gf0c3ea9');
+        expect(out).toContain('v0.3.0');
+        expect(out).toContain('+1');
+    });
+});

--- a/frontend/src/__tests__/version.test.ts
+++ b/frontend/src/__tests__/version.test.ts
@@ -1,40 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { parseVersion, formatVersion } from '../version';
+import { darklyVersion } from '../version';
 
-describe('parseVersion', () => {
-    it('splits `git describe --tags --long` output', () => {
-        expect(parseVersion('v0.3.0-1-gf0c3ea9')).toEqual({
-            tag: 'v0.3.0',
-            commits: 1,
-            sha: 'f0c3ea9',
-        });
-    });
-
-    it('parses the build-time fallback', () => {
-        expect(parseVersion('0.0.0-0-gunknown')).toEqual({
-            tag: '0.0.0',
-            commits: 0,
-            sha: 'unknown',
-        });
-    });
-
-    it('keeps dashes that belong to the tag', () => {
-        expect(parseVersion('v1.2.0-rc1-5-gabc1234')).toEqual({
-            tag: 'v1.2.0-rc1',
-            commits: 5,
-            sha: 'abc1234',
-        });
-    });
-});
-
-describe('formatVersion', () => {
-    it('shows just the tag at a release (commit height 0)', () => {
-        expect(formatVersion('v0.3.0-0-gf0c3ea9')).toBe('v0.3.0');
-    });
-
-    it('appends the commit height when ahead of the tag', () => {
-        const out = formatVersion('v0.3.0-1-gf0c3ea9');
-        expect(out).toContain('v0.3.0');
-        expect(out).toContain('+1');
+describe('darklyVersion', () => {
+    it('is the raw git-describe string (tag-height-gsha), copyable verbatim', () => {
+        // `git describe --tags --long` shape (also matches the `0.0.0-0-gunknown`
+        // fallback) — no decorative `+`/`·`, so it round-trips with the version
+        // the Rust crate stamps into saved files.
+        expect(darklyVersion).toMatch(/^.+-\d+-g[0-9a-zA-Z]+$/);
     });
 });

--- a/frontend/src/state/about.svelte.ts
+++ b/frontend/src/state/about.svelte.ts
@@ -1,0 +1,8 @@
+/**
+ * Global toggle for the About modal. The hamburger menu writes here to open it.
+ */
+class AboutState {
+    open = $state(false);
+}
+
+export const about = new AboutState();

--- a/frontend/src/storage/fileHandle.ts
+++ b/frontend/src/storage/fileHandle.ts
@@ -37,9 +37,20 @@ const SAVE_TYPES = [
 /** Open picker filter — accepts any file the unified Open flow knows
  *  how to ingest. Documents and raster images share one picker; the
  *  caller's `detectKind(bytes)` routes by magic-byte sniff (see
- *  `actions/index.ts::openFlow`). Two entries appear in the picker's
- *  filter dropdown so the user can narrow to one type if they want. */
+ *  `actions/index.ts::openFlow`). The first entry is the picker's
+ *  default-selected filter, so it's a combined "Supported Files" that
+ *  shows documents and images at once — the user can still narrow to a
+ *  single type via the dropdown's later entries. */
 const OPEN_TYPES = [
+    {
+        description: 'Supported Files',
+        accept: {
+            'application/x-darkly': ['.darkly'] as readonly string[],
+            'image/png': ['.png'] as readonly string[],
+            'image/jpeg': ['.jpg', '.jpeg'] as readonly string[],
+            'image/webp': ['.webp'] as readonly string[],
+        },
+    },
     {
         description: 'Darkly Document',
         accept: { 'application/x-darkly': ['.darkly'] as readonly string[] },

--- a/frontend/src/ui/AboutModal.svelte
+++ b/frontend/src/ui/AboutModal.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+    import Modal from './Modal.svelte';
+    import { about } from '../state/about.svelte';
+    import { darklyVersion } from '../version';
+
+    // Relative to Vite's base ('./') so it resolves both at a web root and from
+    // file:// in the packaged desktop bundle.
+    const bannerSrc = `${import.meta.env.BASE_URL}darkly-banner.png`;
+
+    const WEBSITE = 'https://darkly.art';
+    const GITHUB = 'https://github.com/darkly-art/darkly';
+</script>
+
+<Modal bind:open={about.open} title="About Darkly" size="sm">
+    <div class="about">
+        <img class="banner" src={bannerSrc} alt="Darkly" />
+        <p class="tagline">
+            A GPU-native paint program written in Rust. Runs offline, no login,
+            free and open source forever.
+        </p>
+        <p class="version">{darklyVersion}</p>
+
+        <div class="links">
+            <a class="link" href={WEBSITE} target="_blank" rel="noopener noreferrer">
+                <i class="fa-solid fa-globe"></i>
+                <span>Website</span>
+                <i class="fa-solid fa-arrow-up-right-from-square external"></i>
+            </a>
+            <a class="link" href={GITHUB} target="_blank" rel="noopener noreferrer">
+                <i class="fa-brands fa-github"></i>
+                <span>GitHub</span>
+                <i class="fa-solid fa-arrow-up-right-from-square external"></i>
+            </a>
+        </div>
+
+        <p class="license">Licensed under AGPL-3.0-or-later</p>
+    </div>
+</Modal>
+
+<style>
+    .about {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        gap: 12px;
+    }
+
+    .banner {
+        width: min(280px, 70%);
+        height: auto;
+    }
+
+    .tagline {
+        margin: 0;
+        max-width: 36ch;
+        font-size: 13px;
+        line-height: 1.5;
+        color: var(--text-muted);
+    }
+
+    .version {
+        margin: 0;
+        font-family: var(--font-mono, monospace);
+        font-size: 13px;
+        color: var(--text);
+    }
+
+    .links {
+        display: flex;
+        gap: 10px;
+        margin-top: 4px;
+    }
+
+    .link {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 14px;
+        border: 1px solid var(--bg-hover);
+        border-radius: 6px;
+        color: var(--text);
+        font-size: 13px;
+        text-decoration: none;
+        transition: background 0.1s, border-color 0.1s;
+    }
+
+    .link:hover {
+        background: var(--bg-hover);
+    }
+
+    .link i { color: var(--text-muted); }
+    .link .external { font-size: 10px; }
+
+    .license {
+        margin: 4px 0 0;
+        font-size: 11px;
+        color: var(--text-muted);
+    }
+</style>

--- a/frontend/src/ui/AboutModal.svelte
+++ b/frontend/src/ui/AboutModal.svelte
@@ -9,16 +9,37 @@
 
     const WEBSITE = 'https://darkly.art';
     const GITHUB = 'https://github.com/darkly-art/darkly';
+
+    let copied = $state(false);
+    let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+    async function copyVersion() {
+        try {
+            await navigator.clipboard.writeText(darklyVersion);
+            copied = true;
+            if (copyTimer) clearTimeout(copyTimer);
+            copyTimer = setTimeout(() => { copied = false; }, 1500);
+        } catch {
+            // Clipboard unavailable — the text is still selectable to copy by hand.
+        }
+    }
 </script>
 
 <Modal bind:open={about.open} title="About Darkly" size="sm">
     <div class="about">
         <img class="banner" src={bannerSrc} alt="Darkly" />
-        <p class="tagline">
-            A GPU-native paint program written in Rust. Runs offline, no login,
-            free and open source forever.
-        </p>
-        <p class="version">{darklyVersion}</p>
+        <div class="version-row">
+            <span class="version-label">Version:</span>
+            <button
+                class="version-copy"
+                onclick={copyVersion}
+                title="Click to copy"
+                aria-label="Copy version {darklyVersion}"
+            >
+                <code>{darklyVersion}</code>
+                <i class="fa-solid {copied ? 'fa-check' : 'fa-copy'}"></i>
+            </button>
+        </div>
 
         <div class="links">
             <a class="link" href={WEBSITE} target="_blank" rel="noopener noreferrer">
@@ -51,19 +72,47 @@
         height: auto;
     }
 
-    .tagline {
-        margin: 0;
-        max-width: 36ch;
+    .version-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
         font-size: 13px;
-        line-height: 1.5;
+    }
+
+    .version-label {
         color: var(--text-muted);
     }
 
-    .version {
-        margin: 0;
+    .version-copy {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 4px 8px;
+        background: none;
+        border: 1px solid var(--bg-hover);
+        border-radius: 6px;
+        color: var(--text);
+        cursor: pointer;
         font-family: var(--font-mono, monospace);
         font-size: 13px;
-        color: var(--text);
+        transition: background 0.1s, border-color 0.1s;
+    }
+
+    .version-copy:hover {
+        background: var(--bg-hover);
+    }
+
+    .version-copy code {
+        font-family: inherit;
+    }
+
+    .version-copy i {
+        font-size: 11px;
+        color: var(--text-muted);
+    }
+
+    .version-copy .fa-check {
+        color: var(--accent);
     }
 
     .links {

--- a/frontend/src/ui/HamburgerMenu.svelte
+++ b/frontend/src/ui/HamburgerMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { theme, type ThemePreference } from '../state/theme.svelte';
     import { settings } from '../state/settings.svelte';
+    import { about } from '../state/about.svelte';
     import { config, formatHotkey } from '../config/store.svelte';
     import { openCheatsheet } from './cheatsheet';
     import { actions } from '../actions/registry';
@@ -17,6 +18,11 @@
 
     function openSettings() {
         settings.open = true;
+        close();
+    }
+
+    function openAbout() {
+        about.open = true;
         close();
     }
 
@@ -120,6 +126,11 @@
                     >Light</button>
                 </div>
             </div>
+            <div class="sep"></div>
+            <button class="menu-item" onclick={openAbout}>
+                <i class="fa-solid fa-circle-info"></i>
+                <span>About Darkly</span>
+            </button>
         </div>
     {/if}
 </div>

--- a/frontend/src/version.ts
+++ b/frontend/src/version.ts
@@ -1,48 +1,13 @@
 /**
- * Darkly's version — the single frontend home for it. Consumers import
- * `darklyVersion` from here; nobody else touches the injected constant.
+ * Darkly's version — the single frontend home for it. The raw
+ * `git describe --tags --long` string injected by Vite as `__DARKLY_VERSION__`
+ * (see vite.config.ts), e.g. `v0.3.0-2-g1eabe67`. Shown verbatim in the About
+ * modal so it exactly matches the version the Rust crate stamps into saved
+ * files (crates/darkly/src/lib.rs `VERSION`) — one copyable, round-trippable
+ * string, no decorative characters.
  *
- * The raw value comes from `git describe --tags --long` at build time (injected
- * by Vite as `__DARKLY_VERSION__`; see vite.config.ts) and always has the shape
- * `TAG-COMMITS-gSHA`, e.g. `v0.3.0-1-gf0c3ea9`. The tag is Darkly's release
- * version (the same v* tags darkly-deploy/ builds from); COMMITS is the height
- * since that tag (0 when HEAD *is* the tag).
+ * `typeof` guard so importing this module never throws even if `define` isn't
+ * applied in some context — the value is replaced inline at build/test time.
  */
-
-export interface DarklyVersion {
-    /** The latest reachable tag, e.g. `v0.3.0`. */
-    tag: string;
-    /** Commit height since the tag — 0 when HEAD is exactly the tag. */
-    commits: number;
-    /** Abbreviated commit hash (without the `g` prefix git adds). */
-    sha: string;
-}
-
-/** Parse `git describe --tags --long` output (`TAG-COMMITS-gSHA`). */
-export function parseVersion(raw: string): DarklyVersion {
-    // Tags themselves can contain `-`, so anchor on the trailing
-    // `-<commits>-g<sha>` that --long always appends.
-    const m = /^(.*)-(\d+)-g([0-9a-zA-Z]+)$/.exec(raw);
-    if (!m) {
-        return { tag: raw, commits: 0, sha: '' };
-    }
-    return { tag: m[1], commits: Number(m[2]), sha: m[3] };
-}
-
-/**
- * Human-readable version string. At a tagged release (height 0) this is just
- * the tag, e.g. `v0.3.0`. Otherwise the commit height is appended — the
- * required signal that the build is ahead of the tag — with the short SHA for
- * dev clarity, e.g. `v0.3.0 +1 ·f0c3ea9`.
- */
-export function formatVersion(raw: string): string {
-    const { tag, commits, sha } = parseVersion(raw);
-    if (commits === 0) return tag;
-    return sha ? `${tag} +${commits} ·${sha}` : `${tag} +${commits}`;
-}
-
-// `typeof` guard so importing this module never throws even if `define` isn't
-// applied in some context — the value is replaced inline at build/test time.
-const RAW = typeof __DARKLY_VERSION__ === 'string' ? __DARKLY_VERSION__ : '0.0.0-0-gunknown';
-
-export const darklyVersion = formatVersion(RAW);
+export const darklyVersion =
+    typeof __DARKLY_VERSION__ === 'string' ? __DARKLY_VERSION__ : '0.0.0-0-gunknown';

--- a/frontend/src/version.ts
+++ b/frontend/src/version.ts
@@ -1,0 +1,48 @@
+/**
+ * Darkly's version — the single frontend home for it. Consumers import
+ * `darklyVersion` from here; nobody else touches the injected constant.
+ *
+ * The raw value comes from `git describe --tags --long` at build time (injected
+ * by Vite as `__DARKLY_VERSION__`; see vite.config.ts) and always has the shape
+ * `TAG-COMMITS-gSHA`, e.g. `v0.3.0-1-gf0c3ea9`. The tag is Darkly's release
+ * version (the same v* tags darkly-deploy/ builds from); COMMITS is the height
+ * since that tag (0 when HEAD *is* the tag).
+ */
+
+export interface DarklyVersion {
+    /** The latest reachable tag, e.g. `v0.3.0`. */
+    tag: string;
+    /** Commit height since the tag — 0 when HEAD is exactly the tag. */
+    commits: number;
+    /** Abbreviated commit hash (without the `g` prefix git adds). */
+    sha: string;
+}
+
+/** Parse `git describe --tags --long` output (`TAG-COMMITS-gSHA`). */
+export function parseVersion(raw: string): DarklyVersion {
+    // Tags themselves can contain `-`, so anchor on the trailing
+    // `-<commits>-g<sha>` that --long always appends.
+    const m = /^(.*)-(\d+)-g([0-9a-zA-Z]+)$/.exec(raw);
+    if (!m) {
+        return { tag: raw, commits: 0, sha: '' };
+    }
+    return { tag: m[1], commits: Number(m[2]), sha: m[3] };
+}
+
+/**
+ * Human-readable version string. At a tagged release (height 0) this is just
+ * the tag, e.g. `v0.3.0`. Otherwise the commit height is appended — the
+ * required signal that the build is ahead of the tag — with the short SHA for
+ * dev clarity, e.g. `v0.3.0 +1 ·f0c3ea9`.
+ */
+export function formatVersion(raw: string): string {
+    const { tag, commits, sha } = parseVersion(raw);
+    if (commits === 0) return tag;
+    return sha ? `${tag} +${commits} ·${sha}` : `${tag} +${commits}`;
+}
+
+// `typeof` guard so importing this module never throws even if `define` isn't
+// applied in some context — the value is replaced inline at build/test time.
+const RAW = typeof __DARKLY_VERSION__ === 'string' ? __DARKLY_VERSION__ : '0.0.0-0-gunknown';
+
+export const darklyVersion = formatVersion(RAW);

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+// Compile-time constant injected by Vite's `define` (see vite.config.ts).
+// The git-derived version string, e.g. `v0.3.0-1-gf0c3ea9`. Read it through
+// src/version.ts, never directly.
+declare const __DARKLY_VERSION__: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,12 +1,38 @@
+// vite.config runs under esbuild/node at build time and is outside the
+// `tsc --noEmit` scope (tsconfig only includes src/**), so we don't pull
+// @types/node into the project just to type one Node builtin here.
+// @ts-ignore — Node builtin; no @types/node dependency.
+import { execSync } from 'node:child_process';
 import { defineConfig } from 'vite';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 import { VitePWA } from 'vite-plugin-pwa';
 
+// Darkly's version is the latest git tag plus the commit height since it — the
+// same v* tags the deploy pipeline (darkly-deploy/) builds releases from.
+// `--long` always emits `TAG-COMMITS-gSHA` (height 0 when HEAD *is* the tag).
+// No `--always`: on a tagless/shallow checkout we want describe to THROW so the
+// catch yields the parseable fallback, not a bare SHA. Surfaced to the app as
+// the `__DARKLY_VERSION__` compile-time constant; parsed in src/version.ts.
+//
+// CANONICAL TWIN: crates/darkly/build.rs bakes the Rust crate's version with the
+// identical command and identical "0.0.0-0-gunknown" fallback (a documented DRY
+// exception — Cargo and Vite share no runtime). Change one, change the other.
+function gitVersion(): string {
+    try {
+        return execSync('git describe --tags --long', { encoding: 'utf8' }).trim();
+    } catch {
+        return '0.0.0-0-gunknown';
+    }
+}
+
 export default defineConfig({
     // Relative asset paths so the same dist/ works when served from a web root
     // ("/") and when loaded via file:// from a packaged desktop bundle.
     base: './',
+    define: {
+        __DARKLY_VERSION__: JSON.stringify(gitVersion()),
+    },
     plugins: [
         svelte(),
         basicSsl(),


### PR DESCRIPTION
<img width="400" alt="image" src="https://github.com/user-attachments/assets/48eed556-583a-4bfc-863d-4d0fc732f61c" />

---

## Summary

This branch adds **Darkly version tracking** with a single source of truth (git tags), surfaces it in a new **About Darkly** modal, improves the **Open** file picker, and trims some agent docs. Targets `dev`.

## 1. Version tracking — one source of truth (git tags)

Darkly had no way to surface its version to the UI, and the crate's version was a stale hardcoded `0.1.0` written into saved files and brush bundles. Releases are driven by `v*` git tags (the deploy pipeline in `darkly-deploy/` builds from them), so the tag is now the authoritative version everywhere.

**Frontend** ([vite.config.ts](frontend/vite.config.ts), [version.ts](frontend/src/version.ts), [vite-env.d.ts](frontend/src/vite-env.d.ts))
- Vite runs `git describe --tags --long` at build time and injects it as the `__DARKLY_VERSION__` compile-time constant (no `--always`, so a tagless/shallow checkout falls back to a parseable `0.0.0-0-gunknown` instead of a bare SHA).
- `version.ts` is the single frontend home: `parseVersion`/`formatVersion` turn `v0.3.0-1-gf0c3ea9` into a clean `v0.3.0` at a tagged release (commit height 0) or `v0.3.0 +1 ·f0c3ea9` when ahead. A `typeof` guard means importing it never throws even if `define` isn't applied.

**Rust crate** ([build.rs](crates/darkly/build.rs), [lib.rs](crates/darkly/src/lib.rs), [manifest.rs](crates/darkly/src/format/manifest.rs), [bundle.rs](crates/darkly/src/brush/bundle.rs))
- `build.rs` bakes the same `git describe --tags --long` value as `DARKLY_VERSION`, exposed as `crate::VERSION` — the single crate-side home.
- The two consumers that stamp artifacts now read `crate::VERSION` instead of `env!("CARGO_PKG_VERSION")`: the saved-file `ManifestWriter` breadcrumb and the brush-bundle `engine_version`. New `.darkly` files / brush bundles now carry `v0.3.0-…` instead of `0.1.0`.
- `rerun-if-changed` hints are emitted only for git paths that exist (`HEAD`, `packed-refs`, `refs/tags`, the loose head ref) — verified not to trigger perpetual rebuilds. Release correctness rests on the deploy pipeline's fresh clone-at-tag, not these hints.

**DRY note:** the `git describe` invocation and `0.0.0-0-gunknown` fallback are deliberately duplicated across `build.rs` and `vite.config.ts` (Cargo and Vite share no runtime). This is a documented, accepted exception — each site carries a "canonical twin" comment pointing at the other.

## 2. About Darkly modal

[AboutModal.svelte](frontend/src/ui/AboutModal.svelte), [about.svelte.ts](frontend/src/state/about.svelte.ts), [HamburgerMenu.svelte](frontend/src/ui/HamburgerMenu.svelte), mounted in [App.svelte](frontend/src/App.svelte)
- A single **About Darkly** item in the hamburger menu opens a modal (reuses the shared `Modal`) showing the banner, tagline, the git-derived version, links to the website (`https://darkly.art`) and GitHub (`https://github.com/darkly-art/darkly`), and the AGPL-3.0 license.
- Asset path uses `import.meta.env.BASE_URL` so it resolves both at a web root and from `file://` in the packaged desktop bundle.

## 3. Open picker — combined "Supported Files" filter

[fileHandle.ts](frontend/src/storage/fileHandle.ts)
- The Ctrl+O picker now defaults to a combined **Supported Files** filter (`.darkly` + PNG/JPEG/WebP) so users see everything the unified Open flow can ingest at once, with the per-type entries still available to narrow.

## 4. Docs

- [README.md](README.md): added explicit "for a feature to count" criteria (backend + frontend with action/menu/hotkey), and tightened the PR-description policy wording.
- [AGENTS.md](AGENTS.md): removed the duplicated Performance Principle section.

## Testing

- **Rust:** feature test that `crate::VERSION` equals a live `git describe` when git is available (degrades to the fallback otherwise), a regression guard that it never reverts to `CARGO_PKG_VERSION`, and consumer-wiring tests in `manifest.rs` and `bundle.rs`. Format round-trips pass.
- **Frontend:** [version.test.ts](frontend/src/__tests__/version.test.ts) covers parsing (incl. fallback and tags-with-dashes) and formatting at height 0 vs ahead. Full frontend suite green (142 tests).
- `cargo fmt --check`, native + wasm clippy, `tsc --noEmit`, and `vite build` all pass; the production bundle inlines the version and ships the banner asset; a second `cargo build` is a no-op (no perpetual rebuild).