### PR TITLE
Image rescale

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,8 @@ For a feature to count, it must be:
 - [x] Merge down
 - [x] Duplicate layer / group
 - [x] Crop to selection
-- [ ] Interactive crop tool
-- [x] Canvas resize (dimensions + 9-point anchor)
-- [ ] Canvas resize with content scaling
+- [x] Canvas resize
+- [x] Image rescale
 - [x] Select All / Deselect / Invert as menu+hotkey actions
 - [x] Invert selection (boolean op exists)
 - [x] Command palette (Ctrl+Shift+P)

--- a/crates/darkly/src/document/mod.rs
+++ b/crates/darkly/src/document/mod.rs
@@ -209,6 +209,31 @@ impl Document {
         self.entities.get_mut(id).and_then(Entity::as_modifier_mut)
     }
 
+    /// Canvas-space pixel bounds of any pixel-bearing node — a raster layer or
+    /// a mask/selection modifier. `None` for nodes that have no pixels (groups,
+    /// void layers) or unknown ids. Lets callers treat "things with pixels"
+    /// uniformly without branching on layer vs modifier or on layer kind.
+    pub fn node_pixel_bounds(&self, id: LayerId) -> Option<CanvasRect> {
+        if let Some(b) = self.find_node(id).and_then(|n| n.pixels()) {
+            return Some(b.bounds);
+        }
+        self.find_modifier(id)
+            .and_then(|m| m.pixels())
+            .map(|b| b.bounds)
+    }
+
+    /// Set the canvas-space pixel bounds of a raster layer or modifier. No-op
+    /// for nodes without pixels or unknown ids. Pairs with
+    /// [`node_pixel_bounds`](Self::node_pixel_bounds); used by image rescale to
+    /// keep the document's extents in step with the resampled GPU textures.
+    pub fn set_node_pixel_bounds(&mut self, id: LayerId, bounds: CanvasRect) {
+        if let Some(b) = self.find_node_mut(id).and_then(|n| n.pixels_mut()) {
+            b.bounds = bounds;
+        } else if let Some(b) = self.find_modifier_mut(id).and_then(|m| m.pixels_mut()) {
+            b.bounds = bounds;
+        }
+    }
+
     /// Find the host node a modifier is attached to (the layer or group that
     /// owns it on its `modifiers` list).
     pub fn find_modifier_host(&self, modifier_id: LayerId) -> Option<&LayerNode> {

--- a/crates/darkly/src/engine/image_rescale.rs
+++ b/crates/darkly/src/engine/image_rescale.rs
@@ -1,0 +1,137 @@
+//! Image rescale (Photoshop "Image Size").
+//!
+//! Unlike [`canvas_resize`](super::canvas_resize), which only moves the canvas
+//! window, this **resamples every pixel-bearing node** (raster layers + mask
+//! modifiers) to new document dimensions, scaling content about the canvas
+//! origin. It is lossy and undoable: each node's pre-rescale pixels are
+//! snapshotted, and the dims + per-node extents ride one [`ImageRescaleAction`]
+//! (which also folds in the selection clear). The GPU resampling lives in
+//! `Compositor::rescale_nodes`; the undo restore-across-extent-change lives in
+//! `apply_undo` (`engine/rendering.rs`).
+
+use super::canvas_resize::MAX_CANVAS_DIM;
+use super::rendering::commit_undo_region;
+use super::DarklyEngine;
+use crate::coord::CanvasRect;
+use crate::gpu::compositor::scaled_extent_about;
+use crate::gpu::region_store::UndoRegionEntry;
+use crate::layer::LayerId;
+use crate::undo::ImageRescaleAction;
+
+impl DarklyEngine {
+    /// Resample all layer + mask pixels to `(new_width, new_height)`, scaling
+    /// content about the canvas origin (which stays fixed). Lossy + undoable.
+    /// No-ops on a zero/over-limit target, a no-op size, or if any node would
+    /// exceed the max texture dimension after scaling. Clears the active
+    /// selection (folded into the same undo step).
+    pub fn rescale_image(&mut self, new_width: u32, new_height: u32) {
+        self.auto_commit_floating();
+        let (old_w, old_h) = (self.doc.width, self.doc.height);
+        if new_width == 0
+            || new_height == 0
+            || new_width > MAX_CANVAS_DIM
+            || new_height > MAX_CANVAS_DIM
+            || (new_width, new_height) == (old_w, old_h)
+        {
+            return;
+        }
+        let sx = new_width as f32 / old_w as f32;
+        let sy = new_height as f32 / old_h as f32;
+        let origin = self.doc.canvas_origin;
+
+        // Enumerate pixel-bearing nodes by capability: raster layers + mask
+        // modifiers. Void layers answer `pixels() == None` and are skipped
+        // (they regenerate to fill the new canvas).
+        let mut candidate_ids: Vec<LayerId> = Vec::new();
+        for l in self.doc.all_content_layers() {
+            if l.pixels().is_some() {
+                candidate_ids.push(l.id());
+            }
+        }
+        for m in self.doc.all_modifiers() {
+            if m.pixels().is_some() {
+                candidate_ids.push(m.id);
+            }
+        }
+        // Keep only nodes that own a GPU texture in the unified pool. The
+        // selection modifier's pixels live in the compositor's selection_state
+        // (window-sized), not node_textures — it's cleared separately below.
+        let mut nodes: Vec<(LayerId, CanvasRect, wgpu::TextureFormat)> = Vec::new();
+        for id in candidate_ids {
+            if let Some(t) = self.compositor.node_texture(id) {
+                nodes.push((id, t.canvas_extent(), t.format()));
+            }
+        }
+
+        // Refuse if any node would exceed the max texture dimension once scaled.
+        for (_, old_extent, _) in &nodes {
+            let ne = scaled_extent_about(*old_extent, origin, sx, sy);
+            if ne.width > MAX_CANVAS_DIM || ne.height > MAX_CANVAS_DIM {
+                return;
+            }
+        }
+
+        // 1. Snapshot each node's current pixels (old direction) for undo.
+        let mut regions: Vec<UndoRegionEntry> = Vec::with_capacity(nodes.len());
+        for (id, old_extent, format) in &nodes {
+            let frame = self
+                .compositor
+                .node_texture(*id)
+                .expect("node texture present")
+                .canvas_frame();
+            let snap = self.gpu.encode_ret("rescale-save", |enc| {
+                self.region_scratch
+                    .save_region(&self.gpu.device, enc, &frame, *format, *old_extent)
+            });
+            let entry = commit_undo_region(
+                &self.gpu,
+                &self.region_scratch,
+                &mut self.readbacks,
+                "rescale-commit",
+                *id,
+                &frame,
+                &snap,
+                *old_extent,
+            );
+            regions.push(entry);
+        }
+
+        // 2. Clear the active selection while dims are still old (the selection
+        //    texture is window-sized) — folded into this single undo step.
+        let selection = self.clear_selection_collecting_undo();
+
+        // 3. Resample all node textures on the GPU.
+        let ids: Vec<LayerId> = nodes.iter().map(|(id, _, _)| *id).collect();
+        self.gpu.encode("rescale-nodes", |enc| {
+            self.compositor
+                .rescale_nodes(&self.gpu.device, &self.gpu.queue, enc, &ids, sx, sy);
+        });
+
+        // 4. Mirror the resampled extents into the document + record bounds.
+        let mut bounds: Vec<(LayerId, CanvasRect, CanvasRect)> = Vec::with_capacity(nodes.len());
+        for (id, old_extent, _) in &nodes {
+            let new_extent = self
+                .compositor
+                .node_texture(*id)
+                .map(|t| t.canvas_extent())
+                .unwrap_or(*old_extent);
+            self.doc.set_node_pixel_bounds(*id, new_extent);
+            bounds.push((*id, *old_extent, new_extent));
+        }
+
+        // 5. Update canvas dimensions (origin fixed) + push the undo step.
+        self.doc.width = new_width;
+        self.doc.height = new_height;
+        self.push_undo(Box::new(ImageRescaleAction::new(
+            (old_w, old_h),
+            (new_width, new_height),
+            bounds,
+            regions,
+            selection,
+        )));
+
+        // 6. Reconcile window-sized GPU resources + present view to new dims.
+        self.apply_canvas_rect_to_compositor();
+        self.compositor.mark_dirty();
+    }
+}

--- a/crates/darkly/src/engine/mod.rs
+++ b/crates/darkly/src/engine/mod.rs
@@ -7,6 +7,7 @@ mod duplicate;
 mod export;
 mod flatten;
 mod floating;
+mod image_rescale;
 mod layers;
 mod load;
 mod merge;
@@ -717,6 +718,37 @@ impl DarklyEngine {
             .find_modifier(id)
             .and_then(|m| m.pixels())
             .map(|p| p.bounds)
+    }
+
+    /// Test-only: whether the undo / redo stacks have anything to apply.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn test_can_undo(&self) -> bool {
+        self.undo_stack.can_undo()
+    }
+
+    #[cfg(any(test, feature = "testing"))]
+    pub fn test_can_redo(&self) -> bool {
+        self.undo_stack.can_redo()
+    }
+
+    /// Test-only: a pixel-bearing node's document-side `PixelBuffer.bounds`
+    /// (raster layer or mask modifier). Used to assert extents scale on rescale.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn test_node_pixel_bounds(&self, id: LayerId) -> Option<crate::coord::CanvasRect> {
+        self.doc.node_pixel_bounds(id)
+    }
+
+    /// Test-only: the mask modifier id attached to `host_id`, if any (the first
+    /// non-selection pixel-bearing modifier on the host).
+    #[cfg(any(test, feature = "testing"))]
+    pub fn test_mask_id(&self, host_id: LayerId) -> Option<LayerId> {
+        let node = self.doc.find_node(host_id)?;
+        node.modifiers().iter().copied().find(|&mid| {
+            self.doc
+                .find_modifier(mid)
+                .map(|m| m.as_selection().is_none() && m.pixels().is_some())
+                .unwrap_or(false)
+        })
     }
 
     /// Number of GPU textures the compositor currently holds across the

--- a/crates/darkly/src/engine/modifiers/selection.rs
+++ b/crates/darkly/src/engine/modifiers/selection.rs
@@ -336,8 +336,22 @@ impl DarklyEngine {
     }
 
     pub fn clear_selection(&mut self) {
+        if let Some((was_active, entry)) = self.clear_selection_collecting_undo() {
+            self.push_undo(Box::new(SelectionAction::new(was_active, entry)));
+        }
+    }
+
+    /// Clear the active selection and return its undo data `(was_active,
+    /// entry)` **without** pushing an undo step — the caller records it. The
+    /// public [`clear_selection`](Self::clear_selection) wraps it in a
+    /// `SelectionAction`; image rescale folds the pair into its single undo
+    /// step (so a rescale-with-active-selection undoes in one operation).
+    /// Returns `None` when there is no active selection.
+    pub(crate) fn clear_selection_collecting_undo(
+        &mut self,
+    ) -> Option<(bool, crate::gpu::region_store::UndoRegionEntry)> {
         if !self.has_selection() {
-            return;
+            return None;
         }
         let rect = self
             .selection_pixel_bounds()
@@ -354,9 +368,10 @@ impl DarklyEngine {
         self.set_selection_active(false);
         self.invalidate_selection_cpu_cache();
 
-        self.commit_selection_undo(was_active, rect);
+        let entry = self.commit_selection_undo_entry(rect)?;
         self.selection_overlay.clear();
         self.push_merged_overlay();
+        Some((was_active, entry))
     }
 
     pub fn select_all(&mut self) {
@@ -578,22 +593,32 @@ impl DarklyEngine {
     }
 
     pub(crate) fn commit_selection_undo(&mut self, was_active: bool, rect: CanvasRect) {
+        if let Some(entry) = self.commit_selection_undo_entry(rect) {
+            self.push_undo(Box::new(SelectionAction::new(was_active, entry)));
+        }
+    }
+
+    /// Build the selection's GPU undo entry from the pending snapshot (paired
+    /// with a prior [`save_selection_for_undo`](Self::save_selection_for_undo))
+    /// without pushing an action. Returns `None` if the snapshot or selection
+    /// modifier is missing.
+    fn commit_selection_undo_entry(
+        &mut self,
+        rect: CanvasRect,
+    ) -> Option<crate::gpu::region_store::UndoRegionEntry> {
         let Some(snap) = self.pending_selection_snapshot.take() else {
             debug_assert!(false, "commit_selection_undo without a paired save");
-            return;
+            return None;
         };
         let modifier_id = match self.selection_modifier_id() {
             Some(id) => id,
             None => {
                 debug_assert!(false, "commit_selection_undo without a selection modifier");
-                return;
+                return None;
             }
         };
-        let frame = match self.compositor.selection_state() {
-            Some(s) => s.canvas_frame(),
-            None => return,
-        };
-        let entry = commit_undo_region(
+        let frame = self.compositor.selection_state()?.canvas_frame();
+        Some(commit_undo_region(
             &self.gpu,
             &self.region_scratch,
             &mut self.readbacks,
@@ -602,8 +627,7 @@ impl DarklyEngine {
             &frame,
             &snap,
             rect,
-        );
-        self.push_undo(Box::new(SelectionAction::new(was_active, entry)));
+        ))
     }
 
     /// Full-canvas undo rect — used when post-op extent isn't known up-front.

--- a/crates/darkly/src/engine/rendering.rs
+++ b/crates/darkly/src/engine/rendering.rs
@@ -698,31 +698,106 @@ impl DarklyEngine {
             self.apply_canvas_rect_to_compositor();
         }
 
-        // If this is a GPU region action, execute the texture restore.
-        // Node id resolves to the right texture via the unified node-texture
-        // pool — caller no longer dispatches by format.
-        if let Some(entry) = action.gpu_region_entry_mut() {
+        // Execute every GPU region restore this action owns. Most actions own
+        // one; image rescale owns one per pixel-bearing node (and the snapshot
+        // restores across a texture extent change — see below). Node id
+        // resolves to the right texture via the unified node-texture pool.
+        let label = match direction {
+            UndoDirection::Undo => "undo-restore",
+            UndoDirection::Redo => "redo-restore",
+        };
+        for entry in action.gpu_region_entries_mut() {
             let node_id = entry.layer_id;
-            let frame = self
-                .compositor
-                .node_texture(node_id)
-                .map(|t| t.canvas_frame());
-            if let Some(frame) = frame {
-                let label = match direction {
-                    UndoDirection::Undo => "undo-restore",
-                    UndoDirection::Redo => "redo-restore",
-                };
-                restore_gpu_region(
-                    &self.gpu,
-                    &self.region_scratch,
-                    &mut self.readbacks,
-                    entry,
-                    &frame,
-                    label,
-                );
-                // Restored pixels — refresh the panel thumbnail.
-                self.compositor.mark_node_pixels_dirty(node_id);
+            let cur_extent = match self.compositor.node_texture(node_id) {
+                Some(t) => t.canvas_extent(),
+                None => continue,
+            };
+            // A content-scaling rescale swaps the node's document `PixelBuffer.
+            // bounds` in undo/redo; when the GPU texture no longer matches, the
+            // texture must be realloc'd to the doc bounds before the snapshot is
+            // uploaded (the per-node analogue of the canvas-rect reconcile).
+            // Normal actions keep doc bounds == texture extent (growth is
+            // document-led), so `target_extent` is `None` and this is the plain
+            // path. `entry.canvas_rect` is a sub-rect for paint, so it can't be
+            // used to detect the extent change — the doc bounds are the signal.
+            let target_extent = self
+                .doc
+                .node_pixel_bounds(node_id)
+                .filter(|b| *b != cur_extent);
+
+            match target_extent {
+                None => {
+                    // Constant-extent restore (paint, transform, mask, and any
+                    // rescale node whose size didn't change): capture the
+                    // entry's rect and upload, in one encoder.
+                    let frame = self
+                        .compositor
+                        .node_texture(node_id)
+                        .expect("checked above")
+                        .canvas_frame();
+                    restore_gpu_region(
+                        &self.gpu,
+                        &self.region_scratch,
+                        &mut self.readbacks,
+                        entry,
+                        &frame,
+                        label,
+                    );
+                }
+                Some(target_extent) => {
+                    // Extent-changing restore (image rescale): capture the
+                    // *whole* current texture (the opposite-direction content)
+                    // for the forward entry, realloc the node texture to the doc
+                    // bounds (cleared), then upload the saved pixels into it. The
+                    // capture must be submitted before the realloc drops the old
+                    // texture.
+                    let (forward, request) = {
+                        let cur_frame = self
+                            .compositor
+                            .node_texture(node_id)
+                            .expect("checked above")
+                            .canvas_frame();
+                        self.gpu.encode_ret(label, |enc| {
+                            self.region_scratch.capture_region(
+                                enc,
+                                &self.gpu.device,
+                                entry.layer_id,
+                                entry.format,
+                                &cur_frame,
+                                cur_extent,
+                            )
+                        })
+                    };
+                    self.readbacks.submit(
+                        request,
+                        ReadbackContext::UndoRegionReady {
+                            cell: forward.pixels.clone(),
+                        },
+                    );
+                    self.gpu.encode("undo-rescale-realloc", |enc| {
+                        self.compositor.realloc_node_texture(
+                            &self.gpu.device,
+                            &self.gpu.queue,
+                            enc,
+                            node_id,
+                            target_extent,
+                            false,
+                        );
+                    });
+                    let new_frame = self
+                        .compositor
+                        .node_texture(node_id)
+                        .expect("realloc'd above")
+                        .canvas_frame();
+                    self.gpu.encode(label, |enc| {
+                        self.region_scratch
+                            .upload_region(enc, &self.gpu.device, entry, &new_frame);
+                    });
+                    *entry = forward;
+                }
             }
+            // Restored pixels — refresh the panel thumbnail.
+            self.compositor.mark_node_pixels_dirty(node_id);
         }
 
         // If this is a selection GPU action, restore the selection texture
@@ -897,11 +972,10 @@ fn restore_gpu_region(
     frame: &CanvasFrame<'_>,
     label: &str,
 ) {
-    let request = gpu.encode_ret(label, |encoder| {
-        let (swapped, request) = region_scratch.restore_region(encoder, &gpu.device, entry, frame);
-        *entry = swapped;
-        request
+    let (forward, request) = gpu.encode_ret(label, |encoder| {
+        region_scratch.restore_region(encoder, &gpu.device, entry, frame)
     });
+    *entry = forward;
     scheduler.submit(
         request,
         ReadbackContext::UndoRegionReady {

--- a/crates/darkly/src/gpu/compositor.rs
+++ b/crates/darkly/src/gpu/compositor.rs
@@ -44,6 +44,22 @@ pub const MAX_LAYER_DIM: u32 = 16384;
 /// reallocations regardless of dab count.
 pub const LAYER_GROWTH_CHUNK: u32 = 256;
 
+/// Scale a node's canvas extent about `origin` by `(sx, sy)` — the per-node
+/// extent math shared by image rescale's GPU pass and the engine's validation
+/// (so both predict the same new size). Width/height clamp to a 1px minimum.
+pub(crate) fn scaled_extent_about(
+    e: crate::coord::CanvasRect,
+    origin: crate::coord::CanvasPoint,
+    sx: f32,
+    sy: f32,
+) -> crate::coord::CanvasRect {
+    let nx0 = origin.x + ((e.origin.x - origin.x) as f32 * sx).round() as i32;
+    let ny0 = origin.y + ((e.origin.y - origin.y) as f32 * sy).round() as i32;
+    let nw = ((e.width as f32 * sx).round() as i32).max(1) as u32;
+    let nh = ((e.height as f32 * sy).round() as i32).max(1) as u32;
+    crate::coord::CanvasRect::from_xywh(nx0, ny0, nw, nh)
+}
+
 /// Read-only handle to an entity's GPU pixel storage. Returned by
 /// [`Compositor::pixel_data_for`] so callers that need to schedule a
 /// readback (today: the save pipeline) can find the texture for any
@@ -385,6 +401,9 @@ pub struct Compositor {
 
     // --- Floating Content Transform ---
     pub(super) transform_pass: crate::gpu::transform::TransformPass,
+
+    // --- Image rescale resampling ---
+    rescale_pass: crate::gpu::rescale::RescalePass,
 
     // --- Isolation (session state) ---
     /// When `Some(id)`, the render walk descends only into nodes on the
@@ -826,6 +845,7 @@ impl Compositor {
         let tool_overlay = ToolOverlay::new(device, queue, surface_format);
 
         let transform_pass = crate::gpu::transform::TransformPass::new(device);
+        let rescale_pass = crate::gpu::rescale::RescalePass::new(device);
         let content_bounds = ContentBoundsPass::new(device);
 
         Compositor {
@@ -858,6 +878,7 @@ impl Compositor {
             veil_chain,
             void_registry: VoidRegistry::new(),
             transform_pass,
+            rescale_pass,
             isolated_node: None,
             selection_state: None,
             content_bounds,
@@ -956,18 +977,11 @@ impl Compositor {
         self.mark_node_pixels_dirty(layer_id);
     }
 
-    /// Resize a layer's GPU texture to the given canvas-space extent.
-    ///
-    /// **Pure realization.** This method is a faithful reflection of the
-    /// requested extent — it does not compute unions or chunk-align. The
-    /// caller (engine-level `grow_layer`) is responsible for choosing
     /// Resize a node's GPU texture (raster layer or mask modifier) to a new
-    /// canvas extent. Format-agnostic — the existing texture's format drives
-    /// reallocation. If the node is unknown or already at `new_extent`, this
-    /// is a no-op. Otherwise the texture is reallocated and old contents are
-    /// `copy_texture_to_texture`'d into the new texture at the offset that
-    /// preserves their canvas-space anchor; new pixels start zeroed for RGBA
-    /// (transparent) and white-filled for R8 (full reveal).
+    /// canvas extent, copying old contents into the new texture at the offset
+    /// that preserves their canvas-space anchor. Thin wrapper over
+    /// [`realloc_node_texture`](Self::realloc_node_texture) with `copy_old =
+    /// true`.
     ///
     /// **Lockstep growth across host + modifiers is the engine's job** — it
     /// owns the document and walks `host.modifiers` to call this helper for
@@ -979,6 +993,32 @@ impl Compositor {
         encoder: &mut wgpu::CommandEncoder,
         node_id: LayerId,
         new_extent: CanvasRect,
+    ) {
+        self.realloc_node_texture(device, queue, encoder, node_id, new_extent, true);
+    }
+
+    /// Reallocate a node's GPU texture (raster layer or mask modifier) to a new
+    /// canvas extent.
+    ///
+    /// **Pure realization.** A faithful reflection of the requested extent — it
+    /// does not compute unions or chunk-align; the caller chooses `new_extent`.
+    /// Format-agnostic: the existing texture's format drives reallocation. If
+    /// the node is unknown or already at `new_extent`, this is a no-op.
+    ///
+    /// When `copy_old` is `true`, the old contents are
+    /// `copy_texture_to_texture`'d into the new texture at the canvas-anchored
+    /// offset; uncovered pixels start zeroed for RGBA (transparent) and
+    /// white-filled for R8 (full reveal). When `copy_old` is `false`, the new
+    /// texture is left at its allocation default (cleared) — used by undo
+    /// restores that immediately upload the authoritative pixels themselves.
+    pub fn realloc_node_texture(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+        node_id: LayerId,
+        new_extent: CanvasRect,
+        copy_old: bool,
     ) {
         let (current, format) = match self.node_textures.get(&node_id) {
             Some(t) => (t.canvas_extent(), t.format()),
@@ -993,40 +1033,79 @@ impl Compositor {
                 LayerTexture::new_mask_with_extent(device, queue, new_extent)
             }
             wgpu::TextureFormat::Rgba8Unorm => LayerTexture::with_bounds(device, new_extent),
-            other => panic!("resize_node_texture: unsupported format {other:?}"),
+            other => panic!("realloc_node_texture: unsupported format {other:?}"),
         };
 
-        let old_tex = self
-            .node_textures
-            .get(&node_id)
-            .expect("node_textures entry checked above");
-        let copy_dst_x = (current.origin.x - new_extent.origin.x) as u32;
-        let copy_dst_y = (current.origin.y - new_extent.origin.y) as u32;
-        encoder.copy_texture_to_texture(
-            wgpu::TexelCopyTextureInfo {
-                texture: old_tex.texture(),
-                mip_level: 0,
-                origin: wgpu::Origin3d::ZERO,
-                aspect: wgpu::TextureAspect::All,
-            },
-            wgpu::TexelCopyTextureInfo {
-                texture: new_tex.texture(),
-                mip_level: 0,
-                origin: wgpu::Origin3d {
-                    x: copy_dst_x,
-                    y: copy_dst_y,
-                    z: 0,
+        if copy_old {
+            let old_tex = self
+                .node_textures
+                .get(&node_id)
+                .expect("node_textures entry checked above");
+            let copy_dst_x = (current.origin.x - new_extent.origin.x) as u32;
+            let copy_dst_y = (current.origin.y - new_extent.origin.y) as u32;
+            encoder.copy_texture_to_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: old_tex.texture(),
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
                 },
-                aspect: wgpu::TextureAspect::All,
-            },
-            wgpu::Extent3d {
-                width: current.width,
-                height: current.height,
-                depth_or_array_layers: 1,
-            },
-        );
+                wgpu::TexelCopyTextureInfo {
+                    texture: new_tex.texture(),
+                    mip_level: 0,
+                    origin: wgpu::Origin3d {
+                        x: copy_dst_x,
+                        y: copy_dst_y,
+                        z: 0,
+                    },
+                    aspect: wgpu::TextureAspect::All,
+                },
+                wgpu::Extent3d {
+                    width: current.width,
+                    height: current.height,
+                    depth_or_array_layers: 1,
+                },
+            );
+        }
 
+        self.swap_node_texture(device, queue, node_id, new_tex);
+
+        // Resize rewrites the texture; thumbnail must reflect the new
+        // extent + transferred pixels.
+        self.mark_node_pixels_dirty(node_id);
+        self.mark_dirty();
+    }
+
+    /// Replace a node's texture handle and rebuild the cached state that
+    /// referenced the old view. Shared by every path that swaps a node texture
+    /// out from under the compositor (resize/realloc, rescale).
+    fn swap_node_texture(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        node_id: LayerId,
+        new_tex: LayerTexture,
+    ) {
         self.node_textures.insert(node_id, new_tex);
+
+        // A content layer's blend uniform bakes in the texture's canvas extent
+        // (`layer_offset` / `layer_size`). The extent may have just changed, so
+        // refresh it from the cached blend props — otherwise the composite
+        // samples the new texture through stale geometry (the post-resize
+        // squash `BlendUniforms` is designed to make unrepresentable). Masks
+        // have no layer_cache entry and are unaffected.
+        if let Some(cache) = self.layer_cache.get(&node_id) {
+            let ext = self.node_textures[&node_id].canvas_extent();
+            let uniforms = BlendUniforms {
+                opacity: cache.opacity,
+                blend_mode: cache.blend_mode,
+                isolated: cache.isolated as u32,
+                _pad1: 0.0,
+                layer_offset: [ext.x0() as f32, ext.y0() as f32],
+                layer_size: [ext.width as f32, ext.height as f32],
+            };
+            queue.write_buffer(&cache.uniform_buf, 0, bytemuck::bytes_of(&uniforms));
+        }
 
         // Any cached blend bind groups using this node (as parent or child)
         // reference the now-replaced texture view; drop them so the next
@@ -1048,10 +1127,43 @@ impl Compositor {
             });
             self.mask_bind_groups.insert(node_id, mask_bg);
         }
+    }
 
-        // Resize rewrites the texture; thumbnail must reflect the new
-        // extent + transferred pixels.
-        self.mark_node_pixels_dirty(node_id);
+    /// Resample each node's texture from its current extent into a new extent
+    /// scaled about the canvas origin by `(sx, sy)` — the GPU half of image
+    /// rescale. Replaces each node texture (rebuilding cached bind groups via
+    /// [`swap_node_texture`](Self::swap_node_texture)) and marks pixels dirty.
+    ///
+    /// The engine owns the document side (extent bounds, undo snapshots) and
+    /// reads the resulting extents back from `node_texture(id).canvas_extent()`.
+    pub fn rescale_nodes(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+        node_ids: &[LayerId],
+        sx: f32,
+        sy: f32,
+    ) {
+        let origin = self.canvas_origin;
+        for &id in node_ids {
+            let (old_extent, format) = match self.node_textures.get(&id) {
+                Some(t) => (t.canvas_extent(), t.format()),
+                None => continue,
+            };
+            let new_extent = scaled_extent_about(old_extent, origin, sx, sy);
+            let new_tex = {
+                let src = self
+                    .node_textures
+                    .get(&id)
+                    .expect("node_textures entry checked above");
+                self.rescale_pass.resample_node(
+                    device, queue, encoder, src, new_extent, origin, sx, sy, format,
+                )
+            };
+            self.swap_node_texture(device, queue, id, new_tex);
+            self.mark_node_pixels_dirty(id);
+        }
         self.mark_dirty();
     }
 

--- a/crates/darkly/src/gpu/mod.rs
+++ b/crates/darkly/src/gpu/mod.rs
@@ -39,6 +39,7 @@ pub mod paint_target;
 pub mod params;
 pub mod readback;
 pub mod region_store;
+pub mod rescale;
 pub mod selection;
 pub mod straight_composite;
 #[cfg(any(test, feature = "testing"))]

--- a/crates/darkly/src/gpu/region_store.rs
+++ b/crates/darkly/src/gpu/region_store.rs
@@ -471,16 +471,14 @@ impl RegionScratch {
         (entry, request)
     }
 
-    /// Restore saved pixels back to the layer texture, producing a forward
-    /// entry (the pre-restore state) plus its async-readback request for
-    /// redo.
-    ///
-    /// Both branches encode their commands into the supplied encoder, so the
-    /// forward capture sequences strictly before the restore. The
-    /// `Ready` branch allocates a one-shot upload buffer (mapped at
-    /// creation) so the restore stays in the encoder's command stream —
-    /// `queue.write_texture` would re-order to the start of the next submit
-    /// and stomp the forward capture.
+    /// Restore `entry`'s saved pixels into `target`, producing the forward
+    /// entry (the pre-restore state) + its async-readback request for the
+    /// inverse op. The constant-extent combinator of
+    /// [`capture_region`](Self::capture_region) +
+    /// [`upload_region`](Self::upload_region): capture the entry's rect, then
+    /// upload, in one encoder (capture sequences before the overwrite). Use the
+    /// two halves directly when the target texture is realloc'd between them
+    /// (image rescale's extent change).
     pub fn restore_region(
         &self,
         encoder: &mut wgpu::CommandEncoder,
@@ -488,9 +486,134 @@ impl RegionScratch {
         entry: &UndoRegionEntry,
         target: &CanvasFrame<'_>,
     ) -> (UndoRegionEntry, ReadbackRequest) {
+        let (forward, request) = self.capture_region(
+            encoder,
+            device,
+            entry.layer_id,
+            entry.format,
+            target,
+            entry.canvas_rect,
+        );
+        self.upload_region(encoder, device, entry, target);
+        (forward, request)
+    }
+
+    /// Capture `capture_rect` of `target`'s **current** pixels into a fresh
+    /// undo entry (the forward / opposite-direction state) plus its async
+    /// readback request.
+    ///
+    /// This is the first half of an undo restore: snapshot what's there now so
+    /// the inverse operation can put it back. Pairs with
+    /// [`upload_region`](Self::upload_region); a caller that needs to realloc
+    /// the target texture (image rescale changes a node's extent) can do so
+    /// *between* the two calls — capture reads the old extent, upload writes
+    /// the new. For constant-extent restores pass `capture_rect ==
+    /// entry.canvas_rect`; the pair then behaves like the old `restore_region`.
+    ///
+    /// The capture commands must be encoded (and, across an extent change,
+    /// submitted) before the upload overwrites / the realloc replaces the
+    /// target — same encoder preserves order for the constant-extent case.
+    pub fn capture_region(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        device: &wgpu::Device,
+        layer_id: LayerId,
+        format: wgpu::TextureFormat,
+        target: &CanvasFrame<'_>,
+        capture_rect: CanvasRect,
+    ) -> (UndoRegionEntry, ReadbackRequest) {
+        let layer_rect = target
+            .canvas_to_layer_rect(capture_rect)
+            .expect("capture_region rect must overlap the target's canvas extent");
+        let bpp = format.block_copy_size(None).unwrap_or(1);
+        let unpadded_row_bytes = layer_rect.width * bpp;
+        let padded_row_bytes = padded_row(layer_rect.width, bpp);
+        let byte_size = padded_row_bytes as u64 * layer_rect.height as u64;
+        let origin = wgpu::Origin3d {
+            x: layer_rect.x0(),
+            y: layer_rect.y0(),
+            z: 0,
+        };
+        let extent = wgpu::Extent3d {
+            width: layer_rect.width,
+            height: layer_rect.height,
+            depth_or_array_layers: 1,
+        };
+        let texel_layout = wgpu::TexelCopyBufferLayout {
+            offset: 0,
+            bytes_per_row: Some(padded_row_bytes),
+            rows_per_image: Some(layer_rect.height),
+        };
+
+        let (readback, staging) = allocate_pending_buffers(device, byte_size);
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture: target.texture,
+                mip_level: 0,
+                origin,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &readback,
+                layout: texel_layout,
+            },
+            extent,
+        );
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture: target.texture,
+                mip_level: 0,
+                origin,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &staging,
+                layout: texel_layout,
+            },
+            extent,
+        );
+
+        let pixels = Rc::new(RefCell::new(EntryPixels::Pending {
+            readback: readback.clone(),
+            staging,
+        }));
+        let request = ReadbackRequest::from_buffer(
+            readback,
+            layer_rect.height,
+            padded_row_bytes,
+            unpadded_row_bytes,
+        );
+        let forward = UndoRegionEntry {
+            layer_id,
+            canvas_rect: capture_rect,
+            format,
+            padded_row_bytes,
+            unpadded_row_bytes,
+            byte_size,
+            pixels,
+        };
+        (forward, request)
+    }
+
+    /// Upload `entry`'s saved pixels back into `target` at `entry.canvas_rect`
+    /// — the second half of an undo restore. The `Ready` branch allocates a
+    /// one-shot mapped-at-creation upload buffer so the copy stays in the
+    /// encoder's command stream (`queue.write_texture` would re-order to the
+    /// start of the next submit and stomp a same-encoder forward capture).
+    ///
+    /// `target` must already be sized so `entry.canvas_rect` maps fully into
+    /// it (the caller realloc's the node texture for an extent-changing
+    /// restore before calling this).
+    pub fn upload_region(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        device: &wgpu::Device,
+        entry: &UndoRegionEntry,
+        target: &CanvasFrame<'_>,
+    ) {
         let layer_rect = target
             .canvas_to_layer_rect(entry.canvas_rect)
-            .expect("restore_region entry must overlap the target's canvas extent");
+            .expect("upload_region entry must overlap the target's canvas extent");
         let origin = wgpu::Origin3d {
             x: layer_rect.x0(),
             y: layer_rect.y0(),
@@ -511,40 +634,6 @@ impl RegionScratch {
             rows_per_image: Some(height),
         };
 
-        // 1. Allocate the forward entry's pair of staging buffers + capture
-        //    the pre-restore target into BOTH. The commands must precede the
-        //    restore-into-target command below so the forward entry contains
-        //    the redo pixels rather than the undone pixels.
-        let (forward_readback, forward_staging) = allocate_pending_buffers(device, byte_size);
-        encoder.copy_texture_to_buffer(
-            wgpu::TexelCopyTextureInfo {
-                texture: target.texture,
-                mip_level: 0,
-                origin,
-                aspect: wgpu::TextureAspect::All,
-            },
-            wgpu::TexelCopyBufferInfo {
-                buffer: &forward_readback,
-                layout: texel_layout,
-            },
-            extent,
-        );
-        encoder.copy_texture_to_buffer(
-            wgpu::TexelCopyTextureInfo {
-                texture: target.texture,
-                mip_level: 0,
-                origin,
-                aspect: wgpu::TextureAspect::All,
-            },
-            wgpu::TexelCopyBufferInfo {
-                buffer: &forward_staging,
-                layout: texel_layout,
-            },
-            extent,
-        );
-
-        // 2. Restore old pixels into target — same encoder, so this runs
-        //    after the forward capture.
         let pixels_borrow = entry.pixels.borrow();
         match &*pixels_borrow {
             EntryPixels::Pending { staging, .. } => {
@@ -610,29 +699,6 @@ impl RegionScratch {
                 );
             }
         }
-        drop(pixels_borrow);
-
-        let forward_pixels = Rc::new(RefCell::new(EntryPixels::Pending {
-            readback: forward_readback.clone(),
-            staging: forward_staging,
-        }));
-        let request = ReadbackRequest::from_buffer(
-            forward_readback,
-            height,
-            padded_row_bytes,
-            unpadded_row_bytes,
-        );
-
-        let forward = UndoRegionEntry {
-            layer_id: entry.layer_id,
-            canvas_rect: entry.canvas_rect,
-            format: entry.format,
-            padded_row_bytes,
-            unpadded_row_bytes,
-            byte_size,
-            pixels: forward_pixels,
-        };
-        (forward, request)
     }
 
     /// Restore a region directly from the scratch texture to the target,

--- a/crates/darkly/src/gpu/rescale.rs
+++ b/crates/darkly/src/gpu/rescale.rs
@@ -1,0 +1,317 @@
+//! Image-rescale GPU resampling pass.
+//!
+//! Resamples a single layer/mask texture from its old canvas extent into a
+//! freshly-allocated texture at a new extent, scaled about the document's
+//! canvas origin. Upscales bilinearly; downscales through a box pyramid
+//! (`fs_halve` chained until within 2x of the target, then one `fs_resample`)
+//! so large reductions stay anti-aliased. RGBA is resampled in premultiplied
+//! alpha; R8 masks straight. See `shaders/rescale.wgsl`.
+//!
+//! The pass is owned by the [`Compositor`](super::compositor::Compositor),
+//! which drives it per node in `rescale_nodes`.
+
+use crate::coord::{CanvasPoint, CanvasRect};
+use crate::gpu::atlas::LayerTexture;
+
+/// Resample uniform, packed into vec4 rows so the WGSL uniform layout is
+/// unambiguous (16-byte-aligned members; the same discipline as
+/// `TransformBlendUniforms`).
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+struct Params {
+    /// `[new_origin.x, new_origin.y, canvas_origin.x, canvas_origin.y]`
+    p0: [f32; 4],
+    /// `[inv_scale.x, inv_scale.y, old_origin.x, old_origin.y]`
+    p1: [f32; 4],
+    /// `[old_size.x, old_size.y, is_r8, _pad]`
+    p2: [f32; 4],
+}
+
+/// Render pipelines + bind-group layout for the rescale shader. Holds one
+/// pipeline per (entry point × target format) combination.
+pub struct RescalePass {
+    resample_rgba: wgpu::RenderPipeline,
+    resample_r8: wgpu::RenderPipeline,
+    halve_rgba: wgpu::RenderPipeline,
+    halve_r8: wgpu::RenderPipeline,
+    bgl: wgpu::BindGroupLayout,
+}
+
+impl std::fmt::Debug for RescalePass {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RescalePass").finish_non_exhaustive()
+    }
+}
+
+impl RescalePass {
+    pub fn new(device: &wgpu::Device) -> Self {
+        let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("rescale-bgl"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        // Sampled with textureLoad — no hardware filtering.
+                        sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("rescale-layout"),
+            bind_group_layouts: &[Some(&bgl)],
+            immediate_size: 0,
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("rescale-shader"),
+            source: wgpu::ShaderSource::Wgsl(
+                include_str!("../../../../shaders/rescale.wgsl").into(),
+            ),
+        });
+
+        let make = |entry: &str, format: wgpu::TextureFormat, label: &str| {
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some(label),
+                layout: Some(&layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("vs_main"),
+                    buffers: &[],
+                    compilation_options: Default::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some(entry),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format,
+                        blend: None,
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: Default::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    ..Default::default()
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview_mask: None,
+                cache: None,
+            })
+        };
+
+        let rgba = wgpu::TextureFormat::Rgba8Unorm;
+        let r8 = wgpu::TextureFormat::R8Unorm;
+        RescalePass {
+            resample_rgba: make("fs_resample", rgba, "rescale-resample-rgba"),
+            resample_r8: make("fs_resample", r8, "rescale-resample-r8"),
+            halve_rgba: make("fs_halve", rgba, "rescale-halve-rgba"),
+            halve_r8: make("fs_halve", r8, "rescale-halve-r8"),
+            bgl,
+        }
+    }
+
+    /// Resample `src` (at its old extent) into a fresh `LayerTexture` at
+    /// `new_extent`, with content scaled about `canvas_origin` by `(sx, sy)`
+    /// (the document scale = new_dim / old_dim). `format` selects the RGBA
+    /// (premultiplied) or R8 (straight) path.
+    pub fn resample_node(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+        src: &LayerTexture,
+        new_extent: CanvasRect,
+        canvas_origin: CanvasPoint,
+        sx: f32,
+        sy: f32,
+        format: wgpu::TextureFormat,
+    ) -> LayerTexture {
+        let is_r8 = format == wgpu::TextureFormat::R8Unorm;
+        let old_extent = src.canvas_extent();
+        let target_w = new_extent.width.max(1);
+        let target_h = new_extent.height.max(1);
+
+        // Box-pyramid downscale: halve while both axes stay at least 2x the
+        // target, so the final resample only ever upsamples or shrinks <2x.
+        // Each intermediate holds the same old canvas extent at lower res.
+        let halve_params = Params {
+            p0: [0.0, 0.0, 0.0, 0.0],
+            p1: [1.0, 1.0, 0.0, 0.0],
+            p2: [1.0, 1.0, if is_r8 { 1.0 } else { 0.0 }, 0.0],
+        };
+        let mut chain: Vec<wgpu::Texture> = Vec::new();
+        let mut cur_w = src.layer_extent().width;
+        let mut cur_h = src.layer_extent().height;
+        while cur_w >= 2 * target_w && cur_h >= 2 * target_h && cur_w > 1 && cur_h > 1 {
+            let hw = (cur_w / 2).max(1);
+            let hh = (cur_h / 2).max(1);
+            let input_view = match chain.last() {
+                Some(t) => t.create_view(&wgpu::TextureViewDescriptor::default()),
+                None => src
+                    .texture()
+                    .create_view(&wgpu::TextureViewDescriptor::default()),
+            };
+            let out_tex = create_intermediate(device, hw, hh, format);
+            let out_view = out_tex.create_view(&wgpu::TextureViewDescriptor::default());
+            let pipeline = if is_r8 {
+                &self.halve_r8
+            } else {
+                &self.halve_rgba
+            };
+            self.run_pass(
+                device,
+                queue,
+                encoder,
+                pipeline,
+                &input_view,
+                &out_view,
+                &halve_params,
+            );
+            chain.push(out_tex);
+            cur_w = hw;
+            cur_h = hh;
+        }
+
+        let dest = if is_r8 {
+            LayerTexture::new_mask_with_extent(device, queue, new_extent)
+        } else {
+            LayerTexture::with_bounds(device, new_extent)
+        };
+
+        let params = Params {
+            p0: [
+                new_extent.origin.x as f32,
+                new_extent.origin.y as f32,
+                canvas_origin.x as f32,
+                canvas_origin.y as f32,
+            ],
+            p1: [
+                1.0 / sx,
+                1.0 / sy,
+                old_extent.origin.x as f32,
+                old_extent.origin.y as f32,
+            ],
+            p2: [
+                old_extent.width as f32,
+                old_extent.height as f32,
+                if is_r8 { 1.0 } else { 0.0 },
+                0.0,
+            ],
+        };
+        let final_input_view = match chain.last() {
+            Some(t) => t.create_view(&wgpu::TextureViewDescriptor::default()),
+            None => src
+                .texture()
+                .create_view(&wgpu::TextureViewDescriptor::default()),
+        };
+        let pipeline = if is_r8 {
+            &self.resample_r8
+        } else {
+            &self.resample_rgba
+        };
+        self.run_pass(
+            device,
+            queue,
+            encoder,
+            pipeline,
+            &final_input_view,
+            dest.view(),
+            &params,
+        );
+        dest
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn run_pass(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        encoder: &mut wgpu::CommandEncoder,
+        pipeline: &wgpu::RenderPipeline,
+        input_view: &wgpu::TextureView,
+        output_view: &wgpu::TextureView,
+        params: &Params,
+    ) {
+        let ubuf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("rescale-params"),
+            size: std::mem::size_of::<Params>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        queue.write_buffer(&ubuf, 0, bytemuck::bytes_of(params));
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("rescale-bg"),
+            layout: &self.bgl,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(input_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: ubuf.as_entire_binding(),
+                },
+            ],
+        });
+
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("rescale-pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: output_view,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    store: wgpu::StoreOp::Store,
+                },
+                depth_slice: None,
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        pass.set_pipeline(pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.draw(0..3, 0..1);
+    }
+}
+
+fn create_intermediate(
+    device: &wgpu::Device,
+    width: u32,
+    height: u32,
+    format: wgpu::TextureFormat,
+) -> wgpu::Texture {
+    device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("rescale-intermediate"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format,
+        usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::RENDER_ATTACHMENT,
+        view_formats: &[],
+    })
+}

--- a/crates/darkly/src/undo/compound.rs
+++ b/crates/darkly/src/undo/compound.rs
@@ -46,6 +46,13 @@ impl UndoAction for CompoundAction {
             .find_map(|a| a.gpu_region_entry_mut())
     }
 
+    fn gpu_region_entries_mut(&mut self) -> Vec<&mut UndoRegionEntry> {
+        self.actions
+            .iter_mut()
+            .flat_map(|a| a.gpu_region_entries_mut())
+            .collect()
+    }
+
     fn on_evict(&mut self, compositor: &mut Compositor) {
         for action in self.actions.iter_mut() {
             action.on_evict(compositor);

--- a/crates/darkly/src/undo/image_rescale.rs
+++ b/crates/darkly/src/undo/image_rescale.rs
@@ -1,0 +1,123 @@
+//! Undo action for image rescale (Photoshop "Image Size").
+//!
+//! Image rescale is lossy: it resamples every pixel-bearing node to new
+//! dimensions. This action carries the document-side swap (canvas width/height
+//! plus each node's `PixelBuffer.bounds`) and the per-node GPU pixel snapshots
+//! that the engine's `apply_undo` restores — across the node texture extent
+//! change (see `engine/rendering.rs`). It also folds in the selection clear so
+//! a rescale-with-active-selection undoes in a single step.
+//!
+//! Why a dedicated action rather than reusing [`CanvasResizeAction`]: this one
+//! must additionally swap per-node `PixelBuffer.bounds` (canvas resize moves
+//! only the window, never layer extents) and keep `canvas_origin` fixed while
+//! changing width/height.
+//!
+//! [`CanvasResizeAction`]: super::CanvasResizeAction
+
+use super::UndoAction;
+use crate::coord::CanvasRect;
+use crate::document::Document;
+use crate::gpu::compositor::Compositor;
+use crate::gpu::region_store::UndoRegionEntry;
+use crate::layer::LayerId;
+use std::collections::{HashMap, HashSet};
+
+/// The selection clear folded into a rescale, so undo restores the selection
+/// in the same step. Mirrors [`super::SelectionAction`]'s two fields.
+struct SelectionPart {
+    was_active: bool,
+    entry: UndoRegionEntry,
+}
+
+pub struct ImageRescaleAction {
+    old_w: u32,
+    old_h: u32,
+    new_w: u32,
+    new_h: u32,
+    /// Per pixel-bearing node: `(id, old_extent, new_extent)`. The bounds swap
+    /// is what drives `apply_undo`'s per-node texture-extent reconcile so the
+    /// region restores land at the correct layer-local coords either way.
+    bounds: Vec<(LayerId, CanvasRect, CanvasRect)>,
+    /// Old-direction pixel snapshots, one per node (same order as `bounds`).
+    regions: Vec<UndoRegionEntry>,
+    /// Present only if a selection was active and cleared by the rescale.
+    selection: Option<SelectionPart>,
+}
+
+impl ImageRescaleAction {
+    pub fn new(
+        old_dims: (u32, u32),
+        new_dims: (u32, u32),
+        bounds: Vec<(LayerId, CanvasRect, CanvasRect)>,
+        regions: Vec<UndoRegionEntry>,
+        selection: Option<(bool, UndoRegionEntry)>,
+    ) -> Self {
+        ImageRescaleAction {
+            old_w: old_dims.0,
+            old_h: old_dims.1,
+            new_w: new_dims.0,
+            new_h: new_dims.1,
+            bounds,
+            regions,
+            selection: selection.map(|(was_active, entry)| SelectionPart { was_active, entry }),
+        }
+    }
+}
+
+impl UndoAction for ImageRescaleAction {
+    fn undo(&mut self, doc: &mut Document) -> HashMap<LayerId, HashSet<(i32, i32)>> {
+        doc.width = self.old_w;
+        doc.height = self.old_h;
+        for (id, old_extent, _) in &self.bounds {
+            doc.set_node_pixel_bounds(*id, *old_extent);
+        }
+        // GPU pixel + selection restores are handled by the engine via
+        // `gpu_region_entries_mut` / `selection_region_entry_mut`.
+        HashMap::new()
+    }
+
+    fn redo(&mut self, doc: &mut Document) -> HashMap<LayerId, HashSet<(i32, i32)>> {
+        doc.width = self.new_w;
+        doc.height = self.new_h;
+        for (id, _, new_extent) in &self.bounds {
+            doc.set_node_pixel_bounds(*id, *new_extent);
+        }
+        HashMap::new()
+    }
+
+    fn gpu_region_entries_mut(&mut self) -> Vec<&mut UndoRegionEntry> {
+        self.regions.iter_mut().collect()
+    }
+
+    fn selection_region_entry_mut(&mut self) -> Option<&mut UndoRegionEntry> {
+        self.selection.as_mut().map(|s| &mut s.entry)
+    }
+
+    fn swap_selection_active(&mut self, current_active: bool) -> Option<bool> {
+        self.selection.as_mut().map(|s| {
+            let restore_to = s.was_active;
+            s.was_active = current_active;
+            restore_to
+        })
+    }
+
+    fn byte_cost(&self) -> u64 {
+        let regions: u64 = self
+            .regions
+            .iter()
+            .map(|e| e.byte_size)
+            .fold(0, u64::saturating_add);
+        let sel = self
+            .selection
+            .as_ref()
+            .map(|s| s.entry.byte_size)
+            .unwrap_or(0);
+        regions.saturating_add(sel)
+    }
+
+    fn on_evict(&mut self, _compositor: &mut Compositor) {
+        // Storage is action-owned (per-entry buffers / heap), released when the
+        // action drops. Override exists to document the contract — same as
+        // `GpuRegionAction::on_evict`.
+    }
+}

--- a/crates/darkly/src/undo/mod.rs
+++ b/crates/darkly/src/undo/mod.rs
@@ -1,6 +1,7 @@
 mod canvas_resize;
 mod compound;
 mod gpu_region;
+mod image_rescale;
 mod layer;
 mod modifier;
 pub mod property;
@@ -10,6 +11,7 @@ mod tombstones;
 pub use canvas_resize::CanvasResizeAction;
 pub use compound::CompoundAction;
 pub use gpu_region::GpuRegionAction;
+pub use image_rescale::ImageRescaleAction;
 pub use layer::{
     BakeLayersAction, BakeSourceSlot, DuplicateAction, LayerAddAction, LayerMoveAction,
     LayerRemoveAction,
@@ -45,9 +47,20 @@ pub trait UndoAction {
 
     /// If this is a GPU region action, return a mutable reference to its entry.
     /// The engine uses this to execute GPU texture restores during undo/redo,
-    /// then swaps the entry with the forward/backward entry returned by `restore_region`.
+    /// then swaps the entry with the forward entry produced by the restore.
     fn gpu_region_entry_mut(&mut self) -> Option<&mut UndoRegionEntry> {
         None
+    }
+
+    /// Every GPU region entry this action owns. The engine restores each one
+    /// during undo/redo. Defaults to the single [`gpu_region_entry_mut`] entry;
+    /// actions that bundle per-node snapshots (image rescale) or aggregate
+    /// children (compound) override this to return all of them. The single-
+    /// entry default preserves the existing one-region-per-step behaviour.
+    ///
+    /// [`gpu_region_entry_mut`]: Self::gpu_region_entry_mut
+    fn gpu_region_entries_mut(&mut self) -> Vec<&mut UndoRegionEntry> {
+        self.gpu_region_entry_mut().into_iter().collect()
     }
 
     /// If this is a selection GPU action, return a mutable reference to its region entry.

--- a/crates/darkly/tests/image_rescale.rs
+++ b/crates/darkly/tests/image_rescale.rs
@@ -1,0 +1,785 @@
+//! Image rescale ("Image Size") integration tests.
+//!
+//! Exercises content-scaling resize: all layer + mask pixels are resampled to
+//! new document dimensions (distinct from canvas resize, which only moves the
+//! window). Covers the GPU resample (centroid scaling up + down), the lossy
+//! per-node undo that restores across a texture extent change (the load-bearing
+//! capture→realloc→upload path), the multi-region restore (two layers), mask
+//! scaling, and the selection clear.
+//!
+//! It also carries a **tool-accuracy suite** that mirrors `canvas_resize.rs`:
+//! every tool (paint, rect select + marquee mask, marching ants, flood fill,
+//! magic wand, transform-from-selection, color pick, view transform) is checked
+//! both **after a rescale** and **after undoing the rescale** — the coordinate
+//! frames that the rescale-undo bug corrupted. See `image-rescale-undo-handoff.md`.
+//!
+//! Run with: `cargo test -p darkly --test image_rescale --features testing -- --test-threads=1`
+
+use darkly::coord::{CanvasPoint, CanvasRect};
+use darkly::document::SelectionMode;
+use darkly::engine::types::StrokeOp;
+use darkly::engine::DarklyEngine;
+use darkly::gpu::context::GpuContext;
+use darkly::gpu::overlay::{OverlayPrimitive, FLAG_CANVAS_SPACE, KIND_DASHED_LINE};
+use darkly::gpu::test_utils::*;
+use darkly::layer::LayerId;
+
+fn test_engine(width: u32, height: u32) -> DarklyEngine {
+    let (device, queue) = test_device();
+    let gpu = GpuContext::new_headless(device, queue);
+    DarklyEngine::new(gpu, width, height)
+}
+
+/// Paint a short red horizontal stroke centred near plane `(cx, cy)`.
+fn paint_feature(engine: &mut DarklyEngine, layer_id: LayerId, cx: f32, cy: f32) {
+    engine.begin_stroke(layer_id);
+    let steps = 16;
+    for i in 0..=steps {
+        let x = cx - 3.0 + 6.0 * (i as f32 / steps as f32);
+        engine.stroke_to(StrokeOp::BrushStroke {
+            x,
+            y: cy,
+            pressure: 1.0,
+            x_tilt: 0.0,
+            y_tilt: 0.0,
+            rotation: 0.0,
+            tangential_pressure: 0.0,
+            time_ms: i as f64 * 16.0,
+            cr: 1.0,
+            cg: 0.0,
+            cb: 0.0,
+            ca: 1.0,
+        });
+    }
+    engine.end_stroke();
+}
+
+/// Centroid (in canvas px) of clearly-red pixels in an RGBA8 buffer.
+fn red_centroid(px: &[u8], w: u32, h: u32) -> (f32, f32) {
+    let (mut sx, mut sy, mut n) = (0.0f32, 0.0f32, 0u32);
+    for y in 0..h {
+        for x in 0..w {
+            let i = ((y * w + x) * 4) as usize;
+            if px[i] > 128 && px[i + 1] < 80 && px[i + 2] < 80 {
+                sx += x as f32;
+                sy += y as f32;
+                n += 1;
+            }
+        }
+    }
+    assert!(n > 0, "no red pixels found");
+    (sx / n as f32, sy / n as f32)
+}
+
+/// Upscaling 2x scales a painted feature's position about the origin: a feature
+/// at canvas `(cx, cy)` lands near `(2cx, 2cy)` and the canvas dims double.
+#[test]
+fn feature_centroid_scales_after_2x() {
+    let (w, h) = (32u32, 32u32);
+    let mut engine = test_engine(w, h);
+    let layer = engine.add_raster_layer(None);
+    paint_feature(&mut engine, layer, 8.0, 8.0);
+
+    let before = engine.test_readback_canvas();
+    let (cx0, cy0) = red_centroid(&before, w, h);
+
+    engine.rescale_image(2 * w, 2 * h);
+    assert_eq!(engine.canvas_dimensions(), (2 * w, 2 * h));
+
+    let after = engine.test_readback_canvas();
+    let (cx1, cy1) = red_centroid(&after, 2 * w, 2 * h);
+
+    assert!(
+        (cx1 - 2.0 * cx0).abs() < 2.0 && (cy1 - 2.0 * cy0).abs() < 2.0,
+        "feature centroid should scale ~2x: before ({cx0},{cy0}) after ({cx1},{cy1})"
+    );
+}
+
+/// Downscaling 0.25x (two box-pyramid halvings) quarters the dims and the
+/// feature position, and the content survives the reduction.
+#[test]
+fn rescale_downscale_025x() {
+    let (w, h) = (64u32, 64u32);
+    let mut engine = test_engine(w, h);
+    let layer = engine.add_raster_layer(None);
+    paint_feature(&mut engine, layer, 16.0, 16.0);
+
+    let before = engine.test_readback_canvas();
+    let (cx0, cy0) = red_centroid(&before, w, h);
+
+    engine.rescale_image(w / 4, h / 4);
+    assert_eq!(engine.canvas_dimensions(), (w / 4, h / 4));
+
+    let after = engine.test_readback_canvas();
+    // Content must still be present (the halving pyramid didn't lose it).
+    let (cx1, cy1) = red_centroid(&after, w / 4, h / 4);
+    assert!(
+        (cx1 - 0.25 * cx0).abs() < 2.0 && (cy1 - 0.25 * cy0).abs() < 2.0,
+        "feature centroid should scale ~0.25x: before ({cx0},{cy0}) after ({cx1},{cy1})"
+    );
+}
+
+/// MULTI-REGION regression: a rescale snapshots one GPU region per node. Undo
+/// must restore EVERY node's pixels, not just the first — the bug the
+/// `gpu_region_entries_mut` loop fixes (the old single-`if let` restored one).
+#[test]
+fn two_layers_undo_restores_all_pixels() {
+    let (w, h) = (32u32, 32u32);
+    let mut engine = test_engine(w, h);
+    let l1 = engine.add_raster_layer(None);
+    let l2 = engine.add_raster_layer(None);
+    paint_feature(&mut engine, l1, 8.0, 8.0);
+    paint_feature(&mut engine, l2, 20.0, 20.0);
+
+    let before1 = engine.test_readback_layer(l1);
+    let before2 = engine.test_readback_layer(l2);
+
+    engine.rescale_image(2 * w, 2 * h);
+    engine.undo();
+
+    let after1 = engine.test_readback_layer(l1);
+    let after2 = engine.test_readback_layer(l2);
+
+    assert_eq!(
+        after1, before1,
+        "layer 1 pixels must be restored exactly on undo"
+    );
+    assert_eq!(
+        after2, before2,
+        "layer 2 pixels must be restored exactly on undo"
+    );
+}
+
+/// EXTENT-CHANGE regression: the undo restore captures the current (opposite-
+/// direction) pixels, reallocs the node texture to the entry's extent, then
+/// uploads — so undo AND redo both round-trip across the size change.
+#[test]
+fn rescale_undo_then_redo_pixels() {
+    let (w, h) = (32u32, 32u32);
+    let mut engine = test_engine(w, h);
+    let layer = engine.add_raster_layer(None);
+    paint_feature(&mut engine, layer, 10.0, 10.0);
+
+    let before = engine.test_readback_layer(layer);
+    engine.rescale_image(2 * w, 2 * h);
+    let scaled = engine.test_readback_layer(layer);
+    assert_eq!(
+        scaled.len(),
+        (2 * w * 2 * h * 4) as usize,
+        "layer extent should double"
+    );
+
+    engine.undo();
+    let undone = engine.test_readback_layer(layer);
+    assert_eq!(engine.canvas_dimensions(), (w, h));
+    assert_eq!(
+        undone, before,
+        "undo must restore the original pixels exactly"
+    );
+
+    engine.redo();
+    let redone = engine.test_readback_layer(layer);
+    assert_eq!(engine.canvas_dimensions(), (2 * w, 2 * h));
+    assert_eq!(
+        redone, scaled,
+        "redo must restore the resampled pixels exactly"
+    );
+}
+
+/// A layer mask is a pixel-bearing modifier — it must scale in lockstep with
+/// its host layer.
+#[test]
+fn mask_scales_with_layer() {
+    let (w, h) = (32u32, 32u32);
+    let mut engine = test_engine(w, h);
+    let layer = engine.add_raster_layer(None);
+    engine.add_mask(layer);
+    let mask = engine.test_mask_id(layer).expect("mask modifier present");
+
+    assert_eq!(
+        engine.test_node_pixel_bounds(mask),
+        Some(CanvasRect::from_xywh(0, 0, w, h))
+    );
+
+    engine.rescale_image(2 * w, 2 * h);
+
+    assert_eq!(
+        engine.test_node_pixel_bounds(mask),
+        Some(CanvasRect::from_xywh(0, 0, 2 * w, 2 * h)),
+        "mask extent must scale with its host layer"
+    );
+    // GPU texture (R8, 1 byte/px) was actually reallocated to the new extent.
+    assert_eq!(
+        engine.test_readback_layer(mask).len(),
+        (2 * w * 2 * h) as usize
+    );
+}
+
+/// Rescale clears the active selection (folded into the single undo step);
+/// undo restores it.
+#[test]
+fn rescale_clears_active_selection() {
+    let (w, h) = (32u32, 32u32);
+    let mut engine = test_engine(w, h);
+    let _layer = engine.add_raster_layer(None);
+    engine.select_rect(8.0, 8.0, 16.0, 16.0, SelectionMode::Replace, false, 0.0);
+    assert!(
+        engine.has_selection(),
+        "selection should be active before rescale"
+    );
+
+    engine.rescale_image(2 * w, 2 * h);
+    assert!(
+        !engine.has_selection(),
+        "rescale should clear the active selection"
+    );
+
+    engine.undo();
+    assert!(engine.has_selection(), "undo should restore the selection");
+}
+
+/// A no-op rescale (unchanged dims) pushes no undo step.
+#[test]
+fn rescale_noop_when_unchanged() {
+    let (w, h) = (32u32, 32u32);
+    let mut engine = test_engine(w, h);
+    assert!(!engine.test_can_undo());
+    engine.rescale_image(w, h);
+    assert!(
+        !engine.test_can_undo(),
+        "a same-dims rescale must not push an undo step"
+    );
+}
+
+// =========================================================================
+// Tool-accuracy suite — every tool, after a rescale AND after undoing it.
+//
+// These guard the coordinate frames that the rescale-undo bug corrupted:
+// after `rescale_image` (and after `undo()` back to the original dims), a
+// tool driven at a known plane coordinate must land exactly there. The
+// engine math is the source of truth here; the frontend's borrow-free
+// `viewMatrices` mirror is exercised by the vitest suite (the engine test
+// at the default origin can pass while the app is broken — see
+// docs/coordinate-systems.md).
+// =========================================================================
+
+/// Alpha at plane `(x, y)` of a plane-anchored (origin-0) layer readback.
+fn alpha_at(px: &[u8], w: u32, x: u32, y: u32) -> u8 {
+    px[((y * w + x) * 4 + 3) as usize]
+}
+
+/// Paint a horizontal red brush row at plane-y `py`, sweeping plane-x `[x0, x1]`.
+fn paint_row(engine: &mut DarklyEngine, layer_id: LayerId, py: f32, x0: f32, x1: f32) {
+    engine.begin_stroke(layer_id);
+    let steps = 48;
+    for i in 0..=steps {
+        let x = x0 + (x1 - x0) * (i as f32 / steps as f32);
+        engine.stroke_to(StrokeOp::BrushStroke {
+            x,
+            y: py,
+            pressure: 1.0,
+            x_tilt: 0.0,
+            y_tilt: 0.0,
+            rotation: 0.0,
+            tangential_pressure: 0.0,
+            time_ms: i as f64 * 16.0,
+            cr: 1.0,
+            cg: 0.0,
+            cb: 0.0,
+            ca: 1.0,
+        });
+    }
+    engine.end_stroke();
+}
+
+/// Bounding box `(min_x, min_y, max_x, max_y)` of all marching-ants
+/// (`KIND_DASHED_LINE`, `FLAG_CANVAS_SPACE`) vertices, in plane space.
+fn ants_bbox(prims: &[OverlayPrimitive]) -> (f32, f32, f32, f32) {
+    let (mut minx, mut miny, mut maxx, mut maxy) = (f32::MAX, f32::MAX, f32::MIN, f32::MIN);
+    let mut found = false;
+    for p in prims {
+        if p.kind != KIND_DASHED_LINE || (p.flags & FLAG_CANVAS_SPACE) == 0 {
+            continue;
+        }
+        for &[x, y] in &[p.p0, p.p1] {
+            found = true;
+            minx = minx.min(x);
+            miny = miny.min(y);
+            maxx = maxx.max(x);
+            maxy = maxy.max(y);
+        }
+    }
+    assert!(found, "no marching-ants primitives present");
+    (minx, miny, maxx, maxy)
+}
+
+/// Drive pending async GPU readbacks to completion (flush + render), `n` frames.
+fn pump(engine: &mut DarklyEngine, n: u32) {
+    for _ in 0..n {
+        engine.test_flush_readbacks();
+        engine.render(0.0);
+    }
+}
+
+/// A full-canvas RGBA buffer (transparent) with a solid opaque red square at
+/// plane `[x0, x1) × [y0, y1)`.
+fn rgba_with_red_square(w: u32, h: u32, x0: u32, y0: u32, x1: u32, y1: u32) -> Vec<u8> {
+    let mut rgba = vec![0u8; (w * h * 4) as usize];
+    for y in y0..y1 {
+        for x in x0..x1 {
+            let i = ((y * w + x) * 4) as usize;
+            rgba[i] = 255;
+            rgba[i + 3] = 255;
+        }
+    }
+    rgba
+}
+
+/// Flood fill `layer` at plane `(x, y)` with `color`.
+fn flood_fill(
+    engine: &mut DarklyEngine,
+    layer_id: LayerId,
+    x: f32,
+    y: f32,
+    color: [u8; 4],
+    tol: u8,
+) {
+    engine.begin_stroke(layer_id);
+    engine.stroke_to(StrokeOp::FloodFill {
+        x,
+        y,
+        r: color[0],
+        g: color[1],
+        b: color[2],
+        a: color[3],
+        tolerance: tol,
+    });
+    engine.end_stroke();
+}
+
+// ---- Painting --------------------------------------------------------------
+
+/// Paint lands at the intended plane coordinate AFTER a rescale (the resampled
+/// canvas's paint frame is correct).
+#[test]
+fn paint_lands_at_plane_coords_after_rescale() {
+    let (w, h) = (32u32, 32u32);
+    let mut engine = test_engine(w, h);
+    let layer = engine.add_raster_layer(None);
+
+    engine.rescale_image(2 * w, 2 * h); // 64×64, empty layer rescaled
+    paint_feature(&mut engine, layer, 40.0, 40.0);
+
+    let px = engine.test_readback_layer(layer);
+    let (cx, cy) = red_centroid(&px, 2 * w, 2 * h);
+    assert!(
+        (cx - 40.0).abs() < 2.0 && (cy - 40.0).abs() < 2.0,
+        "post-rescale paint landed at ({cx}, {cy}), expected ~(40, 40)"
+    );
+}
+
+/// Paint lands at the intended plane coordinate AFTER undoing a rescale — the
+/// engine-level analogue of the reported "coords don't match the tool" bug.
+/// Uses a 64px base (the default brush floods a 32px canvas, masking position).
+#[test]
+fn paint_lands_at_plane_coords_after_rescale_undo() {
+    let (w, h) = (64u32, 64u32);
+    let mut engine = test_engine(w, h);
+    let layer = engine.add_raster_layer(None);
+
+    engine.rescale_image(2 * w, 2 * h);
+    engine.undo();
+    assert_eq!(engine.canvas_dimensions(), (w, h));
+
+    paint_feature(&mut engine, layer, 40.0, 40.0);
+    let px = engine.test_readback_layer(layer);
+    let (cx, cy) = red_centroid(&px, w, h);
+    assert!(
+        (cx - 40.0).abs() < 2.0 && (cy - 40.0).abs() < 2.0,
+        "post-undo paint landed at ({cx}, {cy}), expected ~(40, 40)"
+    );
+}
+
+// ---- Rect selection: the marquee masks the right plane pixels --------------
+
+/// A selection made AFTER a rescale masks paint to the selected plane pixels.
+#[test]
+fn marquee_masks_same_plane_pixels_after_rescale() {
+    let (w, h) = (64u32, 64u32);
+    let mut engine = test_engine(w, h);
+    let layer = engine.add_raster_layer(None);
+
+    engine.rescale_image(2 * w, 2 * h); // 128×128
+                                        // Select a vertical band: plane x in [16, 64), full height.
+    engine.select_rect(
+        16.0,
+        0.0,
+        48.0,
+        (2 * h) as f32,
+        SelectionMode::Replace,
+        false,
+        0.0,
+    );
+    // Paint a row spanning selected (x<64) and unselected (x>=64) plane-x.
+    paint_row(&mut engine, layer, 40.0, 16.0, 96.0);
+
+    let px = engine.test_readback_layer(layer);
+    assert!(
+        alpha_at(&px, 2 * w, 40, 40) > 0,
+        "a selected plane pixel must be painted through the marquee after rescale"
+    );
+    assert_eq!(
+        alpha_at(&px, 2 * w, 80, 40),
+        0,
+        "an unselected plane pixel must stay transparent after rescale"
+    );
+}
+
+/// A selection made AFTER undoing a rescale masks paint to the selected plane
+/// pixels — the reported bug, at engine level.
+#[test]
+fn marquee_masks_same_plane_pixels_after_rescale_undo() {
+    let (w, h) = (64u32, 64u32);
+    let mut engine = test_engine(w, h);
+    let layer = engine.add_raster_layer(None);
+
+    engine.rescale_image(2 * w, 2 * h);
+    engine.undo();
+    assert_eq!(engine.canvas_dimensions(), (w, h));
+
+    // Plane band x in [8, 32), full height.
+    engine.select_rect(8.0, 0.0, 24.0, h as f32, SelectionMode::Replace, false, 0.0);
+    paint_row(&mut engine, layer, 32.0, 8.0, 56.0);
+
+    let px = engine.test_readback_layer(layer);
+    assert!(
+        alpha_at(&px, w, 20, 32) > 0,
+        "selected plane pixel must be painted through the marquee after undo"
+    );
+    assert_eq!(
+        alpha_at(&px, w, 44, 32),
+        0,
+        "unselected plane pixel must stay transparent after undo"
+    );
+}
+
+// ---- Marching ants track the selection's plane bounds ----------------------
+
+#[test]
+fn marching_ants_track_selection_after_rescale() {
+    let (w, h) = (32u32, 32u32);
+    let mut engine = test_engine(w, h);
+    let _layer = engine.add_raster_layer(None);
+
+    engine.rescale_image(2 * w, 2 * h); // 64×64
+    engine.select_rect(20.0, 16.0, 12.0, 10.0, SelectionMode::Replace, false, 0.0);
+
+    let (minx, miny, maxx, maxy) = ants_bbox(&engine.test_selection_overlay());
+    assert!(
+        (minx - 20.0).abs() <= 2.0 && (miny - 16.0).abs() <= 2.0,
+        "ants min ({minx}, {miny}) must track plane origin (20, 16) after rescale"
+    );
+    assert!(
+        (maxx - 32.0).abs() <= 2.0 && (maxy - 26.0).abs() <= 2.0,
+        "ants max ({maxx}, {maxy}) must track plane far edge (32, 26) after rescale"
+    );
+}
+
+#[test]
+fn marching_ants_track_selection_after_rescale_undo() {
+    let (w, h) = (64u32, 64u32);
+    let mut engine = test_engine(w, h);
+    let _layer = engine.add_raster_layer(None);
+
+    engine.rescale_image(2 * w, 2 * h);
+    engine.undo();
+    assert_eq!(engine.canvas_dimensions(), (w, h));
+
+    engine.select_rect(16.0, 12.0, 10.0, 8.0, SelectionMode::Replace, false, 0.0);
+    let (minx, miny, maxx, maxy) = ants_bbox(&engine.test_selection_overlay());
+    assert!(
+        (minx - 16.0).abs() <= 2.0 && (miny - 12.0).abs() <= 2.0,
+        "ants min ({minx}, {miny}) must track plane origin (16, 12) after undo"
+    );
+    assert!(
+        (maxx - 26.0).abs() <= 2.0 && (maxy - 20.0).abs() <= 2.0,
+        "ants max ({maxx}, {maxy}) must track plane far edge (26, 20) after undo"
+    );
+}
+
+// ---- Flood fill ------------------------------------------------------------
+
+/// Flood fill's seed maps to the right plane pixel AFTER a rescale: a fill
+/// seeded inside the (scaled) red square recolors the square, not the bg.
+#[test]
+fn flood_fill_fills_plane_region_after_rescale() {
+    let (w, h) = (32u32, 32u32);
+    let mut engine = test_engine(w, h);
+    // Red square at plane [8, 16) on a 32² layer.
+    let rgba = rgba_with_red_square(w, h, 8, 8, 16, 16);
+    let layer = engine.paste_image(w, h, &rgba, 0, 0, None);
+
+    engine.rescale_image(2 * w, 2 * h); // square scales to plane [16, 32)
+                                        // Seed inside the scaled square; recolor red → green.
+    flood_fill(&mut engine, layer, 24.0, 24.0, [0, 255, 0, 255], 50);
+    pump(&mut engine, 8);
+
+    let px = engine.test_readback_layer(layer);
+    let i = ((24 * 2 * w + 24) * 4) as usize;
+    assert!(
+        px[i] < 80 && px[i + 1] > 150,
+        "fill seed inside the scaled square must recolor it green, got {:?}",
+        &px[i..i + 4]
+    );
+    // A background pixel (outside the square) must be untouched (transparent).
+    assert_eq!(
+        alpha_at(&px, 2 * w, 4, 4),
+        0,
+        "flood fill must not leak outside the seeded region after rescale"
+    );
+}
+
+/// Flood fill's seed maps to the right plane pixel AFTER undoing a rescale.
+#[test]
+fn flood_fill_fills_plane_region_after_rescale_undo() {
+    let (w, h) = (32u32, 32u32);
+    let mut engine = test_engine(w, h);
+    let rgba = rgba_with_red_square(w, h, 8, 8, 16, 16);
+    let layer = engine.paste_image(w, h, &rgba, 0, 0, None);
+
+    engine.rescale_image(2 * w, 2 * h);
+    engine.undo();
+    assert_eq!(engine.canvas_dimensions(), (w, h));
+
+    // Square is back at plane [8, 16); seed inside it.
+    flood_fill(&mut engine, layer, 12.0, 12.0, [0, 255, 0, 255], 50);
+    pump(&mut engine, 8);
+
+    let px = engine.test_readback_layer(layer);
+    let i = ((12 * w + 12) * 4) as usize;
+    assert!(
+        px[i] < 80 && px[i + 1] > 150,
+        "post-undo fill seed inside the square must recolor it green, got {:?}",
+        &px[i..i + 4]
+    );
+    assert_eq!(
+        alpha_at(&px, w, 2, 2),
+        0,
+        "flood fill must not leak outside the seeded region after undo"
+    );
+}
+
+// ---- Magic wand ------------------------------------------------------------
+
+/// Magic wand seeded inside the (scaled) red square selects the square's plane
+/// bounds AFTER a rescale.
+#[test]
+fn magic_wand_selects_plane_region_after_rescale() {
+    let (w, h) = (32u32, 32u32);
+    let mut engine = test_engine(w, h);
+    let rgba = rgba_with_red_square(w, h, 8, 8, 16, 16);
+    let layer = engine.paste_image(w, h, &rgba, 0, 0, None);
+
+    engine.rescale_image(2 * w, 2 * h); // square → plane [16, 32)
+    engine.select_magic_wand(layer, CanvasPoint::new(24, 24), 50, SelectionMode::Replace);
+    pump(&mut engine, 8);
+
+    assert!(
+        engine.has_selection(),
+        "magic wand should produce a selection"
+    );
+    let (minx, miny, maxx, maxy) = ants_bbox(&engine.test_selection_overlay());
+    assert!(
+        (minx - 16.0).abs() <= 3.0 && (miny - 16.0).abs() <= 3.0,
+        "wand selection min ({minx}, {miny}) must track scaled square origin (16, 16)"
+    );
+    assert!(
+        (maxx - 32.0).abs() <= 3.0 && (maxy - 32.0).abs() <= 3.0,
+        "wand selection max ({maxx}, {maxy}) must track scaled square far edge (32, 32)"
+    );
+}
+
+/// Magic wand selects the square's plane bounds AFTER undoing a rescale.
+#[test]
+fn magic_wand_selects_plane_region_after_rescale_undo() {
+    let (w, h) = (32u32, 32u32);
+    let mut engine = test_engine(w, h);
+    let rgba = rgba_with_red_square(w, h, 8, 8, 16, 16);
+    let layer = engine.paste_image(w, h, &rgba, 0, 0, None);
+
+    engine.rescale_image(2 * w, 2 * h);
+    engine.undo();
+    assert_eq!(engine.canvas_dimensions(), (w, h));
+
+    engine.select_magic_wand(layer, CanvasPoint::new(12, 12), 50, SelectionMode::Replace);
+    pump(&mut engine, 8);
+
+    assert!(
+        engine.has_selection(),
+        "magic wand should produce a selection"
+    );
+    let (minx, miny, maxx, maxy) = ants_bbox(&engine.test_selection_overlay());
+    assert!(
+        (minx - 8.0).abs() <= 3.0 && (miny - 8.0).abs() <= 3.0,
+        "wand selection min ({minx}, {miny}) must track square origin (8, 8) after undo"
+    );
+    assert!(
+        (maxx - 16.0).abs() <= 3.0 && (maxy - 16.0).abs() <= 3.0,
+        "wand selection max ({maxx}, {maxy}) must track square far edge (16, 16) after undo"
+    );
+}
+
+// ---- Transform from selection ---------------------------------------------
+
+/// `begin_transform` from a selection hands a PLANE source origin AFTER a
+/// rescale (not a window-local one).
+#[test]
+fn transform_from_selection_plane_origin_after_rescale() {
+    let (w, h) = (32u32, 32u32);
+    let mut engine = test_engine(w, h);
+    let layer = engine.add_raster_layer(None);
+
+    engine.rescale_image(2 * w, 2 * h); // 64×64
+    paint_feature(&mut engine, layer, 32.0, 28.0);
+    engine.select_rect(24.0, 20.0, 16.0, 12.0, SelectionMode::Replace, false, 0.0);
+
+    assert!(engine.begin_transform(layer), "transform should set up");
+    let (sox, soy, sw, sh, _m) = engine.floating_info().expect("floating active");
+    assert!(
+        (sox - 24.0).abs() <= 1.0 && (soy - 20.0).abs() <= 1.0,
+        "source origin ({sox}, {soy}) must be the selection's plane origin (24, 20)"
+    );
+    assert!(
+        (sw - 16.0).abs() <= 1.0 && (sh - 12.0).abs() <= 1.0,
+        "source size ({sw}, {sh}) should match the selection (16, 12)"
+    );
+}
+
+/// `begin_transform` from a selection hands a PLANE source origin AFTER undoing
+/// a rescale.
+#[test]
+fn transform_from_selection_plane_origin_after_rescale_undo() {
+    let (w, h) = (32u32, 32u32);
+    let mut engine = test_engine(w, h);
+    let layer = engine.add_raster_layer(None);
+
+    engine.rescale_image(2 * w, 2 * h);
+    engine.undo();
+    assert_eq!(engine.canvas_dimensions(), (w, h));
+
+    paint_feature(&mut engine, layer, 16.0, 14.0);
+    engine.select_rect(12.0, 10.0, 8.0, 6.0, SelectionMode::Replace, false, 0.0);
+
+    assert!(engine.begin_transform(layer), "transform should set up");
+    let (sox, soy, sw, sh, _m) = engine.floating_info().expect("floating active");
+    assert!(
+        (sox - 12.0).abs() <= 1.0 && (soy - 10.0).abs() <= 1.0,
+        "source origin ({sox}, {soy}) must be the selection's plane origin (12, 10) after undo"
+    );
+    assert!(
+        (sw - 8.0).abs() <= 1.0 && (sh - 6.0).abs() <= 1.0,
+        "source size ({sw}, {sh}) should match the selection (8, 6) after undo"
+    );
+}
+
+// ---- Color pick ------------------------------------------------------------
+
+/// A merged color pick reads the plane pixel AFTER a rescale.
+#[test]
+fn color_pick_reads_plane_pixel_after_rescale() {
+    use darkly::engine::PickSource;
+
+    let (w, h) = (32u32, 32u32);
+    let mut engine = test_engine(w, h);
+    engine.rescale_image(2 * w, 2 * h); // 64×64
+
+    // Paste a 64×64 layer: red everywhere, green 4×4 at plane (40, 40).
+    let mut rgba = vec![0u8; (2 * w * 2 * h * 4) as usize];
+    for px in rgba.chunks_exact_mut(4) {
+        px.copy_from_slice(&[200, 0, 0, 255]);
+    }
+    for y in 40..44 {
+        for x in 40..44 {
+            let i = ((y * 2 * w + x) * 4) as usize;
+            rgba[i..i + 4].copy_from_slice(&[0, 200, 0, 255]);
+        }
+    }
+    let _layer = engine.paste_image(2 * w, 2 * h, &rgba, 0, 0, None);
+    let _ = engine.test_readback_canvas(); // force the merged composite
+
+    engine.pick_color(41.0, 41.0, PickSource::Merged);
+    engine.test_flush_readbacks();
+    let c = engine.last_picked_color();
+    assert!(
+        c[1] > 150 && c[0] < 80,
+        "merged pick after rescale must read the plane pixel (green); got {c:?}"
+    );
+}
+
+/// A merged color pick reads the plane pixel AFTER undoing a rescale.
+#[test]
+fn color_pick_reads_plane_pixel_after_rescale_undo() {
+    use darkly::engine::PickSource;
+
+    let (w, h) = (32u32, 32u32);
+    let mut engine = test_engine(w, h);
+    engine.rescale_image(2 * w, 2 * h);
+    engine.undo();
+    assert_eq!(engine.canvas_dimensions(), (w, h));
+
+    // Paste a 32×32 layer: red everywhere, green 4×4 at plane (20, 20).
+    let mut rgba = vec![0u8; (w * h * 4) as usize];
+    for px in rgba.chunks_exact_mut(4) {
+        px.copy_from_slice(&[200, 0, 0, 255]);
+    }
+    for y in 20..24 {
+        for x in 20..24 {
+            let i = ((y * w + x) * 4) as usize;
+            rgba[i..i + 4].copy_from_slice(&[0, 200, 0, 255]);
+        }
+    }
+    let _layer = engine.paste_image(w, h, &rgba, 0, 0, None);
+    let _ = engine.test_readback_canvas();
+
+    engine.pick_color(21.0, 21.0, PickSource::Merged);
+    engine.test_flush_readbacks();
+    let c = engine.last_picked_color();
+    assert!(
+        c[1] > 150 && c[0] < 80,
+        "merged pick after undo must read the plane pixel (green); got {c:?}"
+    );
+}
+
+// ---- View transform / screen→plane ----------------------------------------
+
+/// The cached view transform (which `screen_to_plane` consumes, same as the
+/// present pass) tracks the new dims after a rescale and reverts on undo.
+#[test]
+fn screen_to_plane_tracks_dims_through_rescale_and_undo() {
+    let (w, h) = (64u32, 64u32);
+    let mut engine = test_engine(w, h);
+    let _layer = engine.add_raster_layer(None);
+
+    let (sw, sh) = (200.0_f32, 200.0_f32);
+    engine.set_view_transform(0.0, 0.0, 1.0, 0.0, false, sw, sh);
+
+    let (cx0, cy0) = engine.screen_to_plane(sw / 2.0, sh / 2.0);
+    assert!(
+        (cx0 - 32.0).abs() < 1e-2 && (cy0 - 32.0).abs() < 1e-2,
+        "pre-rescale center should map to (32, 32), got ({cx0}, {cy0})"
+    );
+
+    engine.rescale_image(2 * w, 2 * h); // 128×128, center → (64, 64)
+    let (cx1, cy1) = engine.screen_to_plane(sw / 2.0, sh / 2.0);
+    assert!(
+        (cx1 - 64.0).abs() < 1e-2 && (cy1 - 64.0).abs() < 1e-2,
+        "post-rescale center must map to the new canvas center (64, 64), got ({cx1}, {cy1})"
+    );
+
+    engine.undo();
+    let (cx2, cy2) = engine.screen_to_plane(sw / 2.0, sh / 2.0);
+    assert!(
+        (cx2 - 32.0).abs() < 1e-2 && (cy2 - 32.0).abs() < 1e-2,
+        "after undo, center must map back to (32, 32), got ({cx2}, {cy2})"
+    );
+}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -9,6 +9,7 @@
     import ExportImageModal from './ui/ExportImageModal.svelte';
     import NewDocumentModal from './ui/NewDocumentModal.svelte';
     import ResizeCanvasModal from './ui/ResizeCanvasModal.svelte';
+    import ImageRescaleModal from './ui/ImageRescaleModal.svelte';
     import ConfirmDiscardModal from './ui/ConfirmDiscardModal.svelte';
     import RecoveryModal from './ui/RecoveryModal.svelte';
     import AboutModal from './ui/AboutModal.svelte';
@@ -63,6 +64,7 @@
 <ExportImageModal />
 <NewDocumentModal />
 <ResizeCanvasModal />
+<ImageRescaleModal />
 <ConfirmDiscardModal />
 <RecoveryModal />
 <AboutModal />

--- a/frontend/src/actions/index.ts
+++ b/frontend/src/actions/index.ts
@@ -4,6 +4,7 @@ import { config } from '../config/store.svelte';
 import { settings } from '../state/settings.svelte';
 import { newDocument } from '../state/newDocument.svelte';
 import { resizeCanvas } from '../state/resizeCanvas.svelte';
+import { imageRescale } from '../state/imageRescale.svelte';
 import { exportImage } from '../state/exportImage.svelte';
 import { loadError, parseLoadErrorMessage } from '../state/loadError.svelte';
 import { toast } from '../state/toast.svelte';
@@ -264,7 +265,7 @@ export function registerActions() {
         description: 'Undo the last action.',
         icon: 'fa6-solid:rotate-left',
         menuPath: ['Edit:10'],
-        handler: () => { app.handle?.undo(); app.refreshLayerTree(); },
+        handler: () => { app.handle?.undo(); app.syncCanvasRect(); app.refreshLayerTree(); },
     });
     actions.register({
         id: 'redo',
@@ -273,7 +274,7 @@ export function registerActions() {
         description: 'Redo the last undone action.',
         icon: 'fa6-solid:rotate-right',
         menuPath: ['Edit:20'],
-        handler: () => { app.handle?.redo(); app.refreshLayerTree(); },
+        handler: () => { app.handle?.redo(); app.syncCanvasRect(); app.refreshLayerTree(); },
     });
 
     // -- Colors --
@@ -349,6 +350,18 @@ export function registerActions() {
         handler: () => {
             if (!app.handle) return;
             resizeCanvas.open = true;
+        },
+    });
+    actions.register({
+        id: 'rescaleImage',
+        displayName: 'Image Size…',
+        category: 'edit',
+        description: 'Resample all layers to new document dimensions.',
+        icon: 'fa6-solid:expand',
+        menuPath: ['Image:11'],
+        handler: () => {
+            if (!app.handle) return;
+            imageRescale.open = true;
         },
     });
     actions.register({

--- a/frontend/src/actions/index.ts
+++ b/frontend/src/actions/index.ts
@@ -354,9 +354,9 @@ export function registerActions() {
     });
     actions.register({
         id: 'rescaleImage',
-        displayName: 'Image Size…',
+        displayName: 'Scale Image to New Size',
         category: 'edit',
-        description: 'Resample all layers to new document dimensions.',
+        description: 'Resize all layers to new document dimensions.',
         icon: 'fa6-solid:expand',
         menuPath: ['Image:11'],
         handler: () => {

--- a/frontend/src/state/imageRescale.svelte.ts
+++ b/frontend/src/state/imageRescale.svelte.ts
@@ -1,0 +1,10 @@
+/**
+ * Global toggle for the "Image Size" (rescale) modal. The `rescaleImage`
+ * action dispatches into this; the modal reads it. Distinct from
+ * `resizeCanvas` (which resizes the window without scaling content).
+ */
+class ImageRescaleState {
+    open = $state(false);
+}
+
+export const imageRescale = new ImageRescaleState();

--- a/frontend/src/ui/ImageRescaleModal.svelte
+++ b/frontend/src/ui/ImageRescaleModal.svelte
@@ -1,0 +1,297 @@
+<script lang="ts">
+    import Modal from './Modal.svelte';
+    import Icon from '../icons/Icon.svelte';
+    import { imageRescale } from '../state/imageRescale.svelte';
+    import { app } from '../state/app.svelte';
+    import { MAX_DIM, clampDim } from './resizePreview';
+
+    // Source dimensions, captured when the modal opens.
+    let oldW = $state(1);
+    let oldH = $state(1);
+
+    // Target dimensions in pixels — the model. Inputs (`wInput`/`hInput`) are
+    // shown in the current `unit` and converted to/from these.
+    let pxW = $state(1);
+    let pxH = $state(1);
+
+    let unit = $state<'px' | '%'>('px');
+    // Aspect-ratio link defaults ON: a non-uniform rescale distorts content.
+    let linkAspect = $state(true);
+
+    let wInput = $state(1);
+    let hInput = $state(1);
+
+    function fromPxW(px: number): number {
+        return unit === 'px' ? px : Math.round((px / oldW) * 1000) / 10;
+    }
+    function fromPxH(px: number): number {
+        return unit === 'px' ? px : Math.round((px / oldH) * 1000) / 10;
+    }
+    function toPxW(v: number): number {
+        return unit === 'px' ? clampDim(v) : clampDim((oldW * v) / 100);
+    }
+    function toPxH(v: number): number {
+        return unit === 'px' ? clampDim(v) : clampDim((oldH * v) / 100);
+    }
+
+    // Refresh the displayed inputs from the pixel model (after a unit switch,
+    // an aspect-linked change to the other axis, or on open).
+    function syncInputs() {
+        wInput = fromPxW(pxW);
+        hInput = fromPxH(pxH);
+    }
+
+    let prevOpen = false;
+    $effect(() => {
+        if (imageRescale.open && !prevOpen) {
+            const r = app.handle?.canvas_rect();
+            if (r) {
+                oldW = r[2];
+                oldH = r[3];
+            }
+            pxW = oldW;
+            pxH = oldH;
+            unit = 'px';
+            linkAspect = true;
+            syncInputs();
+        }
+        prevOpen = imageRescale.open;
+    });
+
+    function onWidthInput() {
+        pxW = toPxW(wInput);
+        if (linkAspect) {
+            pxH = clampDim((pxW * oldH) / oldW);
+        }
+        syncInputs();
+    }
+
+    function onHeightInput() {
+        pxH = toPxH(hInput);
+        if (linkAspect) {
+            pxW = clampDim((pxH * oldW) / oldH);
+        }
+        syncInputs();
+    }
+
+    function setUnit(u: 'px' | '%') {
+        unit = u;
+        syncInputs();
+    }
+
+    function close() {
+        imageRescale.open = false;
+    }
+
+    function apply() {
+        const w = clampDim(pxW);
+        const h = clampDim(pxH);
+        app.handle?.rescale_image(w, h);
+        // New dims are known synchronously this JS turn — recenter the
+        // coordinate transforms before any pointer event reads them.
+        app.syncCanvasRect();
+        app.refreshLayerTree();
+        app.requestFrame();
+        close();
+    }
+
+    function onKeydown(e: KeyboardEvent) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            apply();
+        }
+    }
+</script>
+
+<Modal bind:open={imageRescale.open} title="Image Size" size="sm">
+    <div class="body" onkeydown={onKeydown} role="presentation">
+        <div class="unit-row">
+            <span class="label">Units</span>
+            <div class="unit-toggle">
+                <button type="button" class:active={unit === 'px'} onclick={() => setUnit('px')}>px</button>
+                <button type="button" class:active={unit === '%'} onclick={() => setUnit('%')}>%</button>
+            </div>
+        </div>
+
+        <div class="dim-row">
+            <label class="field">
+                <span class="label">Width</span>
+                <div class="num">
+                    <input
+                        type="number"
+                        min="1"
+                        max={unit === 'px' ? MAX_DIM : undefined}
+                        step={unit === 'px' ? 1 : 0.1}
+                        bind:value={wInput}
+                        oninput={onWidthInput}
+                    />
+                    <span class="unit">{unit}</span>
+                </div>
+            </label>
+            <label class="field">
+                <span class="label">Height</span>
+                <div class="num">
+                    <input
+                        type="number"
+                        min="1"
+                        max={unit === 'px' ? MAX_DIM : undefined}
+                        step={unit === 'px' ? 1 : 0.1}
+                        bind:value={hInput}
+                        oninput={onHeightInput}
+                    />
+                    <span class="unit">{unit}</span>
+                </div>
+            </label>
+            <button
+                type="button"
+                class="link-toggle"
+                class:active={linkAspect}
+                aria-pressed={linkAspect}
+                aria-label={linkAspect ? 'Unlock aspect ratio' : 'Lock aspect ratio'}
+                title={linkAspect ? 'Unlock aspect ratio' : 'Lock aspect ratio'}
+                onclick={() => (linkAspect = !linkAspect)}
+            >
+                <Icon name={linkAspect ? 'fa6-solid:link' : 'fa6-solid:link-slash'} />
+            </button>
+        </div>
+
+        <div class="actions">
+            <div class="dims-readout">{clampDim(pxW)} × {clampDim(pxH)} px</div>
+            <button type="button" class="cancel" onclick={close}>Cancel</button>
+            <button type="button" class="ok" onclick={apply}>Rescale</button>
+        </div>
+    </div>
+</Modal>
+
+<style>
+    .body {
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+        min-width: 320px;
+    }
+
+    .label {
+        font-size: 12px;
+        color: var(--text-muted);
+    }
+
+    .unit-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .unit-toggle {
+        display: inline-flex;
+        border: 1px solid var(--bg-hover);
+        border-radius: 6px;
+        overflow: hidden;
+    }
+
+    .unit-toggle button {
+        background: transparent;
+        border: none;
+        color: var(--text-muted);
+        padding: 4px 12px;
+        cursor: pointer;
+        font-size: 12px;
+    }
+
+    .unit-toggle button.active {
+        background: var(--accent, var(--bg-hover));
+        color: var(--text);
+    }
+
+    .dim-row {
+        display: flex;
+        align-items: flex-end;
+        gap: 12px;
+    }
+
+    .field {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        flex: 1;
+    }
+
+    .num {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        background: var(--bg);
+        border: 1px solid var(--bg-hover);
+        border-radius: 6px;
+        padding: 0 8px;
+    }
+
+    .num input {
+        flex: 1;
+        background: transparent;
+        border: none;
+        color: var(--text);
+        padding: 6px 0;
+        width: 100%;
+        font-size: 14px;
+    }
+
+    .num input:focus {
+        outline: none;
+    }
+
+    .num .unit {
+        color: var(--text-muted);
+        font-size: 12px;
+    }
+
+    .link-toggle {
+        background: transparent;
+        border: 1px solid var(--bg-hover);
+        border-radius: 6px;
+        color: var(--text-muted);
+        cursor: pointer;
+        height: 32px;
+        width: 32px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .link-toggle.active {
+        color: var(--text);
+        border-color: var(--accent, var(--text-muted));
+    }
+
+    .actions {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .dims-readout {
+        flex: 1;
+        font-size: 12px;
+        color: var(--text-muted);
+    }
+
+    .cancel,
+    .ok {
+        border: 1px solid var(--bg-hover);
+        border-radius: 6px;
+        padding: 7px 16px;
+        cursor: pointer;
+        font-size: 13px;
+    }
+
+    .cancel {
+        background: transparent;
+        color: var(--text-muted);
+    }
+
+    .ok {
+        background: var(--accent, var(--bg-hover));
+        color: var(--text);
+        border-color: transparent;
+    }
+</style>

--- a/frontend/wasm/src/api.rs
+++ b/frontend/wasm/src/api.rs
@@ -118,6 +118,12 @@ enum Command {
     },
     /// Crop the canvas window to the active selection's plane bounds.
     CropToSelection,
+    /// Image rescale ("Image Size"): resample all layer + mask content to new
+    /// document dimensions. Unlike `ResizeCanvasRect`, content is scaled.
+    RescaleImage {
+        w: u32,
+        h: u32,
+    },
 
     // Selection
     SelectRect {
@@ -254,6 +260,7 @@ fn drain_commands(commands: &RefCell<Vec<Command>>, engine: &mut DarklyEngine) {
                 engine.resize_canvas(rect);
             }
             Command::CropToSelection => engine.crop_to_selection(),
+            Command::RescaleImage { w, h } => engine.rescale_image(w, h),
             Command::FillBackground(id) => engine.fill_background(LayerId::from_ffi(id)),
             Command::FillBackgroundColor(id, c) => {
                 engine.fill_background_color(LayerId::from_ffi(id), c)
@@ -502,6 +509,7 @@ impl DarklySession {
                 doc_height,
             )),
             commands: RefCell::new(Vec::new()),
+            last_frame_count: std::cell::Cell::new(0.0),
         }
     }
 }
@@ -522,6 +530,15 @@ pub struct DarklyHandle {
     /// Unified command queue — all fire-and-forget mutations are queued here.
     /// Drained by [`render`] or [`flush_if_needed`].
     commands: RefCell<Vec<Command>>,
+    /// Borrow-free mirror of the engine's master frame counter. Refreshed
+    /// whenever [`frame_count`](Self::frame_count) successfully borrows the
+    /// engine; read back when it can't. The rAF loop calls `frame_count`
+    /// *before* `render`, and WebGPU event pumping can run that rAF callback
+    /// *inside* an outer `render`'s `borrow_mut` (see the re-entrancy note at
+    /// the top of this module) — so this read, like `render`, must tolerate a
+    /// busy engine instead of panicking. A one-frame-stale counter is harmless
+    /// (it only phase-locks throttle divisors).
+    last_frame_count: std::cell::Cell<f64>,
 }
 
 impl DarklyHandle {
@@ -666,6 +683,7 @@ impl DarklyHandle {
         DarklyHandle {
             engine: RefCell::new(DarklyEngine::new(gpu, doc_width, doc_height)),
             commands: RefCell::new(Vec::new()),
+            last_frame_count: std::cell::Cell::new(0.0),
         }
     }
 
@@ -1521,6 +1539,13 @@ impl DarklyHandle {
         self.push(Command::CropToSelection);
     }
 
+    /// Image rescale ("Image Size"): resample all layer + mask content to new
+    /// document dimensions `(w, h)`. The canvas origin stays; content is scaled
+    /// (lossy, undoable). Queued; applied on the next drain.
+    pub fn rescale_image(&self, w: u32, h: u32) {
+        self.push(Command::RescaleImage { w, h });
+    }
+
     /// Rename the document. Not undoable — matches every other editor's
     /// title-bar rename affordance. Subsequent saves write the new name
     /// into `manifest.name`.
@@ -2022,7 +2047,17 @@ impl DarklyHandle {
     /// `u64` directly — values up to 2^53 round-trip exactly, more than
     /// enough for ~3 million years at 60Hz.
     pub fn frame_count(&self) -> f64 {
-        self.engine.borrow().frame_count() as f64
+        // The rAF loop reads this *before* `render`, and WebGPU event pumping
+        // can run that rAF inside an outer `render`'s `borrow_mut` (module
+        // re-entrancy note) — so a plain `borrow()` here would panic exactly
+        // like a re-entrant `render` would without its `try_borrow_mut`. Fall
+        // back to the last-seen value when the engine is busy; refresh the
+        // mirror whenever we can. Stale-by-one-frame only nudges throttle
+        // divisor phase, never correctness.
+        if let Ok(engine) = self.engine.try_borrow() {
+            self.last_frame_count.set(engine.frame_count() as f64);
+        }
+        self.last_frame_count.get()
     }
 
     /// Engine-side thumbnail dimension used by the auto-queue path. The

--- a/shaders/rescale.wgsl
+++ b/shaders/rescale.wgsl
@@ -1,0 +1,101 @@
+// Image-rescale resampling.
+//
+// `fs_resample` maps each destination pixel back to a normalized position
+// inside the source's old canvas extent and bilinearly samples it — used for
+// upscaling and for the final (≤2x) downscale step. `fs_halve` box-reduces a
+// texture to half size; the engine chains it (a box pyramid) so large
+// reductions stay anti-aliased, then runs one `fs_resample` to the exact size.
+//
+// RGBA is resampled in premultiplied alpha (premultiply on load, un-premultiply
+// on store) so transparent texels don't bleed colour across edges — the same
+// discipline as transform_commit.wgsl. R8 masks are single-channel and straight.
+//
+// Samples are taken with `textureLoad` (no hardware sampler) so the premultiply
+// happens *before* the filter weights are applied.
+
+// Packed into vec4 rows for an unambiguous uniform layout (see the matching
+// Rust `Params`):
+//   p0 = [new_origin.xy,  canvas_origin.xy]
+//   p1 = [inv_scale.xy,   old_origin.xy]
+//   p2 = [old_size.xy,    is_r8, _pad]
+// new_origin:    canvas-space offset of the destination texture's (0,0) pixel.
+// canvas_origin: the rescale anchor (document scales about it).
+// inv_scale:     old_size / new_size — maps a dest canvas point back to source.
+// old_origin:    canvas-space offset of the source's old extent (0,0) pixel.
+// old_size:      source old-extent dimensions in canvas pixels.
+// is_r8:         0.0 = RGBA (premultiplied resample), 1.0 = R8 (straight).
+struct Params {
+    p0: vec4f,
+    p1: vec4f,
+    p2: vec4f,
+};
+
+@group(0) @binding(0) var t_src: texture_2d<f32>;
+@group(0) @binding(1) var<uniform> u: Params;
+
+struct VsOut { @builtin(position) pos: vec4f };
+
+@vertex
+fn vs_main(@builtin(vertex_index) idx: u32) -> VsOut {
+    // Fullscreen triangle.
+    let uv = vec2f(f32((idx << 1u) & 2u), f32(idx & 2u));
+    var out: VsOut;
+    out.pos = vec4f(uv * 2.0 - 1.0, 0.0, 1.0);
+    return out;
+}
+
+fn premul(c: vec4f) -> vec4f { return vec4f(c.rgb * c.a, c.a); }
+
+fn unpremul(c: vec4f) -> vec4f {
+    if (c.a <= 0.0) { return vec4f(0.0); }
+    return vec4f(c.rgb / c.a, c.a);
+}
+
+fn load_weighted(p: vec2i, dims: vec2i, is_r8: bool) -> vec4f {
+    let c = clamp(p, vec2i(0), dims - vec2i(1));
+    let texel = textureLoad(t_src, c, 0);
+    if (is_r8) { return texel; }
+    return premul(texel);
+}
+
+@fragment
+fn fs_resample(in: VsOut) -> @location(0) vec4f {
+    let new_origin = u.p0.xy;
+    let canvas_origin = u.p0.zw;
+    let inv_scale = u.p1.xy;
+    let old_origin = u.p1.zw;
+    let old_size = u.p2.xy;
+    let is_r8 = u.p2.z > 0.5;
+
+    let dims = vec2i(textureDimensions(t_src));
+    let c_new = new_origin + in.pos.xy;
+    let c_old = canvas_origin + (c_new - canvas_origin) * inv_scale;
+    let uv = (c_old - old_origin) / old_size;     // 0..1 within old extent
+    let texel = uv * vec2f(dims) - vec2f(0.5);        // bilinear sample center
+    let base = vec2i(floor(texel));
+    let f = texel - floor(texel);
+    let s00 = load_weighted(base + vec2i(0, 0), dims, is_r8);
+    let s10 = load_weighted(base + vec2i(1, 0), dims, is_r8);
+    let s01 = load_weighted(base + vec2i(0, 1), dims, is_r8);
+    let s11 = load_weighted(base + vec2i(1, 1), dims, is_r8);
+    let top = mix(s00, s10, f.x);
+    let bot = mix(s01, s11, f.x);
+    let p = mix(top, bot, f.y);
+    if (is_r8) { return p; }
+    return unpremul(p);
+}
+
+@fragment
+fn fs_halve(in: VsOut) -> @location(0) vec4f {
+    let is_r8 = u.p2.z > 0.5;
+    let dims = vec2i(textureDimensions(t_src));
+    let dst = vec2i(floor(in.pos.xy));
+    let src = dst * 2;
+    let s00 = load_weighted(src + vec2i(0, 0), dims, is_r8);
+    let s10 = load_weighted(src + vec2i(1, 0), dims, is_r8);
+    let s01 = load_weighted(src + vec2i(0, 1), dims, is_r8);
+    let s11 = load_weighted(src + vec2i(1, 1), dims, is_r8);
+    let p = (s00 + s10 + s01 + s11) * 0.25;
+    if (is_r8) { return p; }
+    return unpremul(p);
+}


### PR DESCRIPTION

<img width="500" alt="image" src="https://github.com/user-attachments/assets/b73d1dfb-f1d9-4d8f-8b28-f35089b19cb0" />

---

## Image rescale ("Image Size")

Adds content-scaling resize — resamples every layer and mask to new document
dimensions — alongside the existing canvas resize (which only moves the window).
Reachable via **Image ▸ Image Size…**.

### GPU resampling
- New `gpu/rescale.rs` (`RescalePass`) + `shaders/rescale.wgsl`. Premultiplied-alpha
  bilinear for upscale; a box pyramid (`fs_halve` chained until within 2× of the
  target, then one `fs_resample`) for downscale so large reductions stay
  anti-aliased. R8 masks resample straight; samples use `textureLoad` so the
  premultiply precedes the filter weights.
- `Compositor::rescale_nodes` resamples each node texture from its current extent
  to a new extent scaled about the canvas origin, then swaps it in.

### Undo across a texture extent change (the hard part)
- `region_store::restore_region` is split into reusable halves `capture_region` +
  `upload_region` (and kept as a thin combinator for the constant-extent callers).
- New `UndoAction::gpu_region_entries_mut` (default = the single existing entry;
  `CompoundAction` aggregates children) so one undo step can restore *every* node.
- `apply_undo` now loops over those entries and, when a node's GPU texture no
  longer matches its (just-swapped) document `PixelBuffer.bounds`, reallocates the
  texture to the doc bounds before uploading — the per-node analogue of the
  existing canvas-rect reconcile. Single-direction snapshots round-trip both ways.
- New `ImageRescaleAction` carries the dims + per-node bounds swap, the per-node
  pixel snapshots, and the folded selection clear (via a non-committing core
  extracted from `clear_selection`), so a rescale undoes in one step.

### Plumbing
- Engine `rescale_image` (`engine/image_rescale.rs`): enumerates pixel-bearing
  nodes by capability (`pixels().is_some()` — voids skipped), snapshots, resamples,
  mirrors new extents into the document, clears the selection, pushes one undo step.
- WASM `Command::RescaleImage` + `rescale_image(w, h)`.
- Frontend `ImageRescaleModal.svelte` (px ↔ % toggle, aspect-lock on by default),
  `imageRescale` state, `rescaleImage` action (`Image:11`), mounted in `App.svelte`.

### Shared/refactor + incidental fixes
- `resize_node_texture` refactored into `realloc_node_texture(…, copy_old)`; the
  bind-group-rebuild + blend-geometry-uniform refresh now live in one shared
  `swap_node_texture`. **This fixes a latent composite bug**: a node texture swap
  (resize/realloc/rescale) previously left the cached blend `layer_offset/size`
  stale, squashing content after an extent change.
- `Document::node_pixel_bounds` / `set_node_pixel_bounds` treat raster layers and
  modifiers uniformly.

### Tests
- New `tests/image_rescale.rs`: centroid scales on 2× and on 0.25× (two halvings);
  multi-region undo restores both of two layers; undo↔redo round-trips pixels
  across the extent change; mask scales with its host; rescale clears the active
  selection (undo restores it); a same-dims rescale pushes no undo step.

### README
- Flips `Image rescale` to `[x]` in Features & Roadmap.
