### PR TITLE
Clean up rust async architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,33 @@ jobs:
           targets: wasm32-unknown-unknown
       - run: cargo clippy -p darkly-wasm --target wasm32-unknown-unknown --all-targets -- -D warnings
 
+  engine-borrow-gate:
+    name: engine borrow gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: No raw RefCell<DarklyEngine> borrow outside EngineCell
+        run: |
+          # The engine reentrancy invariant: `EngineCell::with`
+          # (engine/host/cell.rs) is the *sole* sanctioned borrow of the engine
+          # — a try-acquire that yields instead of panicking. Any other
+          # `RefCell<DarklyEngine>` in production source is a raw borrow site
+          # that can poison the cell under the browser event-pump re-entrancy
+          # (commit 219a879). `engine/protocol/transport.rs`'s `try_drain` is
+          # allowed: it also try-borrows (yields instead of panicking) and is the
+          # one transport-side engine accessor. Doc-comment mentions are ignored.
+          violations=$(grep -rn --include='*.rs' 'RefCell<DarklyEngine>' \
+              crates/darkly/src frontend/wasm/src \
+            | grep -v 'engine/host/cell.rs' \
+            | grep -v 'engine/protocol/transport.rs' \
+            | grep -vE ':[0-9]+://' || true)
+          if [ -n "$violations" ]; then
+            echo "::error::Raw RefCell<DarklyEngine> borrow outside EngineCell (engine/host/cell.rs):"
+            echo "$violations"
+            exit 1
+          fi
+          echo "ok: EngineCell::with is the only engine borrow"
+
   test:
     name: cargo test + coverage
     runs-on: ubuntu-latest

--- a/crates/darkly/src/document/mod.rs
+++ b/crates/darkly/src/document/mod.rs
@@ -92,7 +92,7 @@ pub struct Document {
 
     /// Sticky "has unsaved changes" bit. Set at the [`UndoStack::push`]
     /// chokepoint — any new undoable mutation flips it true. Cleared
-    /// only by a successful save (`poll_save_result`) or a load
+    /// only by a successful save (`start_save_document`) or a load
     /// (`open_document` installs a fresh staging doc with `dirty = false`).
     /// Not undoable on purpose: an undo back to the original state
     /// shouldn't pretend the work was never done. Not serialized — the

--- a/crates/darkly/src/engine/clipboard.rs
+++ b/crates/darkly/src/engine/clipboard.rs
@@ -1,5 +1,7 @@
 //! Copy, cut, paste operations.
 
+use serde_json::Value;
+
 use super::rendering::commit_undo_region;
 use super::types::ClipboardExport;
 use super::{DarklyEngine, PendingCopy, ReadbackContext, RichCopyMask, RichCopyMetadata};
@@ -7,6 +9,7 @@ use crate::clipboard::{
     Clipboard, ClipboardRect, ImageClip, LayerClipboard, MaskClipboard,
     LAYER_CLIPBOARD_SCHEMA_VERSION,
 };
+use crate::engine::protocol::Response;
 use crate::gpu::blend_mode;
 use crate::gpu::paint_target::GpuPaintTarget;
 use crate::gpu::readback;
@@ -15,15 +18,19 @@ use crate::undo::{GpuRegionAction, LayerAddAction};
 
 impl DarklyEngine {
     /// Copy the active layer's content (masked by selection) into the internal
-    /// clipboard. Kicks off an async GPU readback — the result is available via
-    /// `poll_copy_result()` on the next frame. Returns `None` immediately.
-    pub fn copy(&mut self, layer_id: LayerId) -> Option<ClipboardExport> {
+    /// clipboard. Defers: the originating request's promise resolves with the
+    /// [`ClipboardExport`] once the async GPU readback lands (typically the next
+    /// frame). When there's nothing to copy, resolves immediately with `null`.
+    pub fn copy(&mut self, layer_id: LayerId) {
+        let request = self.current_request();
+
         // The copy target is any pixel-bearing node: a raster/void layer, or a
         // modifier (the active paint target when editing a mask is the mask
         // modifier id directly). `start_copy_readback` gates on the node's
         // texture, so a non-pixel target simply no-ops there.
         if self.doc.layer(layer_id).is_none() && !self.doc.is_modifier(layer_id) {
-            return None;
+            self.resolve_request(request, Response::json(Value::Null));
+            return;
         }
 
         if self.has_selection() && self.selection_cpu_cache().is_none() {
@@ -31,18 +38,12 @@ impl DarklyEngine {
             self.pending_copy = Some(PendingCopy {
                 layer_id,
                 is_cut: false,
+                request,
             });
-            return None;
+            return;
         }
 
-        self.start_copy_readback(layer_id, false);
-        None
-    }
-
-    /// Poll for a completed copy result. Returns the ClipboardExport once the
-    /// GPU readback has completed (typically the next frame after copy/cut).
-    pub fn poll_copy_result(&mut self) -> Option<ClipboardExport> {
-        self.pending_copy_result.take()
+        self.start_copy_readback(layer_id, false, request);
     }
 
     /// Start a GPU readback for copy (or cut).
@@ -55,7 +56,7 @@ impl DarklyEngine {
     ///
     /// Both extraction and erase use GPU float math on the same selection
     /// texture, guaranteeing `extracted + remaining == original`.
-    pub(crate) fn start_copy_readback(&mut self, layer_id: LayerId, is_cut: bool) {
+    pub(crate) fn start_copy_readback(&mut self, layer_id: LayerId, is_cut: bool, request: u64) {
         let canvas_w = self.doc.width;
         let canvas_h = self.doc.height;
 
@@ -64,27 +65,36 @@ impl DarklyEngine {
         // call. Caller's id alone selects the surface; format follows.
         let format = match self.compositor.node_texture(layer_id) {
             Some(t) => t.format(),
-            None => return,
+            // No GPU texture for this target — nothing to read back.
+            None => {
+                self.resolve_request(request, Response::json(Value::Null));
+                return;
+            }
         };
 
         // Compute copy region from selection bounds (or full canvas).
         let region = match self.copy_region_from_selection(canvas_w, canvas_h) {
             Some(r) => r,
             None => {
-                // Selection bounds unknown — defer.
-                self.pending_copy = Some(PendingCopy { layer_id, is_cut });
+                // Selection bounds unknown — defer until the cache populates.
+                self.pending_copy = Some(PendingCopy {
+                    layer_id,
+                    is_cut,
+                    request,
+                });
                 return;
             }
         };
         let [_, _, rw, rh] = region;
         if rw == 0 || rh == 0 {
+            self.resolve_request(request, Response::json(Value::Null));
             return;
         }
 
         if self.has_selection() {
-            self.copy_with_selection(layer_id, region, is_cut, format);
+            self.copy_with_selection(layer_id, region, is_cut, format, request);
         } else {
-            self.copy_without_selection(layer_id, region, is_cut, format);
+            self.copy_without_selection(layer_id, region, is_cut, format, request);
         }
     }
 
@@ -98,6 +108,7 @@ impl DarklyEngine {
         region: [u32; 4],
         is_cut: bool,
         format: wgpu::TextureFormat,
+        request: u64,
     ) {
         let [rx, ry, rw, rh] = region;
         // The copy `region` is window-local; layer reads operate in plane space,
@@ -225,7 +236,7 @@ impl DarklyEngine {
             }
 
             // 4. Kick async readback of the masked staging texture.
-            let request = readback::request_readback(
+            let readback_req = readback::request_readback(
                 &self.gpu.device,
                 encoder,
                 &staging_tex,
@@ -233,11 +244,12 @@ impl DarklyEngine {
                 crate::coord::LayerRect::from_xywh(0, 0, rw, rh),
             );
             self.readbacks.submit(
-                request,
+                readback_req,
                 ReadbackContext::Copy {
                     node_id: layer_id,
                     region,
                     is_cut,
+                    request,
                 },
             );
         });
@@ -268,6 +280,7 @@ impl DarklyEngine {
         region: [u32; 4],
         is_cut: bool,
         format: wgpu::TextureFormat,
+        request: u64,
     ) {
         let [rx, ry, rw, rh] = region;
         // `region` is the canvas window in window-local coords; lift it to plane
@@ -288,14 +301,15 @@ impl DarklyEngine {
         };
 
         self.gpu.encode("copy-readback", |encoder| {
-            let request =
+            let readback_req =
                 readback::request_readback(&self.gpu.device, encoder, texture, format, layer_rect);
             self.readbacks.submit(
-                request,
+                readback_req,
                 ReadbackContext::Copy {
                     node_id: layer_id,
                     region,
                     is_cut,
+                    request,
                 },
             );
         });
@@ -343,6 +357,7 @@ impl DarklyEngine {
         node_id: LayerId,
         region: [u32; 4],
         is_cut: bool,
+        request: u64,
         pixels: Vec<u8>,
     ) {
         let [rx, ry, rw, rh] = region;
@@ -378,18 +393,23 @@ impl DarklyEngine {
         let o = self.doc.canvas_origin;
         let clip = ImageClip::from_rgba(rw, rh, rgba, rx as i32 + o.x, ry as i32 + o.y);
         let (export_rgba, ew, eh, eox, eoy) = clip.to_rgba();
-        self.pending_copy_result = Some(ClipboardExport {
+        let export = ClipboardExport {
             rgba: export_rgba.to_vec(),
             width: ew,
             height: eh,
             offset_x: eox,
             offset_y: eoy,
-        });
+        };
+        let mut value = match serde_json::to_value(&export) {
+            Ok(v) => v,
+            Err(_) => Value::Null,
+        };
 
         // Promote to a `LayerClipboard` if `copy_layer_rich` captured the
         // source layer's metadata. The pixels we just received become the
         // base64 payload; everything else (blend mode, opacity, …) was
-        // snapshotted at copy time.
+        // snapshotted at copy time. The rich JSON folds into the same copy
+        // promise (a `rich` field on the response) — no second poll hop.
         if let Some(meta) = self.pending_rich_metadata.take() {
             use base64::{engine::general_purpose::STANDARD, Engine as _};
             let layer_clip = LayerClipboard {
@@ -418,37 +438,45 @@ impl DarklyEngine {
                     pixels_b64: String::new(),
                 }),
             };
-            self.pending_layer_clip = Some(layer_clip.to_json());
+            if let Value::Object(map) = &mut value {
+                map.insert("rich".to_string(), Value::String(layer_clip.to_json()));
+            }
             self.clipboard = Some(Clipboard::Layer(layer_clip));
         } else {
             self.clipboard = Some(Clipboard::ImageData(clip));
         }
 
         let _ = is_cut;
+        self.resolve_request(request, Response::json(value));
     }
 
     /// Cut = copy + clear. The clear happens on GPU during start_copy_readback.
-    /// Returns `None` immediately; result available via `poll_copy_result()`.
-    pub fn cut(&mut self, layer_id: LayerId) -> Option<ClipboardExport> {
+    /// Defers like [`Self::copy`]; the request resolves with the
+    /// [`ClipboardExport`] once the readback lands.
+    pub fn cut(&mut self, layer_id: LayerId) {
+        let request = self.current_request();
+
         // Accept a modifier id (mask edit target) as well as a layer — see
         // `copy`. The actual texture gate lives in `start_copy_readback`.
         if self.doc.layer(layer_id).is_none() && !self.doc.is_modifier(layer_id) {
-            return None;
+            self.resolve_request(request, Response::json(Value::Null));
+            return;
         }
         if !self.doc.is_node_editable(layer_id) {
-            return None;
+            self.resolve_request(request, Response::json(Value::Null));
+            return;
         }
 
         if self.has_selection() && self.selection_cpu_cache().is_none() {
             self.pending_copy = Some(PendingCopy {
                 layer_id,
                 is_cut: true,
+                request,
             });
-            return None;
+            return;
         }
 
-        self.start_copy_readback(layer_id, true);
-        None
+        self.start_copy_readback(layer_id, true, request);
     }
 
     /// Paste raw RGBA bytes as a new layer. Used for both internal and external
@@ -519,9 +547,10 @@ impl DarklyEngine {
     /// paste. Pixel bytes still flow through the existing async readback;
     /// the metadata is stitched in when `complete_copy` runs.
     ///
-    /// Returns `None` immediately. The result is available via
-    /// `poll_copy_rich_result()` once the readback lands (next frame).
-    pub fn copy_layer_rich(&mut self, layer_id: LayerId) -> Option<()> {
+    /// Defers like [`Self::copy`]; the request resolves once the readback
+    /// lands, with the [`ClipboardExport`] fields plus a `rich` field carrying
+    /// the JSON-serialised `LayerClipboard` (folded into the one promise).
+    pub fn copy_layer_rich(&mut self, layer_id: LayerId) {
         // Snapshot metadata up-front. Layers can mutate while the readback
         // is in flight; pinning at copy time matches user intent and keeps
         // the snapshot independent of whatever happens before completion.
@@ -559,30 +588,26 @@ impl DarklyEngine {
             // Mask modifier: copy pixels only, no rich metadata.
             _ if self.doc.is_modifier(layer_id) => None,
             // Groups / voids / unknown ids have no pixel-readback path here.
-            _ => return None,
+            _ => {
+                self.resolve_request(self.current_request(), Response::json(Value::Null));
+                return;
+            }
         };
+        let request = self.current_request();
         self.pending_rich_metadata = meta;
 
         // Reuse the standard copy path for the pixel readback. When
         // `complete_copy` runs and finds `pending_rich_metadata` populated,
-        // it builds the `LayerClipboard` JSON and stashes it on
-        // `pending_layer_clip`.
+        // it folds the `LayerClipboard` JSON into the copy promise's response.
         if self.has_selection() && self.selection_cpu_cache().is_none() {
             self.pending_copy = Some(PendingCopy {
                 layer_id,
                 is_cut: false,
+                request,
             });
-            return None;
+            return;
         }
-        self.start_copy_readback(layer_id, false);
-        None
-    }
-
-    /// Drain the most recent rich-copy result. Returns the JSON-serialised
-    /// `LayerClipboard` when the async readback has completed, otherwise
-    /// `None`. Mirrors `poll_copy_result`.
-    pub fn poll_copy_rich_result(&mut self) -> Option<String> {
-        self.pending_layer_clip.take()
+        self.start_copy_readback(layer_id, false, request);
     }
 
     /// Paste a `LayerClipboard` JSON envelope as a new layer. Restores the

--- a/crates/darkly/src/engine/clipboard.rs
+++ b/crates/darkly/src/engine/clipboard.rs
@@ -1,10 +1,14 @@
 //! Copy, cut, paste operations.
 
+use std::rc::Rc;
+
 use serde_json::Value;
 
+use super::host::cell::EngineCell;
+use super::host::executor::yield_now;
 use super::rendering::commit_undo_region;
 use super::types::ClipboardExport;
-use super::{DarklyEngine, PendingCopy, ReadbackContext, RichCopyMask, RichCopyMetadata};
+use super::{DarklyEngine, RichCopyMask, RichCopyMetadata};
 use crate::clipboard::{
     Clipboard, ClipboardRect, ImageClip, LayerClipboard, MaskClipboard,
     LAYER_CLIPBOARD_SCHEMA_VERSION,
@@ -12,41 +16,100 @@ use crate::clipboard::{
 use crate::engine::protocol::Response;
 use crate::gpu::blend_mode;
 use crate::gpu::paint_target::GpuPaintTarget;
-use crate::gpu::readback;
+use crate::gpu::readback::{self, ReadbackFuture};
 use crate::layer::{Layer, LayerId};
 use crate::undo::{GpuRegionAction, LayerAddAction};
 
+/// The pixel-readback half of a copy/cut, ready to await. Carries the kicked
+/// [`ReadbackFuture`] plus the `node_id` + `region` the completion needs.
+struct CopyReadback {
+    future: ReadbackFuture,
+    node_id: LayerId,
+    region: [u32; 4],
+}
+
+/// Run a copy/cut as a linear task: warm the selection cache if cold, kick the
+/// masked GPU readback, await the pixels, build the clipboard export. Each step
+/// is a scoped `cell.with_async` burst, so the engine is free across every
+/// `.await` (a readback can only land while the engine is free to be polled).
+async fn run_copy(cell: Rc<EngineCell>, layer_id: LayerId, is_cut: bool, request: u64) {
+    // 1. Warm the selection CPU cache if a selection is active but cold — the
+    //    copy region is derived from it. Kick the readback once, then await the
+    //    cache (filled by the sink scheduler's `SelectionReadback` handler when
+    //    a frame poll lands it).
+    let cold = cell
+        .with_async(|e| e.has_selection() && e.selection_cpu_cache().is_none())
+        .await;
+    if cold {
+        cell.with_async(|e| e.kick_selection_readback()).await;
+        loop {
+            if cell.with_async(|e| e.selection_cpu_cache().is_some()).await {
+                break;
+            }
+            yield_now().await;
+        }
+    }
+
+    // 2. Kick the masked copy readback. `None` means there was nothing to copy
+    //    (no texture, empty region) — the burst already resolved the request.
+    let Some(kicked) = cell
+        .with_async(|e| e.kick_copy_readback(layer_id, is_cut, request))
+        .await
+    else {
+        return;
+    };
+    let CopyReadback {
+        future,
+        node_id,
+        region,
+    } = kicked;
+
+    // 3. Await the pre-masked staging pixels. `None` means the handle was
+    //    disposed mid-flight (slot cancelled) — drop the task silently; teardown
+    //    already rejected the request.
+    let Some(pixels) = future.await else {
+        return;
+    };
+
+    // 4. Build the clipboard export and resolve the originating request.
+    cell.with_async(|e| e.complete_copy(node_id, region, is_cut, request, pixels))
+        .await;
+}
+
 impl DarklyEngine {
     /// Copy the active layer's content (masked by selection) into the internal
-    /// clipboard. Defers: the originating request's promise resolves with the
-    /// [`ClipboardExport`] once the async GPU readback lands (typically the next
-    /// frame). When there's nothing to copy, resolves immediately with `null`.
+    /// clipboard. Spawns a [`run_copy`] task; the originating request's promise
+    /// resolves with the [`ClipboardExport`] once the async GPU readback lands
+    /// (typically the next frame). When there's nothing to copy, resolves
+    /// immediately with `null`.
     pub fn copy(&mut self, layer_id: LayerId) {
         let request = self.current_request();
 
         // The copy target is any pixel-bearing node: a raster/void layer, or a
         // modifier (the active paint target when editing a mask is the mask
-        // modifier id directly). `start_copy_readback` gates on the node's
+        // modifier id directly). `kick_copy_readback` gates on the node's
         // texture, so a non-pixel target simply no-ops there.
         if self.doc.layer(layer_id).is_none() && !self.doc.is_modifier(layer_id) {
             self.resolve_request(request, Response::json(Value::Null));
             return;
         }
 
-        if self.has_selection() && self.selection_cpu_cache().is_none() {
-            // Selection cache not ready — defer until SelectionReadback completes.
-            self.pending_copy = Some(PendingCopy {
-                layer_id,
-                is_cut: false,
-                request,
-            });
-            return;
-        }
-
-        self.start_copy_readback(layer_id, false, request);
+        self.spawn_copy_task(layer_id, false, request);
     }
 
-    /// Start a GPU readback for copy (or cut).
+    /// Spawn the copy/cut task onto the host executor. The task warms the
+    /// selection cache (if cold), kicks the masked readback, awaits it, and
+    /// resolves `request` — see [`run_copy`].
+    fn spawn_copy_task(&mut self, layer_id: LayerId, is_cut: bool, request: u64) {
+        let cell = self.self_cell();
+        self.spawn(Some(request), run_copy(cell, layer_id, is_cut, request));
+    }
+
+    /// Kick a GPU readback for copy (or cut), returning a [`CopyReadback`] the
+    /// task awaits — or `None` (after resolving `request` with `null`) when
+    /// there is nothing to read back. By the time this runs the selection cache
+    /// is warm (the task ensured it), so [`copy_region_from_selection`] always
+    /// resolves.
     ///
     /// When a selection is active, masking is done entirely on GPU:
     /// 1. Copy the layer region to a staging texture
@@ -56,7 +119,12 @@ impl DarklyEngine {
     ///
     /// Both extraction and erase use GPU float math on the same selection
     /// texture, guaranteeing `extracted + remaining == original`.
-    pub(crate) fn start_copy_readback(&mut self, layer_id: LayerId, is_cut: bool, request: u64) {
+    fn kick_copy_readback(
+        &mut self,
+        layer_id: LayerId,
+        is_cut: bool,
+        request: u64,
+    ) -> Option<CopyReadback> {
         let canvas_w = self.doc.width;
         let canvas_h = self.doc.height;
 
@@ -68,48 +136,50 @@ impl DarklyEngine {
             // No GPU texture for this target — nothing to read back.
             None => {
                 self.resolve_request(request, Response::json(Value::Null));
-                return;
+                return None;
             }
         };
 
-        // Compute copy region from selection bounds (or full canvas).
-        let region = match self.copy_region_from_selection(canvas_w, canvas_h) {
-            Some(r) => r,
-            None => {
-                // Selection bounds unknown — defer until the cache populates.
-                self.pending_copy = Some(PendingCopy {
-                    layer_id,
-                    is_cut,
-                    request,
-                });
-                return;
-            }
-        };
+        // Compute copy region from selection bounds (or full canvas). The task
+        // warms the selection cache before calling, so the region always
+        // resolves here; `?` guards the unreachable cold-cache case.
+        let region = self.copy_region_from_selection(canvas_w, canvas_h)?;
         let [_, _, rw, rh] = region;
         if rw == 0 || rh == 0 {
             self.resolve_request(request, Response::json(Value::Null));
-            return;
+            return None;
         }
 
-        if self.has_selection() {
-            self.copy_with_selection(layer_id, region, is_cut, format, request);
+        let future = if self.has_selection() {
+            self.copy_with_selection(layer_id, region, is_cut, format)
         } else {
-            self.copy_without_selection(layer_id, region, is_cut, format, request);
-        }
+            self.copy_without_selection(layer_id, region, is_cut, format)
+        };
+        // No readback encoded (layer disjoint from the region) → nothing to copy.
+        let Some(future) = future else {
+            self.resolve_request(request, Response::json(Value::Null));
+            return None;
+        };
+        Some(CopyReadback {
+            future,
+            node_id: layer_id,
+            region,
+        })
     }
 
     /// Copy/cut path when a selection is active: mask the layer region by the
     /// selection entirely on GPU, then async-read the pre-masked staging
     /// texture. On cut, the same selection texture erases the layer in place,
-    /// guaranteeing `extracted + remaining == original`.
+    /// guaranteeing `extracted + remaining == original`. Returns the awaitable
+    /// readback of the masked staging texture (always `Some` — a staging texture
+    /// is always created for the selected region).
     fn copy_with_selection(
         &mut self,
         layer_id: LayerId,
         region: [u32; 4],
         is_cut: bool,
         format: wgpu::TextureFormat,
-        request: u64,
-    ) {
+    ) -> Option<ReadbackFuture> {
         let [rx, ry, rw, rh] = region;
         // The copy `region` is window-local; layer reads operate in plane space,
         // so they lift it by `canvas_origin` (identity for an un-cropped doc).
@@ -180,7 +250,7 @@ impl DarklyEngine {
             .expect("has_selection true → selection_state allocated")
             .selection_bind_group();
 
-        self.gpu.encode("copy-gpu-extract", |encoder| {
+        let readback_req = self.gpu.encode_ret("copy-gpu-extract", |encoder| {
             // 1. Copy the layer's covered portion of the selected region into
             //    the staging texture. Clear first so any part of the region the
             //    layer does NOT cover stays transparent (else the masked
@@ -235,23 +305,15 @@ impl DarklyEngine {
                 );
             }
 
-            // 4. Kick async readback of the masked staging texture.
-            let readback_req = readback::request_readback(
+            // 4. Encode the readback of the masked staging texture; the task
+            //    awaits the returned future.
+            readback::request_readback(
                 &self.gpu.device,
                 encoder,
                 &staging_tex,
                 format,
                 crate::coord::LayerRect::from_xywh(0, 0, rw, rh),
-            );
-            self.readbacks.submit(
-                readback_req,
-                ReadbackContext::Copy {
-                    node_id: layer_id,
-                    region,
-                    is_cut,
-                    request,
-                },
-            );
+            )
         });
 
         // Commit undo for cut.
@@ -269,19 +331,23 @@ impl DarklyEngine {
             self.push_undo(Box::new(GpuRegionAction::new(entry)));
             self.compositor.mark_node_pixels_dirty(layer_id);
         }
+
+        // Submit the awaitable readback once the cut undo's borrow of
+        // `target_frame` has ended (it borrows the compositor).
+        Some(self.await_readback(readback_req))
     }
 
     /// Copy/cut path with no selection: read the layer's covered portion of the
     /// requested region straight back, no masking. On cut, clear the whole
-    /// layer (which handles its own undo).
+    /// layer (which handles its own undo). Returns `None` when the layer is
+    /// disjoint from the requested region (nothing to read back).
     fn copy_without_selection(
         &mut self,
         layer_id: LayerId,
         region: [u32; 4],
         is_cut: bool,
         format: wgpu::TextureFormat,
-        request: u64,
-    ) {
+    ) -> Option<ReadbackFuture> {
         let [rx, ry, rw, rh] = region;
         // `region` is the canvas window in window-local coords; lift it to plane
         // (`+ canvas_origin`), then translate to the layer texture's own texel
@@ -296,28 +362,21 @@ impl DarklyEngine {
                 .to_canvas(self.doc.canvas_origin);
             match layer_tex.canvas_to_layer_rect(region_plane) {
                 Some(lr) => (layer_tex.texture(), lr),
-                None => return,
+                None => return None,
             }
         };
 
-        self.gpu.encode("copy-readback", |encoder| {
-            let readback_req =
-                readback::request_readback(&self.gpu.device, encoder, texture, format, layer_rect);
-            self.readbacks.submit(
-                readback_req,
-                ReadbackContext::Copy {
-                    node_id: layer_id,
-                    region,
-                    is_cut,
-                    request,
-                },
-            );
+        let readback_req = self.gpu.encode_ret("copy-readback", |encoder| {
+            readback::request_readback(&self.gpu.device, encoder, texture, format, layer_rect)
         });
+        let future = self.await_readback(readback_req);
 
         if is_cut {
             // gpu_clear_layer handles its own undo save/commit.
             self.gpu_clear_layer(layer_id);
         }
+
+        Some(future)
     }
 
     /// Determine the copy region from the selection (or full canvas).
@@ -450,14 +509,14 @@ impl DarklyEngine {
         self.resolve_request(request, Response::json(value));
     }
 
-    /// Cut = copy + clear. The clear happens on GPU during start_copy_readback.
+    /// Cut = copy + clear. The clear happens on GPU during the readback kick.
     /// Defers like [`Self::copy`]; the request resolves with the
     /// [`ClipboardExport`] once the readback lands.
     pub fn cut(&mut self, layer_id: LayerId) {
         let request = self.current_request();
 
         // Accept a modifier id (mask edit target) as well as a layer — see
-        // `copy`. The actual texture gate lives in `start_copy_readback`.
+        // `copy`. The actual texture gate lives in `kick_copy_readback`.
         if self.doc.layer(layer_id).is_none() && !self.doc.is_modifier(layer_id) {
             self.resolve_request(request, Response::json(Value::Null));
             return;
@@ -467,16 +526,7 @@ impl DarklyEngine {
             return;
         }
 
-        if self.has_selection() && self.selection_cpu_cache().is_none() {
-            self.pending_copy = Some(PendingCopy {
-                layer_id,
-                is_cut: true,
-                request,
-            });
-            return;
-        }
-
-        self.start_copy_readback(layer_id, true, request);
+        self.spawn_copy_task(layer_id, true, request);
     }
 
     /// Paste raw RGBA bytes as a new layer. Used for both internal and external
@@ -599,15 +649,7 @@ impl DarklyEngine {
         // Reuse the standard copy path for the pixel readback. When
         // `complete_copy` runs and finds `pending_rich_metadata` populated,
         // it folds the `LayerClipboard` JSON into the copy promise's response.
-        if self.has_selection() && self.selection_cpu_cache().is_none() {
-            self.pending_copy = Some(PendingCopy {
-                layer_id,
-                is_cut: false,
-                request,
-            });
-            return;
-        }
-        self.start_copy_readback(layer_id, false, request);
+        self.spawn_copy_task(layer_id, false, request);
     }
 
     /// Paste a `LayerClipboard` JSON envelope as a new layer. Restores the

--- a/crates/darkly/src/engine/export.rs
+++ b/crates/darkly/src/engine/export.rs
@@ -4,24 +4,23 @@
 //! bytes for the JS side to encode via `OffscreenCanvas`.
 
 use super::{DarklyEngine, ReadbackContext};
+use crate::engine::protocol::Response;
 use crate::gpu::readback;
 
-/// Completed export readback — drained by `poll_export_result`.
-pub struct ExportImageResult {
-    pub width: u32,
-    pub height: u32,
-    pub rgba: Vec<u8>,
-}
-
 impl DarklyEngine {
-    /// Start an async readback of the full composited canvas. Returns
-    /// immediately; the result lands on `pending_export_result` once the
-    /// readback completes (typically the next frame).
+    /// Start an async readback of the full composited canvas. Defers: the
+    /// originating request's promise resolves with `{ width, height }` plus the
+    /// RGBA8 bytes side-channel once the readback completes (typically the next
+    /// frame). The JS side encodes the bytes via `OffscreenCanvas`.
     pub fn start_export(&mut self) {
+        let request = self.current_request();
+
         if self
             .readbacks
             .any(|c| matches!(c, ReadbackContext::ExportImage { .. }))
         {
+            // An export is already in flight — nothing new to read back.
+            self.resolve_request(request, Response::json(serde_json::Value::Null));
             return;
         }
 
@@ -39,30 +38,28 @@ impl DarklyEngine {
         let texture = self.compositor.composited_texture();
 
         self.gpu.encode("export-readback", |encoder| {
-            let request = readback::request_readback(
+            let req = readback::request_readback(
                 &self.gpu.device,
                 encoder,
                 texture,
                 wgpu::TextureFormat::Rgba8Unorm,
                 crate::coord::LayerRect::from_xywh(0, 0, width, height),
             );
-            self.readbacks
-                .submit(request, ReadbackContext::ExportImage { width, height });
+            self.readbacks.submit(
+                req,
+                ReadbackContext::ExportImage {
+                    width,
+                    height,
+                    request,
+                },
+            );
         });
     }
 
-    /// Drain the most recent export result. Returns `None` until the
-    /// async readback completes (next frame after `start_export`).
-    pub fn poll_export_result(&mut self) -> Option<ExportImageResult> {
-        self.pending_export_result.take()
-    }
-
-    /// Stash a completed export readback. Called by `handle_completed_readback`.
-    pub(crate) fn complete_export(&mut self, width: u32, height: u32, rgba: Vec<u8>) {
-        self.pending_export_result = Some(ExportImageResult {
-            width,
-            height,
-            rgba,
-        });
+    /// Resolve the export request with the completed readback bytes. Called by
+    /// `handle_completed_readback`.
+    pub(crate) fn complete_export(&mut self, width: u32, height: u32, request: u64, rgba: Vec<u8>) {
+        let value = serde_json::json!({ "width": width, "height": height });
+        self.resolve_request(request, Response::binary(value, rgba));
     }
 }

--- a/crates/darkly/src/engine/host/cell.rs
+++ b/crates/darkly/src/engine/host/cell.rs
@@ -1,0 +1,77 @@
+//! [`EngineCell`] — the sole sanctioned engine borrow.
+//!
+//! The whole engine is one actor cell: a `RefCell<DarklyEngine>` exposed *only*
+//! through a scoped accessor that hands out `&mut DarklyEngine` for the duration
+//! of a synchronous closure and never returns a guard. Two invariants fall out
+//! of that shape, and they are the reason this type exists:
+//!
+//! - **No held guard ⇒ no borrow across `.await`.** A caller cannot stash the
+//!   `&mut` and suspend; the borrow is released when the closure returns, before
+//!   any `.await` in the surrounding task. This makes the borrow-across-await
+//!   deadlock (a task holding the engine while the frame loop's `device.poll`
+//!   needs it) *structurally unrepresentable*.
+//! - **Try-acquire, never panic.** [`with`](EngineCell::with) uses
+//!   `try_borrow_mut` and yields `None` on contention instead of panicking. The
+//!   re-entrancy eruption (`queue.submit` pumping the browser event queue while a
+//!   borrow is held, commit `219a879`) becomes a yield, not a poisoned cell.
+//!
+//! A CI grep gate enforces that this is the *only* place the engine cell is
+//! borrowed — any raw `.borrow()` / `.borrow_mut()` on a `RefCell<DarklyEngine>`
+//! outside this file fails the build.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::engine::DarklyEngine;
+
+/// One actor cell wrapping the whole engine. Tasks hold a cheap `Rc<EngineCell>`
+/// clone; every engine access goes through [`with`](Self::with).
+pub struct EngineCell(RefCell<DarklyEngine>);
+
+impl EngineCell {
+    /// Wrap an engine. Returns an `Rc` so tasks (and the engine's own
+    /// `self_cell` back-reference) can share it.
+    pub fn new(engine: DarklyEngine) -> Rc<Self> {
+        Rc::new(EngineCell(RefCell::new(engine)))
+    }
+
+    /// Run `f` with exclusive access to the engine for the duration of the
+    /// closure. Returns `Some(f(...))`, or `None` if the engine is already
+    /// borrowed (the re-entrancy yield). The borrow is released when `f`
+    /// returns — you cannot carry it across an `.await`.
+    pub fn with<R>(&self, f: impl FnOnce(&mut DarklyEngine) -> R) -> Option<R> {
+        self.0.try_borrow_mut().ok().map(|mut e| f(&mut e))
+    }
+
+    /// Async variant of [`with`](Self::with): if the engine is busy, yield and
+    /// retry on the next executor tick rather than skipping the burst. The
+    /// task-facing combinator — keeps a migrated op's body a linear sequence of
+    /// `cell.with_async(|e| …).await` bursts that each observe the engine even
+    /// across a transient re-entrant borrow. `FnOnce` (the closure runs at most
+    /// once, only on the attempt that wins the borrow), so a burst can move
+    /// owned data — e.g. readback pixels — into the engine.
+    pub async fn with_async<R>(self: &Rc<Self>, f: impl FnOnce(&mut DarklyEngine) -> R) -> R {
+        let mut f = Some(f);
+        loop {
+            if let Ok(mut e) = self.0.try_borrow_mut() {
+                let f = f.take().expect("with_async closure runs exactly once");
+                return f(&mut e);
+            }
+            super::executor::yield_now().await;
+        }
+    }
+
+    /// Try to reclaim the wrapped engine, consuming the cell. Succeeds only when
+    /// this is the last `Rc` — i.e. every task that captured a clone has been
+    /// dropped. Used by teardown (and tests) to recover the engine.
+    pub fn into_engine(self: Rc<Self>) -> Result<DarklyEngine, Rc<Self>> {
+        Rc::try_unwrap(self).map(|cell| cell.0.into_inner())
+    }
+
+    /// `true` if more than one `Rc<EngineCell>` is alive — i.e. at least one
+    /// task still holds a strong reference. Teardown asserts this is `false`
+    /// after the executor's task list is dropped.
+    pub fn has_outstanding_tasks(self: &Rc<Self>) -> bool {
+        Rc::strong_count(self) > 1
+    }
+}

--- a/crates/darkly/src/engine/host/executor.rs
+++ b/crates/darkly/src/engine/host/executor.rs
@@ -1,0 +1,162 @@
+//! Frame-driven, single-threaded task executor — dependency-free.
+//!
+//! A migrated multi-step GPU op is an ordinary `async` block that re-acquires
+//! the engine between `.await`s (each acquire is an [`EngineCell::with`] burst).
+//! This executor runs those blocks. It is deliberately *not* a reactor:
+//!
+//! - **No-op waker.** Progress is frame-driven — a readback completes because a
+//!   frame called `device.poll`, not because anything woke a task. So every task
+//!   is polled once per [`tick`](Executor::tick) with a hand-rolled no-op
+//!   `RawWaker`; there is no wake plumbing to get wrong.
+//! - **No external runtime.** No `futures` / `async-task` /
+//!   `wasm-bindgen-futures` dependency; the whole thing is a `Vec<Task>` and a
+//!   poll loop.
+//!
+//! Each [`Task`] carries the originating protocol `request` id (when it has one)
+//! so teardown can reject the right promise before dropping the task.
+//!
+//! [`EngineCell::with`]: super::cell::EngineCell::with
+
+use std::cell::RefCell;
+use std::future::Future;
+use std::pin::Pin;
+use std::ptr;
+use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+/// One in-flight op. `future` re-acquires the engine via captured
+/// `Rc<EngineCell>` bursts; `request` is the protocol id to reject on teardown
+/// (`None` for fire-and-forget tasks with no promise to settle).
+pub struct Task {
+    pub request: Option<u64>,
+    pub future: Pin<Box<dyn Future<Output = ()>>>,
+}
+
+impl Task {
+    pub fn new(request: Option<u64>, future: impl Future<Output = ()> + 'static) -> Self {
+        Task {
+            request,
+            future: Box::pin(future),
+        }
+    }
+
+    /// The protocol id this task ultimately resolves, if any.
+    pub fn request(&self) -> Option<u64> {
+        self.request
+    }
+}
+
+/// The task list. Interior-mutable (`RefCell`) so the host's `tick`/`pump` —
+/// and a re-entrant call reached through the event pump — can drive it through a
+/// shared `&self`. A re-entrant `tick` `try_borrow`s and yields rather than
+/// double-borrowing.
+pub struct Executor {
+    tasks: RefCell<Vec<Task>>,
+}
+
+impl Default for Executor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Executor {
+    pub fn new() -> Self {
+        Executor {
+            tasks: RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Enqueue a task. Polled starting on the next [`tick`](Self::tick).
+    pub fn spawn(&self, task: Task) {
+        self.tasks.borrow_mut().push(task);
+    }
+
+    /// Poll every task once. Completed tasks are dropped. Returns `true` if any
+    /// task completed this tick (a progress signal the host uses to decide
+    /// whether to re-poll readbacks within the same frame).
+    ///
+    /// Re-entrant safety: if the task list is already borrowed (this `tick` was
+    /// reached re-entrantly through a task's `queue.submit` event pump), yields
+    /// `false` instead of panicking. Polling a task can re-enter — the borrow is
+    /// held across `future.poll`, so the nested `tick` must not take it again.
+    pub fn tick(&self) -> bool {
+        let Ok(mut tasks) = self.tasks.try_borrow_mut() else {
+            return false;
+        };
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut completed = false;
+        let mut i = 0;
+        while i < tasks.len() {
+            match tasks[i].future.as_mut().poll(&mut cx) {
+                Poll::Ready(()) => {
+                    tasks.swap_remove(i);
+                    completed = true;
+                    // Don't increment — swap_remove moved the last task here.
+                }
+                Poll::Pending => i += 1,
+            }
+        }
+        completed
+    }
+
+    /// `true` if any task is still in flight. Drives the host's `needsMore`
+    /// keepalive — without it a frame loop with a deferred op mid-flight could
+    /// sleep before the op finishes.
+    pub fn has_pending_tasks(&self) -> bool {
+        !self.tasks.borrow().is_empty()
+    }
+
+    /// Drain every task, returning the protocol ids that were still in flight so
+    /// teardown can reject their promises. Dropping the tasks releases the
+    /// `Rc<EngineCell>` clones each captured — mandatory, or a disposed handle's
+    /// engine (and its GPU resources) leaks behind the still-living tasks.
+    pub fn drain_pending_requests(&self) -> Vec<u64> {
+        self.tasks
+            .borrow_mut()
+            .drain(..)
+            .filter_map(|t| t.request)
+            .collect()
+    }
+}
+
+/// A future that yields exactly once (Pending on first poll, Ready after). With
+/// the no-op waker the executor re-polls every tick, so this is "give other
+/// tasks a turn / retry next tick" — used by [`with_async`] when the engine is
+/// transiently busy.
+///
+/// [`with_async`]: super::cell::EngineCell::with_async
+pub fn yield_now() -> YieldNow {
+    YieldNow { yielded: false }
+}
+
+pub struct YieldNow {
+    yielded: bool,
+}
+
+impl Future for YieldNow {
+    type Output = ();
+    fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
+        if self.yielded {
+            Poll::Ready(())
+        } else {
+            self.yielded = true;
+            Poll::Pending
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// No-op waker — progress is frame-driven, so waking is a no-op.
+// ---------------------------------------------------------------------------
+
+fn noop_waker() -> Waker {
+    fn no_op(_: *const ()) {}
+    fn clone(_: *const ()) -> RawWaker {
+        RawWaker::new(ptr::null(), &VTABLE)
+    }
+    static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, no_op, no_op, no_op);
+    // SAFETY: the vtable's clone/wake/drop are all no-ops over a null data
+    // pointer that is never dereferenced — the canonical no-op waker.
+    unsafe { Waker::from_raw(RawWaker::new(ptr::null(), &VTABLE)) }
+}

--- a/crates/darkly/src/engine/host/mod.rs
+++ b/crates/darkly/src/engine/host/mod.rs
@@ -1,0 +1,315 @@
+//! [`EngineHost`] — the inverted frame loop that unifies request transport and
+//! readback completion under one frame-driven executor.
+//!
+//! The architectural unlock: `render`/composite is **one scheduled burst among
+//! many**, not the outer borrow everything nests inside. The host wraps
+//! `(EngineCell, Executor)`; every burst acquires the engine through the scoped
+//! [`EngineCell::with`] and releases it before any `.await`, so a deferred op
+//! (copy / cut / …) is an ordinary `async` block that re-acquires the engine
+//! between readback `.await`s instead of a `pending_*` field + a central resume
+//! `match`.
+//!
+//! Two entry points mirror the two TS drain triggers so request latency is
+//! preserved:
+//!
+//! - [`tick`](EngineHost::tick) — the **frame** path (rAF). Full orchestration
+//!   including composite.
+//! - [`pump`](EngineHost::pump) — the **macrotask** path (`MessageChannel`).
+//!   Drains + drives tasks but skips composite, so simple requests resolve
+//!   sub-frame rather than ~16 ms later.
+//!
+//! ## Injected drain/image closures
+//!
+//! The request transport and the `OffscreenCanvas` image side-FIFO live
+//! bridge-side, not in the host, so `tick`/`pump` take them as closures
+//! (`apply_images`, `drain`) rather than owning them. A backend that holds those
+//! in the core instead can pass thin closures over its own state; the
+//! orchestration (drain → drive tasks → composite) is identical regardless.
+
+pub mod cell;
+pub mod executor;
+
+use std::rc::Rc;
+
+use cell::EngineCell;
+use executor::Executor;
+
+use crate::engine::protocol::RequestOutcome;
+use crate::engine::DarklyEngine;
+use crate::gpu::context::GpuContext;
+
+/// Cap on the in-frame readback re-poll in [`drive_tasks`](EngineHost::drive_tasks).
+/// A chain of already-landed readbacks drains in one frame instead of one stage
+/// per frame; newly-*kicked* readbacks still land next frame (a kicked readback
+/// isn't ready the same frame regardless).
+const MAX_REPOLL: u32 = 4;
+
+/// Result of a [`tick`](EngineHost::tick). Mirrors the TS `{ busy, needsMore,
+/// results }` contract the rAF loop consumes; the bridge layers `state` on top
+/// from a scoped read.
+pub struct FrameOutcome {
+    /// The engine was already borrowed (re-entrant frame reached through the
+    /// event pump). Nothing ran — the caller must not reschedule.
+    pub busy: bool,
+    /// Animations, in-flight readbacks, or in-flight tasks need another frame.
+    pub needs_more: bool,
+    /// Terminal outcomes for requests dispatched (or resolved) this frame.
+    pub outcomes: Vec<RequestOutcome>,
+}
+
+impl FrameOutcome {
+    fn busy() -> Self {
+        FrameOutcome {
+            busy: true,
+            needs_more: false,
+            outcomes: Vec::new(),
+        }
+    }
+}
+
+/// Result of a [`pump`](EngineHost::pump) — the macrotask path. No composite, so
+/// no `needsMore`.
+pub struct PumpOutcome {
+    pub busy: bool,
+    pub outcomes: Vec<RequestOutcome>,
+}
+
+/// Wraps the engine cell and the frame-driven executor. `&self` throughout: the
+/// executor is interior-mutable and the cell is try-acquired, so the host needs
+/// no outer `RefCell` and a re-entrant call yields instead of panicking.
+pub struct EngineHost {
+    cell: Rc<EngineCell>,
+    executor: Executor,
+}
+
+impl EngineHost {
+    /// Build a fresh engine and wrap it. The same entry for browser, Tauri, and
+    /// headless tests.
+    pub fn new(gpu: GpuContext, doc_width: u32, doc_height: u32) -> Self {
+        Self::adopt(DarklyEngine::new(gpu, doc_width, doc_height))
+    }
+
+    /// Build a fresh engine sharing a `DarklySession`-owned tool session, then
+    /// wrap it (the multi-tab path).
+    pub fn new_with_tool_session(
+        gpu: GpuContext,
+        tool_session: crate::tool::SharedToolSession,
+        doc_width: u32,
+        doc_height: u32,
+    ) -> Self {
+        Self::adopt(DarklyEngine::new_with_tool_session(
+            gpu,
+            tool_session,
+            doc_width,
+            doc_height,
+        ))
+    }
+
+    /// Wrap an already-constructed engine and wire its `self_cell`
+    /// back-reference so deferring handlers can build futures that re-acquire
+    /// the engine between awaits.
+    pub fn adopt(engine: DarklyEngine) -> Self {
+        let cell = EngineCell::new(engine);
+        let weak = Rc::downgrade(&cell);
+        cell.with(|e| e.set_self_cell(weak))
+            .expect("freshly-built cell is not borrowed");
+        EngineHost {
+            cell,
+            executor: Executor::new(),
+        }
+    }
+
+    /// The engine cell — for scoped reads the host doesn't orchestrate (e.g. the
+    /// bridge reading `engine_state` after a tick).
+    pub fn cell(&self) -> &Rc<EngineCell> {
+        &self.cell
+    }
+
+    /// Move any handler-spawned tasks from the engine's `pending_spawns` into the
+    /// executor. Run after every dispatch burst and after each task tick (a task
+    /// could, in principle, spawn another).
+    fn collect_spawns(&self) {
+        if let Some(spawns) = self.cell.with(|e| e.take_pending_spawns()) {
+            for task in spawns {
+                self.executor.spawn(task);
+            }
+        }
+    }
+
+    /// Drive in-flight tasks: poll readbacks (fill slots) **before** ticking the
+    /// executor so a slot landing this frame is observed this frame, with a
+    /// bounded re-poll so a chain of already-landed readbacks drains in one
+    /// frame. The executor tick happens outside any cell borrow — each task
+    /// self-acquires per burst.
+    fn drive_tasks(&self) {
+        for _ in 0..MAX_REPOLL {
+            self.collect_spawns();
+            let harvested = self.cell.with(|e| e.poll_readbacks()).unwrap_or(false);
+            let progressed = self.executor.tick();
+            self.collect_spawns();
+            if !harvested && !progressed {
+                break;
+            }
+        }
+    }
+
+    /// The **frame** path (rAF). Drains the FIFO, drives tasks, composites, and
+    /// collects terminal outcomes — each step a scoped burst released before the
+    /// next; `.await`s happen only inside the executor's tasks, between bursts.
+    pub fn tick(
+        &self,
+        time_secs: f32,
+        apply_images: impl FnOnce(&mut DarklyEngine),
+        drain: impl FnOnce(&mut DarklyEngine) -> Vec<RequestOutcome>,
+    ) -> FrameOutcome {
+        // Apply pending image uploads, then drain the FIFO and dispatch handlers
+        // (a deferring handler spawns a task) — one burst.
+        let Some(mut outcomes) = self.cell.with(|e| {
+            apply_images(e);
+            drain(e)
+        }) else {
+            return FrameOutcome::busy();
+        };
+
+        // Move spawned tasks into the executor and drive them between bursts.
+        self.drive_tasks();
+
+        // Composite. `render` also polls the sink scheduler / diff-rect /
+        // content-bounds and returns the animation keepalive; OR in the executor
+        // so a deferred op in flight keeps frames coming (see
+        // `DarklyEngine::render`).
+        let needs_more = self.cell.with(|e| e.render(time_secs)).unwrap_or(false)
+            || self.executor.has_pending_tasks();
+
+        // A task may have resolved its request during drive_tasks or the render
+        // poll — flush terminal outcomes for the JS id→promise table.
+        if let Some(completed) = self.cell.with(|e| e.take_completed_requests()) {
+            outcomes.extend(completed);
+        }
+
+        FrameOutcome {
+            busy: false,
+            needs_more,
+            outcomes,
+        }
+    }
+
+    /// The **macrotask** path (`MessageChannel`). Same as [`tick`](Self::tick)
+    /// minus the composite, so simple requests resolve sub-frame and a deferred
+    /// task can still progress between frames. Armed at pointer frequency, so it
+    /// early-outs cheaply when idle (the readback poll only calls `device.poll`
+    /// when a scheduler has work, and an empty-executor tick is O(0)).
+    pub fn pump(
+        &self,
+        apply_images: impl FnOnce(&mut DarklyEngine),
+        drain: impl FnOnce(&mut DarklyEngine) -> Vec<RequestOutcome>,
+    ) -> PumpOutcome {
+        let Some(mut outcomes) = self.cell.with(|e| {
+            apply_images(e);
+            drain(e)
+        }) else {
+            return PumpOutcome {
+                busy: true,
+                outcomes: Vec::new(),
+            };
+        };
+
+        self.drive_tasks();
+
+        if let Some(completed) = self.cell.with(|e| e.take_completed_requests()) {
+            outcomes.extend(completed);
+        }
+
+        PumpOutcome {
+            busy: false,
+            outcomes,
+        }
+    }
+
+    /// Tear down the host: cancel every in-flight readback slot, reject every
+    /// still-pending task's request so no JS promise dangles, flush the terminal
+    /// outcomes one last time, then **drop** the executor's task list. The drop
+    /// is mandatory — each task captured an `Rc<EngineCell>`, so a task left
+    /// alive keeps the engine (and its GPU resources) alive past dispose.
+    /// Returns the final outcomes (the rejections) for the caller to flush to the
+    /// promise table.
+    pub fn dispose(&self) -> Vec<RequestOutcome> {
+        // `drain_pending_requests` empties the executor — dropping every task
+        // releases the `Rc<EngineCell>` clones each captured, so the engine is no
+        // longer kept alive behind them.
+        let mut pending_ids = self.executor.drain_pending_requests();
+        self.cell
+            .with(|e| {
+                // A task enqueued this dispatch but not yet moved into the
+                // executor still sits in `pending_spawns` — drain and reject it
+                // too, dropping the task (and its cell clone).
+                for task in e.take_pending_spawns() {
+                    if let Some(id) = task.request() {
+                        pending_ids.push(id);
+                    }
+                }
+                e.cancel_async_readbacks();
+                for id in pending_ids {
+                    e.reject_request(
+                        id,
+                        crate::engine::protocol::ProtocolError::engine("handle disposed"),
+                    );
+                }
+                e.take_completed_requests()
+            })
+            .unwrap_or_default()
+    }
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    /// Scoped engine access for test setup/inspection. Panics on contention
+    /// (tests are single-threaded with no live frame), unlike the production
+    /// try-acquire paths.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn with<R>(&self, f: impl FnOnce(&mut DarklyEngine) -> R) -> R {
+        self.cell
+            .with(f)
+            .expect("test host engine should not be borrowed")
+    }
+
+    /// Drive tasks + readbacks to quiescence (blocking `device.poll(Wait)` so
+    /// native readbacks land deterministically). Test stand-in for the rAF loop
+    /// flushing a deferred op to completion.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn pump_until_idle(&self) {
+        for _ in 0..256 {
+            self.collect_spawns();
+            let harvested = self.with(|e| e.test_poll_readbacks_blocking());
+            let progressed = self.executor.tick();
+            self.collect_spawns();
+            // The sink scheduler / diff-rect can also gate a task indirectly
+            // (cold selection cache lands via the sink path); run a render poll
+            // so those advance too.
+            self.with(|e| {
+                e.render(0.0);
+            });
+            let idle =
+                !self.executor.has_pending_tasks() && self.with(|e| !e.has_pending_readbacks());
+            if idle && !harvested && !progressed {
+                break;
+            }
+        }
+    }
+
+    /// `true` if any executor task is still in flight. Test-only.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn has_pending_tasks(&self) -> bool {
+        self.executor.has_pending_tasks()
+    }
+
+    /// Recover the engine, asserting no task still holds the cell. Test-only —
+    /// lets a test resume direct `&mut engine` use after a deferred op.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn into_engine(self) -> DarklyEngine {
+        self.cell
+            .into_engine()
+            .unwrap_or_else(|_| panic!("a task still holds the engine cell"))
+    }
+}

--- a/crates/darkly/src/engine/layers.rs
+++ b/crates/darkly/src/engine/layers.rs
@@ -750,7 +750,7 @@ impl DarklyEngine {
 
     /// True when the document has unsaved changes. Set sticky at the
     /// [`crate::undo::UndoStack::push`] chokepoint; cleared on a
-    /// successful save (`poll_save_result`) or load (`open_document`
+    /// successful save (`start_save_document`) or load (`open_document`
     /// installs a fresh `dirty = false` doc). UI close-tab and
     /// `beforeunload` flows consult this to decide whether to prompt.
     pub fn is_dirty(&self) -> bool {

--- a/crates/darkly/src/engine/mod.rs
+++ b/crates/darkly/src/engine/mod.rs
@@ -25,7 +25,6 @@ mod undo_dispatch;
 mod veils;
 mod voids;
 
-pub use export::ExportImageResult;
 pub use load::LoadDocument;
 pub use rendering::{PickSource, DEFAULT_THUMB_SIZE};
 pub use save::{SaveError, SaveJob, SavePurpose, SaveReadbackKind};
@@ -92,9 +91,12 @@ pub(crate) struct PendingAdjustment {
 }
 
 /// Deferred copy/cut — waiting for selection CPU cache to be populated.
+/// `request` is the originating protocol request id; it travels through the
+/// resume so the copy's promise resolves when the readback finally lands.
 pub(crate) struct PendingCopy {
     pub layer_id: LayerId,
     pub is_cut: bool,
+    pub request: u64,
 }
 
 /// Layer metadata snapshot captured at `copy_layer_rich` time. Combined with
@@ -148,6 +150,10 @@ pub(crate) enum ReadbackContext {
         node_id: LayerId,
         region: [u32; 4],
         is_cut: bool,
+        /// Originating copy/cut request id — resolved with the
+        /// `ClipboardExport` (plus rich-layer JSON for `copy_layer_rich`) when
+        /// the masked staging readback lands.
+        request: u64,
     },
     MagicWand {
         was_active: bool,
@@ -161,17 +167,18 @@ pub(crate) enum ReadbackContext {
     /// Async readback of the selection GPU texture for CPU cache update.
     SelectionReadback,
     /// Async readback of the full composited canvas for image export
-    /// (PNG/JPEG/WebP). Result lands on `pending_export_result` and is
-    /// drained by `poll_export_result`.
+    /// (PNG/JPEG/WebP). On completion resolves the originating `request` with
+    /// `{ width, height }` + the RGBA8 bytes side-channel.
     ExportImage {
         width: u32,
         height: u32,
+        request: u64,
     },
     /// Async readback for `.darkly` save flow. One readback per pixel-bearing
     /// entity (raster layer, mask, selection) plus one for the composite.
     /// The destination (blob path or composite slot) is encoded in `kind`;
     /// on completion, `complete_save_readback` routes the pixels accordingly.
-    /// When every blob lands, `poll_save_result` hands back a `SaveBundle`.
+    /// When every blob lands, the save request resolves with the `SaveBundle`.
     SaveDocument {
         kind: save::SaveReadbackKind,
         /// Source texture dimensions in pixels — readback rows come back
@@ -495,26 +502,32 @@ pub struct DarklyEngine {
 
     // --- Async readback ---
     pub(crate) readbacks: ReadbackScheduler<ReadbackContext>,
-    /// Completed copy result — picked up by the frontend on the next poll.
-    pub(crate) pending_copy_result: Option<ClipboardExport>,
     /// Metadata snapshot captured at `copy_layer_rich` time. When the async
     /// pixel readback completes, this snapshot is combined with the pixels
-    /// to build a `LayerClipboard` and stash it in `pending_layer_clip`.
+    /// to build a `LayerClipboard` folded into the copy promise's response.
     pub(crate) pending_rich_metadata: Option<RichCopyMetadata>,
-    /// Completed rich-copy result, ready for the frontend to drain. Holds
-    /// the JSON-serialised `LayerClipboard` for transmission via the
-    /// system clipboard's `web application/x-darkly-layer` custom MIME.
-    pub(crate) pending_layer_clip: Option<String>,
     /// Last picked color — returned immediately while async readback is in flight.
     pub(crate) last_picked_color: [u8; 4],
-    /// Completed image-export result — drained by `poll_export_result()`.
-    pub(crate) pending_export_result: Option<ExportImageResult>,
-    /// Active save job — populated by `start_save_document`, drained by
-    /// `poll_save_result` once every pixel blob and the composite have
-    /// landed. Only one save can be in flight per engine; a second
-    /// `start_save_document` while this is `Some` errors with
-    /// [`SaveError::InProgress`].
+    /// Active save job — populated by `start_save_document`, finished by
+    /// `complete_save_readback` once every pixel blob and the composite have
+    /// landed (which resolves the originating save request). Only one save can
+    /// be in flight per engine; a second `start_save_document` while this is
+    /// `Some` errors with [`SaveError::InProgress`].
     pub(crate) active_save_job: Option<SaveJob>,
+
+    // --- Deferred request resolution ---
+    /// The protocol request id currently being dispatched. Set by
+    /// [`crate::engine::protocol::Transport::drain_with`] before each handler
+    /// runs; read by the one-shot readback ops (copy / cut / export / save) via
+    /// [`Self::current_request`] so they can stash it in their readback context
+    /// and resolve the right promise when the readback lands. `0` outside of a
+    /// dispatch (and the default in direct test calls).
+    pub(crate) current_request_id: u64,
+    /// Terminal outcomes for deferred requests whose async readback has landed
+    /// (or which resolved immediately because there was nothing to read back).
+    /// Drained by `drain_with` and after `render`, then merged into the
+    /// outcomes the transport hands back to the JS id→promise table.
+    pub(crate) completed_requests: Vec<protocol::RequestOutcome>,
     pub(crate) thumbnail_cache: ThumbnailCache,
     /// Monotonic counter bumped each time a thumbnail readback lands in
     /// the cache. Mirrored to a Svelte-reactive epoch in the frontend so
@@ -649,12 +662,11 @@ impl DarklyEngine {
             pending_adjustment: None,
             pending_copy: None,
             readbacks: ReadbackScheduler::new(),
-            pending_copy_result: None,
             pending_rich_metadata: None,
-            pending_layer_clip: None,
             last_picked_color: [0, 0, 0, 0],
-            pending_export_result: None,
             active_save_job: None,
+            current_request_id: 0,
+            completed_requests: Vec::new(),
             thumbnail_cache: ThumbnailCache::new(),
             thumbnail_version: 0,
             layer_growth_capped: false,
@@ -686,6 +698,58 @@ impl DarklyEngine {
         );
 
         engine
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Deferred request resolution
+// ---------------------------------------------------------------------------
+//
+// One-shot GPU readback ops (copy / cut / export / save) can't return their
+// result in the same FFI call — the bytes land a frame later. Instead of a
+// separate `poll_*` request, the op stashes the originating request id and
+// pushes the terminal outcome onto `completed_requests` when the readback
+// lands; the transport merges that into the outcomes it hands the JS
+// id→promise table, so the request that kicked the readback is the request
+// that resolves with the result.
+
+impl DarklyEngine {
+    /// Record the request id the transport is about to dispatch. Read by a
+    /// deferring op via [`Self::current_request`].
+    pub(crate) fn set_current_request(&mut self, id: u64) {
+        self.current_request_id = id;
+    }
+
+    /// The request id currently being dispatched. A deferring op captures this
+    /// into its readback context so completion resolves the right promise.
+    pub(crate) fn current_request(&self) -> u64 {
+        self.current_request_id
+    }
+
+    /// Resolve a deferred request with its result. Pushed onto the outbound
+    /// queue and flushed by the next `drain_with` / post-`render` step.
+    pub(crate) fn resolve_request(&mut self, id: u64, response: protocol::Response) {
+        self.completed_requests.push(protocol::RequestOutcome {
+            id,
+            result: Ok(response),
+        });
+    }
+
+    /// Reject a deferred request — the readback failed or the op found nothing
+    /// to do and chose to surface that as a rejection. Exactly one terminal
+    /// outcome (resolve or reject) per deferred request is guaranteed.
+    #[allow(dead_code)]
+    pub(crate) fn reject_request(&mut self, id: u64, err: protocol::ProtocolError) {
+        self.completed_requests.push(protocol::RequestOutcome {
+            id,
+            result: Err(err),
+        });
+    }
+
+    /// Drain the outbound completion queue. Called by the transport's
+    /// `drain_with` and by the WASM `render` after compositing.
+    pub fn take_completed_requests(&mut self) -> Vec<protocol::RequestOutcome> {
+        std::mem::take(&mut self.completed_requests)
     }
 }
 
@@ -1135,6 +1199,38 @@ impl DarklyEngine {
         brush.topology_version = brush.topology_version.wrapping_add(1);
     }
 
+    /// Set the request id a directly-called deferring op (copy / export / …)
+    /// will stash. Production code goes through the transport, which sets this
+    /// per dispatch; direct test callers set it explicitly so they can fetch
+    /// the resolved outcome by id via [`Self::test_drive_completed`].
+    #[cfg(any(test, feature = "testing"))]
+    pub fn test_set_request_id(&mut self, id: u64) {
+        self.current_request_id = id;
+    }
+
+    /// Remove and return the already-landed terminal response for deferred
+    /// request `id`, without driving any readbacks. `None` if it hasn't
+    /// resolved yet (or rejected).
+    #[cfg(any(test, feature = "testing"))]
+    pub fn test_take_completed(&mut self, id: u64) -> Option<protocol::Response> {
+        let pos = self.completed_requests.iter().position(|o| o.id == id)?;
+        self.completed_requests.remove(pos).result.ok()
+    }
+
+    /// Drive pending readbacks to completion and return the terminal response
+    /// for the deferred request `id`, or `None` if it never resolves. Test
+    /// stand-in for the frame loop that flushes `completed_requests`.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn test_drive_completed(&mut self, id: u64) -> Option<protocol::Response> {
+        for _ in 0..32 {
+            self.test_flush_readbacks();
+            if let Some(resp) = self.test_take_completed(id) {
+                return Some(resp);
+            }
+        }
+        None
+    }
+
     /// Block until all pending async readbacks complete. For tests only.
     /// Uses `device.poll(Wait)` to ensure mapping callbacks fire, then
     /// dispatches every completed readback through the shared handler —
@@ -1148,19 +1244,6 @@ impl DarklyEngine {
         for (ctx, pixels) in completed {
             self.handle_completed_readback(ctx, pixels);
         }
-    }
-
-    /// Block on the GPU device only — fire map callbacks — WITHOUT
-    /// polling or dispatching the readback scheduler. On native this
-    /// stands in for the browser event loop that resolves buffer
-    /// mappings on web. For tests that must verify another code path
-    /// (e.g. `poll_save_result`) does the scheduler drain itself.
-    #[cfg(test)]
-    pub fn test_wait_gpu(&mut self) {
-        let _ = self.gpu.device.poll(wgpu::PollType::Wait {
-            submission_index: None,
-            timeout: None,
-        });
     }
 }
 

--- a/crates/darkly/src/engine/mod.rs
+++ b/crates/darkly/src/engine/mod.rs
@@ -9,6 +9,7 @@ mod duplicate;
 mod export;
 mod flatten;
 mod floating;
+pub mod host;
 mod image_rescale;
 mod layer_flip;
 mod layers;
@@ -48,12 +49,14 @@ use crate::brush::stroke_engine::StrokeEngine;
 use crate::brush::wire::BrushWireType;
 use crate::clipboard::Clipboard;
 use crate::document::Document;
+use crate::engine::host::cell::EngineCell;
+use crate::engine::host::executor::Task;
 use crate::gpu::compositor::Compositor;
 use crate::gpu::context::GpuContext;
 use crate::gpu::diff_rect::DiffRectPass;
 use crate::gpu::overlay::OverlayPrimitive;
 use crate::gpu::paint_target::PaintPipelines;
-use crate::gpu::readback::ReadbackScheduler;
+use crate::gpu::readback::{ReadbackScheduler, ReadbackSlot};
 use crate::gpu::region_store::{EntryPixels, RegionScratch};
 use crate::gpu::selection::SelectionPipelines;
 use crate::gpu::transform::FloatingContent;
@@ -62,7 +65,9 @@ use crate::gpu::view::{ViewParams, ViewTransform};
 use crate::gpu::void_preview::VoidPreviewRenderer;
 use crate::layer::LayerId;
 use crate::undo::UndoStack;
+use std::cell::RefCell;
 use std::collections::HashMap;
+use std::rc::{Rc, Weak};
 
 // ---------------------------------------------------------------------------
 // Internal helper types
@@ -88,15 +93,6 @@ pub(crate) struct PendingFlip {
 pub(crate) struct PendingAdjustment {
     pub node_id: LayerId,
     pub adjustment_type: String,
-}
-
-/// Deferred copy/cut — waiting for selection CPU cache to be populated.
-/// `request` is the originating protocol request id; it travels through the
-/// resume so the copy's promise resolves when the readback finally lands.
-pub(crate) struct PendingCopy {
-    pub layer_id: LayerId,
-    pub is_cut: bool,
-    pub request: u64,
 }
 
 /// Layer metadata snapshot captured at `copy_layer_rich` time. Combined with
@@ -146,15 +142,6 @@ pub(crate) enum ReadbackContext {
         extent: crate::gpu::flood_fill::LayerFloodFillExtent,
     },
     ColorPick,
-    Copy {
-        node_id: LayerId,
-        region: [u32; 4],
-        is_cut: bool,
-        /// Originating copy/cut request id — resolved with the
-        /// `ClipboardExport` (plus rich-layer JSON for `copy_layer_rich`) when
-        /// the masked staging readback lands.
-        request: u64,
-    },
     MagicWand {
         was_active: bool,
         node_id: LayerId,
@@ -497,11 +484,27 @@ pub struct DarklyEngine {
     pub(crate) pending_flip: Option<PendingFlip>,
     /// Pending destructive adjustment waiting for the selection CPU cache.
     pub(crate) pending_adjustment: Option<PendingAdjustment>,
-    /// Pending copy/cut waiting for selection CPU cache.
-    pub(crate) pending_copy: Option<PendingCopy>,
 
     // --- Async readback ---
     pub(crate) readbacks: ReadbackScheduler<ReadbackContext>,
+    /// Completion-slot scheduler for *awaitable* readbacks: a deferred op's task
+    /// `.await`s a [`ReadbackFuture`] whose slot this scheduler fills on harvest,
+    /// rather than routing the completion through the central
+    /// `handle_completed_readback` match the sink [`readbacks`](Self::readbacks)
+    /// scheduler uses. Both share the engine's one `device.poll`; see
+    /// [`poll_readbacks`](Self::poll_readbacks).
+    ///
+    /// [`ReadbackFuture`]: crate::gpu::readback::ReadbackFuture
+    pub(crate) async_readbacks: ReadbackScheduler<Rc<RefCell<ReadbackSlot>>>,
+    /// Weak back-reference to this engine's own [`EngineCell`], set once at
+    /// host construction. A deferring handler upgrades it to build a future that
+    /// re-acquires the engine between awaits. `Weak` so it doesn't form a cycle
+    /// with the cell that owns the engine.
+    pub(crate) self_cell: Weak<EngineCell>,
+    /// Tasks a handler spawned this dispatch, awaiting transfer into the host's
+    /// executor after the dispatch burst (the host can't push directly — it
+    /// doesn't hold the engine during dispatch).
+    pub(crate) pending_spawns: Vec<Task>,
     /// Metadata snapshot captured at `copy_layer_rich` time. When the async
     /// pixel readback completes, this snapshot is combined with the pixels
     /// to build a `LayerClipboard` folded into the copy promise's response.
@@ -660,8 +663,10 @@ impl DarklyEngine {
             pending_transform: None,
             pending_flip: None,
             pending_adjustment: None,
-            pending_copy: None,
             readbacks: ReadbackScheduler::new(),
+            async_readbacks: ReadbackScheduler::new(),
+            self_cell: Weak::new(),
+            pending_spawns: Vec::new(),
             pending_rich_metadata: None,
             last_picked_color: [0, 0, 0, 0],
             active_save_job: None,
@@ -750,6 +755,133 @@ impl DarklyEngine {
     /// `drain_with` and by the WASM `render` after compositing.
     pub fn take_completed_requests(&mut self) -> Vec<protocol::RequestOutcome> {
         std::mem::take(&mut self.completed_requests)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host integration — self-cell back-reference, task spawning, awaitable
+// readbacks (engine/host/*).
+// ---------------------------------------------------------------------------
+//
+// A deferring handler builds a linear `async` block that re-acquires the engine
+// between readback `.await`s. To do that it needs a handle to its own
+// `EngineCell` (`self_cell`, wired once by the host at construction) and a way
+// to enqueue the block (`spawn`, drained by the host into its executor after the
+// dispatch burst). The awaited readbacks land in `async_readbacks`, a completion
+// slot the future polls — see `crate::gpu::readback::ReadbackFuture`.
+
+impl DarklyEngine {
+    /// Wire the back-reference to this engine's own cell. Called once by
+    /// `EngineHost::adopt`.
+    pub(crate) fn set_self_cell(&mut self, cell: Weak<EngineCell>) {
+        self.self_cell = cell;
+    }
+
+    /// An `Rc<EngineCell>` clone for a deferring handler to capture into the
+    /// task it builds. Panics if called before the host wired `self_cell` — a
+    /// deferring handler can only run under a host.
+    pub(crate) fn self_cell(&self) -> Rc<EngineCell> {
+        self.self_cell
+            .upgrade()
+            .expect("self_cell not wired — deferring op requires an EngineHost")
+    }
+
+    /// Enqueue a task that runs on the host's frame-driven executor. `request`
+    /// is the protocol id the task ultimately resolves (so teardown can reject
+    /// it). Pushed onto `pending_spawns`; the host moves it into the executor
+    /// after the dispatch burst returns.
+    pub(crate) fn spawn(
+        &mut self,
+        request: Option<u64>,
+        future: impl std::future::Future<Output = ()> + 'static,
+    ) {
+        self.pending_spawns.push(Task::new(request, future));
+    }
+
+    /// Take the tasks spawned this dispatch for transfer into the executor.
+    pub(crate) fn take_pending_spawns(&mut self) -> Vec<Task> {
+        std::mem::take(&mut self.pending_spawns)
+    }
+
+    /// Submit an awaitable readback. Returns a [`ReadbackFuture`] a task can
+    /// `.await`; the engine fills its slot when the readback lands in
+    /// [`poll_readbacks`](Self::poll_readbacks).
+    ///
+    /// [`ReadbackFuture`]: crate::gpu::readback::ReadbackFuture
+    pub(crate) fn await_readback(
+        &mut self,
+        request: crate::gpu::readback::ReadbackRequest,
+    ) -> crate::gpu::readback::ReadbackFuture {
+        let slot = Rc::new(RefCell::new(ReadbackSlot::Pending));
+        self.async_readbacks.submit(request, slot.clone());
+        crate::gpu::readback::ReadbackFuture::new(slot)
+    }
+
+    /// Drive **both** readback schedulers off one `device.poll`, then harvest
+    /// each: sink completions dispatch through `handle_completed_readback`, async
+    /// completions fill their awaiting task's slot. Returns `true` if anything
+    /// landed. The single per-frame readback poll for the whole engine — the
+    /// host calls this; `render` calls it too (direct callers / the composite
+    /// frame).
+    pub(crate) fn poll_readbacks(&mut self) -> bool {
+        self.drive_and_harvest_readbacks(false)
+    }
+
+    /// Shared body of [`poll_readbacks`](Self::poll_readbacks). `wait = true`
+    /// uses a blocking `device.poll(Wait)` (test driver only, native — see
+    /// CLAUDE.md "No Blocking GPU Readbacks"); production passes `false` (Poll).
+    fn drive_and_harvest_readbacks(&mut self, wait: bool) -> bool {
+        self.readbacks.begin_pending();
+        self.async_readbacks.begin_pending();
+
+        if self.readbacks.has_pending() || self.async_readbacks.has_pending() {
+            let poll_type = if wait {
+                wgpu::PollType::Wait {
+                    submission_index: None,
+                    timeout: None,
+                }
+            } else {
+                wgpu::PollType::Poll
+            };
+            let _ = self.gpu.device.poll(poll_type);
+        }
+
+        // Sink completions — dispatch through the shared handler.
+        let sink = self.readbacks.harvest();
+        let sink_landed = !sink.is_empty();
+        for (ctx, pixels) in sink {
+            self.handle_completed_readback(ctx, pixels);
+        }
+
+        // Async completions — fill the awaiting task's slot.
+        let async_done = self.async_readbacks.harvest();
+        let async_landed = !async_done.is_empty();
+        for (slot, pixels) in async_done {
+            *slot.borrow_mut() = ReadbackSlot::Ready(pixels);
+        }
+
+        sink_landed || async_landed
+    }
+
+    /// `true` if either readback scheduler has work in flight. Folds into the
+    /// host's `needsMore` keepalive alongside the executor's pending tasks.
+    pub(crate) fn has_pending_readbacks(&self) -> bool {
+        self.readbacks.has_pending() || self.async_readbacks.has_pending()
+    }
+
+    /// Cancel every in-flight awaitable readback, resolving each waiting task's
+    /// future to `None`. Called on host teardown so a task awaiting a disposed
+    /// handle unwinds instead of hanging.
+    pub(crate) fn cancel_async_readbacks(&mut self) {
+        for slot in self.async_readbacks.drain() {
+            *slot.borrow_mut() = ReadbackSlot::Cancelled;
+        }
+    }
+
+    /// Blocking unified readback flush for the test host's `pump_until_idle`.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn test_poll_readbacks_blocking(&mut self) -> bool {
+        self.drive_and_harvest_readbacks(true)
     }
 }
 

--- a/crates/darkly/src/engine/protocol/handlers/clipboard.rs
+++ b/crates/darkly/src/engine/protocol/handlers/clipboard.rs
@@ -1,9 +1,9 @@
 //! Copy / cut / paste, including rich (metadata-bearing) layer clipboard.
 
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::json;
 
-use crate::engine::protocol::{bad_payload, decode, layer_id, RequestRegistration, Response};
+use crate::engine::protocol::{decode, layer_id, RequestRegistration, Response};
 use crate::layer::LayerId;
 
 /// `active_layer_id` follows the f64 negative-means-none FFI convention.
@@ -11,53 +11,30 @@ fn active(id: i64) -> Option<LayerId> {
     (id >= 0).then(|| LayerId::from_ffi(id as u64))
 }
 
-fn export_value(
-    export: Option<crate::engine::ClipboardExport>,
-) -> Result<Value, crate::engine::protocol::ProtocolError> {
-    match export {
-        Some(e) => serde_json::to_value(&e).map_err(bad_payload),
-        None => Ok(Value::Null),
-    }
-}
-
 pub fn registrations() -> Vec<RequestRegistration> {
     vec![
+        // Copy / cut / rich-copy defer: the request's promise resolves with the
+        // `ClipboardExport` (plus a `rich` field for `copy_layer_rich`) once the
+        // async GPU readback lands — no separate `poll_*` round-trip.
         RequestRegistration {
             kind: "copy",
             handle: |engine, payload, _b| {
-                let export = engine.copy(layer_id(payload)?);
-                Ok(Response::json(export_value(export)?))
+                engine.copy(layer_id(payload)?);
+                Ok(Response::deferred())
             },
         },
         RequestRegistration {
             kind: "cut",
             handle: |engine, payload, _b| {
-                let export = engine.cut(layer_id(payload)?);
-                Ok(Response::json(export_value(export)?))
-            },
-        },
-        RequestRegistration {
-            kind: "poll_copy_result",
-            handle: |engine, _payload, _b| {
-                let export = engine.poll_copy_result();
-                Ok(Response::json(export_value(export)?))
+                engine.cut(layer_id(payload)?);
+                Ok(Response::deferred())
             },
         },
         RequestRegistration {
             kind: "copy_layer_rich",
             handle: |engine, payload, _b| {
                 engine.copy_layer_rich(layer_id(payload)?);
-                Ok(Response::empty())
-            },
-        },
-        RequestRegistration {
-            kind: "poll_copy_rich_result",
-            handle: |engine, _payload, _b| {
-                let value = match engine.poll_copy_rich_result() {
-                    Some(s) => Value::String(s),
-                    None => Value::Null,
-                };
-                Ok(Response::json(value))
+                Ok(Response::deferred())
             },
         },
         RequestRegistration {

--- a/crates/darkly/src/engine/protocol/handlers/image_io.rs
+++ b/crates/darkly/src/engine/protocol/handlers/image_io.rs
@@ -1,11 +1,13 @@
 //! Image export (PNG/JPEG/WebP readback) and native `.darkly` save / open.
 //!
-//! Multi-blob outputs (`poll_save_result`) concatenate every byte buffer into
-//! the single [`Response`] `bytes` side-channel; the JSON value carries the
-//! lengths so the JS edge can slice them back out in order.
+//! `start_export` and `start_save_document` defer: each resolves its own
+//! request's promise once the async GPU readback(s) land. The save result is a
+//! multi-blob binary payload — every byte buffer concatenated into the single
+//! [`Response`] `bytes` side-channel with the lengths in the JSON value
+//! (packed by `engine::save::pack_save_bundle`), so the JS edge can slice them
+//! back out in order.
 
 use serde::Deserialize;
-use serde_json::json;
 
 use crate::engine::protocol::{bad_payload, ProtocolError, RequestRegistration, Response};
 use crate::engine::SavePurpose;
@@ -16,17 +18,7 @@ pub fn registrations() -> Vec<RequestRegistration> {
             kind: "start_export",
             handle: |engine, _payload, _b| {
                 engine.start_export();
-                Ok(Response::empty())
-            },
-        },
-        RequestRegistration {
-            kind: "poll_export_result",
-            handle: |engine, _payload, _b| {
-                let Some(result) = engine.poll_export_result() else {
-                    return Ok(Response::json(serde_json::Value::Null));
-                };
-                let value = json!({ "width": result.width, "height": result.height });
-                Ok(Response::binary(value, result.rgba))
+                Ok(Response::deferred())
             },
         },
         RequestRegistration {
@@ -47,37 +39,10 @@ pub fn registrations() -> Vec<RequestRegistration> {
                     SavePurpose::File
                 };
                 match engine.start_save_document(purpose) {
-                    Ok(()) => Ok(Response::empty()),
+                    // The bundle resolves this request when every readback lands.
+                    Ok(()) => Ok(Response::deferred()),
                     Err(e) => Err(ProtocolError::engine(e.to_string())),
                 }
-            },
-        },
-        RequestRegistration {
-            kind: "poll_save_result",
-            handle: |engine, _payload, _b| {
-                let Some(bundle) = engine.poll_save_result() else {
-                    return Ok(Response::json(serde_json::Value::Null));
-                };
-                // Pack: manifest ++ composite ++ blob0 ++ blob1 ++ ...
-                let mut bytes = Vec::new();
-                bytes.extend_from_slice(&bundle.manifest_json);
-                bytes.extend_from_slice(&bundle.composite_rgba);
-                let blobs: Vec<serde_json::Value> = bundle
-                    .blobs
-                    .iter()
-                    .map(|b| {
-                        bytes.extend_from_slice(&b.bytes);
-                        json!({ "path": b.path, "len": b.bytes.len() })
-                    })
-                    .collect();
-                let value = json!({
-                    "manifestLen": bundle.manifest_json.len(),
-                    "compositeWidth": bundle.composite_width,
-                    "compositeHeight": bundle.composite_height,
-                    "compositeLen": bundle.composite_rgba.len(),
-                    "blobs": blobs,
-                });
-                Ok(Response::binary(value, bytes))
             },
         },
         RequestRegistration {

--- a/crates/darkly/src/engine/protocol/mod.rs
+++ b/crates/darkly/src/engine/protocol/mod.rs
@@ -44,12 +44,25 @@ pub use crate::gpu::params::param_values_from_json as params_from_json;
 pub struct Response {
     pub value: Value,
     pub bytes: Option<Vec<u8>>,
+    /// When `true`, the handler kicked an async GPU readback instead of
+    /// producing a result inline: the transport emits **no** outcome for the
+    /// request this drain, and the engine pushes the request's terminal
+    /// outcome onto its `completed_requests` queue once the readback lands (or
+    /// fails). The `value`/`bytes` of a deferred response are ignored. Used by
+    /// the one-shot readback ops (copy / cut / export / save) so the request
+    /// that kicked the readback is the request that resolves with its result —
+    /// no separate `poll_*` round-trip.
+    pub deferred: bool,
 }
 
 impl Response {
     /// JSON-only response (the common case).
     pub fn json(value: Value) -> Self {
-        Response { value, bytes: None }
+        Response {
+            value,
+            bytes: None,
+            deferred: false,
+        }
     }
 
     /// JSON envelope + binary side-channel payload (always surfaces a `bytes`
@@ -58,6 +71,7 @@ impl Response {
         Response {
             value,
             bytes: Some(bytes),
+            deferred: false,
         }
     }
 
@@ -66,6 +80,18 @@ impl Response {
         Response {
             value: Value::Null,
             bytes: None,
+            deferred: false,
+        }
+    }
+
+    /// A deferred response: the handler kicked an async readback and the
+    /// request's promise stays pending until the engine resolves it via
+    /// `completed_requests`. See [`Response::deferred`].
+    pub fn deferred() -> Self {
+        Response {
+            value: Value::Null,
+            bytes: None,
+            deferred: true,
         }
     }
 }

--- a/crates/darkly/src/engine/protocol/transport.rs
+++ b/crates/darkly/src/engine/protocol/transport.rs
@@ -95,16 +95,39 @@ impl Transport {
     /// Drain and dispatch every queued request **under an already-held engine
     /// borrow** — the `render` path, which composites in the same borrow right
     /// after. Requests are dispatched in FIFO submission order.
+    ///
+    /// Two kinds of outcome flow out of here:
+    ///
+    /// 1. **Inline** — a handler that returns a normal [`Response`] resolves its
+    ///    request now; its `(id, result)` is emitted this drain.
+    /// 2. **Deferred** — a handler that kicked an async readback returns
+    ///    [`Response::deferred`]; no outcome is emitted for it now. The
+    ///    request's `id` is recorded on the engine (`current_request`) so the
+    ///    readback's completion handler can push the terminal outcome onto the
+    ///    engine's `completed_requests` queue, which is flushed here (and after
+    ///    `render`) — letting a later frame resolve an earlier-dispatched id.
     pub fn drain_with(&self, engine: &mut DarklyEngine) -> Vec<RequestOutcome> {
         let reqs: Vec<QueuedRequest> = self.queue.borrow_mut().drain(..).collect();
-        reqs.into_iter()
-            .map(|req| RequestOutcome {
-                id: req.id,
-                result: self
-                    .registry
-                    .dispatch(engine, &req.kind, req.payload, &req.bytes),
-            })
-            .collect()
+        let mut outcomes = Vec::with_capacity(reqs.len());
+        for req in reqs {
+            // Record the id being dispatched so a deferring op can stash it in
+            // its readback context and resolve the right promise on completion.
+            engine.set_current_request(req.id);
+            let result = self
+                .registry
+                .dispatch(engine, &req.kind, req.payload, &req.bytes);
+            // A deferred response carries no result yet — skip it; the engine
+            // emits this id's terminal outcome via `completed_requests`.
+            if matches!(&result, Ok(r) if r.deferred) {
+                continue;
+            }
+            outcomes.push(RequestOutcome { id: req.id, result });
+        }
+        // Flush any deferred completions that have landed: immediate
+        // self-resolves queued during this drain, plus readback completions
+        // from prior frames' renders.
+        outcomes.extend(engine.take_completed_requests());
+        outcomes
     }
 
     /// Non-blocking drain — the scheduler path. `try_borrow_mut`s the engine and

--- a/crates/darkly/src/engine/rendering.rs
+++ b/crates/darkly/src/engine/rendering.rs
@@ -314,20 +314,14 @@ impl DarklyEngine {
         self.drain_readbacks() || any_completed
     }
 
-    /// Poll the GPU readback scheduler once (non-blocking `device.poll`)
-    /// and dispatch every completed readback to its handler. Returns true
-    /// if any landed. Run once per frame from [`Self::poll_pending`]; this is
-    /// what drives deferred ops (copy / export / save) to completion and
-    /// resolves their requests.
+    /// Poll both readback schedulers once (non-blocking `device.poll`) and
+    /// dispatch / fill every completed readback. Returns true if any landed. Run
+    /// once per frame from [`Self::poll_pending`]; this is what drives deferred
+    /// ops (export / save, and the awaitable readbacks behind copy / cut tasks)
+    /// to completion and resolves their requests. Delegates to the engine's
+    /// unified [`poll_readbacks`](Self::poll_readbacks).
     pub(crate) fn drain_readbacks(&mut self) -> bool {
-        let completed = self.readbacks.poll(&self.gpu.device);
-        if completed.is_empty() {
-            return false;
-        }
-        for (ctx, pixels) in completed {
-            self.handle_completed_readback(ctx, pixels);
-        }
-        true
+        self.poll_readbacks()
     }
 
     /// Dispatch a completed readback to the appropriate handler. Shared
@@ -346,14 +340,6 @@ impl DarklyEngine {
                 if pixels.len() >= 4 {
                     self.last_picked_color = [pixels[0], pixels[1], pixels[2], pixels[3]];
                 }
-            }
-            ReadbackContext::Copy {
-                node_id,
-                region,
-                is_cut,
-                request,
-            } => {
-                self.complete_copy(node_id, region, is_cut, request, pixels);
             }
             ReadbackContext::MagicWand {
                 was_active,
@@ -389,11 +375,9 @@ impl DarklyEngine {
             }
             ReadbackContext::SelectionReadback => {
                 self.update_selection_overlay_from_readback(pixels);
-                // Resume deferred operations that were waiting for
-                // selection cpu_cache / pixel_bounds.
-                if let Some(pc) = self.pending_copy.take() {
-                    self.start_copy_readback(pc.layer_id, pc.is_cut, pc.request);
-                }
+                // Resume deferred operations waiting on selection cpu_cache /
+                // pixel_bounds. (Copy/cut tasks await the selection cache
+                // directly via their own combinator, not through this arm.)
                 if self.selection_pixel_bounds().is_some() {
                     if let Some(pt) = self.pending_transform.take() {
                         if self.floating.is_none() {
@@ -598,7 +582,7 @@ impl DarklyEngine {
                     anim_us: 0,
                     compositor_us: 0,
                 };
-                return self.readbacks.has_pending()
+                return self.has_pending_readbacks()
                     || self.compositor.has_pending_content_bounds()
                     || self.diff_rect.is_pending();
             }
@@ -614,7 +598,7 @@ impl DarklyEngine {
                 anim_us: 0,
                 compositor_us: 0,
             };
-            return self.readbacks.has_pending() || self.compositor.has_pending_content_bounds();
+            return self.has_pending_readbacks() || self.compositor.has_pending_content_bounds();
         }
 
         let t_anim = web_time::Instant::now();
@@ -639,9 +623,13 @@ impl DarklyEngine {
             compositor_us,
         };
 
-        // Keep requesting frames while async operations are in flight.
+        // Keep requesting frames while async operations are in flight. The
+        // executor's own in-flight tasks are OR'd in host-side (the host owns
+        // the executor); `has_pending_readbacks` covers the async-readback
+        // scheduler a copy/cut task awaits, so a copy kicked with nothing else
+        // animating still keeps frames coming until it lands.
         self.compositor.needs_animation(&self.doc)
-            || self.readbacks.has_pending()
+            || self.has_pending_readbacks()
             || self.compositor.has_pending_content_bounds()
             || self.diff_rect.is_pending()
     }

--- a/crates/darkly/src/engine/rendering.rs
+++ b/crates/darkly/src/engine/rendering.rs
@@ -316,12 +316,9 @@ impl DarklyEngine {
 
     /// Poll the GPU readback scheduler once (non-blocking `device.poll`)
     /// and dispatch every completed readback to its handler. Returns true
-    /// if any landed.
-    ///
-    /// Factored out of [`Self::poll_pending`] so the save flow can drain
-    /// its own readbacks from [`Self::poll_save_result`] — letting a
-    /// backgrounded tab finish a recovery snapshot without running a full
-    /// `render()`/present (only the focused tab renders).
+    /// if any landed. Run once per frame from [`Self::poll_pending`]; this is
+    /// what drives deferred ops (copy / export / save) to completion and
+    /// resolves their requests.
     pub(crate) fn drain_readbacks(&mut self) -> bool {
         let completed = self.readbacks.poll(&self.gpu.device);
         if completed.is_empty() {
@@ -354,8 +351,9 @@ impl DarklyEngine {
                 node_id,
                 region,
                 is_cut,
+                request,
             } => {
-                self.complete_copy(node_id, region, is_cut, pixels);
+                self.complete_copy(node_id, region, is_cut, request, pixels);
             }
             ReadbackContext::MagicWand {
                 was_active,
@@ -375,8 +373,12 @@ impl DarklyEngine {
                     pixels,
                 );
             }
-            ReadbackContext::ExportImage { width, height } => {
-                self.complete_export(width, height, pixels);
+            ReadbackContext::ExportImage {
+                width,
+                height,
+                request,
+            } => {
+                self.complete_export(width, height, request, pixels);
             }
             ReadbackContext::SaveDocument {
                 kind,
@@ -390,7 +392,7 @@ impl DarklyEngine {
                 // Resume deferred operations that were waiting for
                 // selection cpu_cache / pixel_bounds.
                 if let Some(pc) = self.pending_copy.take() {
-                    self.start_copy_readback(pc.layer_id, pc.is_cut);
+                    self.start_copy_readback(pc.layer_id, pc.is_cut, pc.request);
                 }
                 if self.selection_pixel_bounds().is_some() {
                     if let Some(pt) = self.pending_transform.take() {

--- a/crates/darkly/src/engine/save.rs
+++ b/crates/darkly/src/engine/save.rs
@@ -33,8 +33,8 @@ use crate::layer::LayerId;
 /// Errors `start_save_document` can return synchronously.
 #[derive(Debug)]
 pub enum SaveError {
-    /// A save is already in flight on this engine. Wait for
-    /// `poll_save_result` to return `Some` before kicking off another.
+    /// A save is already in flight on this engine. Wait for the in-flight
+    /// `start_save_document` request to resolve before kicking off another.
     /// The UI disables the Save action for that tab during a save.
     InProgress,
 }
@@ -84,9 +84,9 @@ pub enum SaveReadbackKind {
 }
 
 /// In-flight save state — created by [`DarklyEngine::start_save_document`]
-/// and drained by [`DarklyEngine::poll_save_result`]. The fields capture
-/// everything the save needs that's *not* a pixel readback (those land
-/// asynchronously into `pending_blobs` / `composite`).
+/// and finished by `complete_save_readback` once every readback lands. The
+/// fields capture everything the save needs that's *not* a pixel readback
+/// (those land asynchronously into `pending_blobs` / `composite`).
 pub struct SaveJob {
     /// Manifest built synchronously at submit time. Captures the
     /// document's tree / modifier / veil / requires state at the moment
@@ -106,9 +106,12 @@ pub struct SaveJob {
     /// Composite readback result. `None` until the `Composite` arm
     /// fires.
     composite: Option<(u32, u32, Vec<u8>)>,
-    /// Why this save was started — gates whether the drain clears
+    /// Why this save was started — gates whether finishing clears
     /// `doc.dirty` (see [`SavePurpose`]).
     purpose: SavePurpose,
+    /// Originating `start_save_document` request id. When the last readback
+    /// lands, the assembled [`SaveBundle`] resolves this request's promise.
+    request: u64,
 }
 
 impl SaveJob {
@@ -121,8 +124,8 @@ impl SaveJob {
 
 impl DarklyEngine {
     /// Kick off a save. Synchronously builds the [`Manifest`], pins
-    /// every source texture, and queues all readbacks. Returns
-    /// immediately; the result lands on [`Self::poll_save_result`] once
+    /// every source texture, and queues all readbacks. Defers: the
+    /// originating request resolves with the packed `SaveBundle` once
     /// every readback completes (typically within a few frames).
     ///
     /// `purpose` decides whether the eventual drain clears `doc.dirty`:
@@ -132,6 +135,7 @@ impl DarklyEngine {
         if self.active_save_job.is_some() {
             return Err(SaveError::InProgress);
         }
+        let request = self.current_request();
 
         let (manifest, pixel_blobs) = build_manifest(self);
 
@@ -184,68 +188,16 @@ impl DarklyEngine {
             pending_blobs,
             composite: None,
             purpose,
+            request,
         });
 
         Ok(())
     }
 
-    /// Drain a completed save. Returns `None` while any readback is
-    /// still in flight; returns `Some(SaveBundle)` once every pixel
-    /// blob and the composite have landed.
-    ///
-    /// A [`SavePurpose::File`] drain also clears the [`Document::dirty`]
-    /// flag — the bundle handoff is the moment the document's contents
-    /// are no longer "unsaved." Edits queued between `start_save_document`
-    /// and this drain are intentionally lost from the dirty flag's POV:
-    /// the snapshot built at submit time is what's leaving the engine, so
-    /// the document on disk matches the snapshot we just sealed. A
-    /// [`SavePurpose::Snapshot`] (autosave) drain leaves `dirty` alone.
-    ///
-    /// Drives the readback scheduler itself before checking completion,
-    /// so a backgrounded tab — whose `render()` loop isn't running — can
-    /// still finish its snapshot when pumped via this method alone.
-    pub fn poll_save_result(&mut self) -> Option<SaveBundle> {
-        // Advance any in-flight GPU readbacks (non-blocking) so a save can
-        // complete without a full render/present. Harmless no-op when the
-        // frame loop already drained this frame.
-        if self.active_save_job.is_some() {
-            self.drain_readbacks();
-        }
-        let job = self.active_save_job.as_ref()?;
-        if !job.is_complete() {
-            return None;
-        }
-        let job = self.active_save_job.take().unwrap();
-        let manifest_json = serde_json::to_vec_pretty(&job.manifest).ok()?;
-        let (composite_width, composite_height, composite_rgba) = job.composite.unwrap();
-        let mut blobs: Vec<SaveBlob> = job
-            .pending_blobs
-            .into_iter()
-            .map(|(path, bytes)| SaveBlob {
-                path,
-                bytes: bytes.unwrap_or_default(),
-            })
-            .collect();
-        // Stable ordering for tests + bit-stable output.
-        blobs.sort_by(|a, b| a.path.cmp(&b.path));
-        // Only a real file save means "disk matches" — an autosave snapshot
-        // wrote to OPFS, not the user's file, so it must leave `dirty` set.
-        if job.purpose == SavePurpose::File {
-            self.doc.dirty = false;
-        }
-        Some(SaveBundle {
-            manifest_json,
-            composite_width,
-            composite_height,
-            composite_rgba,
-            blobs,
-        })
-    }
-
     /// Dispatch from `handle_completed_readback` — populate the matching
-    /// blob slot or the composite triple. Unknown keys are silently
-    /// dropped (the save was cancelled or a stale readback completed
-    /// after `poll_save_result` drained the job).
+    /// blob slot or the composite triple, then finish the save once every
+    /// readback has landed. Unknown keys are silently dropped (the save was
+    /// cancelled or a stale readback completed after the job finished).
     pub(crate) fn complete_save_readback(
         &mut self,
         kind: SaveReadbackKind,
@@ -267,7 +219,82 @@ impl DarklyEngine {
                 }
             }
         }
+        if job.is_complete() {
+            self.finish_save_job();
+        }
     }
+
+    /// Assemble the [`SaveBundle`] from the completed job and resolve the
+    /// originating `start_save_document` request with the packed binary
+    /// response. A [`SavePurpose::File`] save also clears [`Document::dirty`]
+    /// — the bundle handoff is the moment the document's contents are no
+    /// longer "unsaved." Edits queued between `start_save_document` and here
+    /// are intentionally invisible to the dirty flag: the snapshot built at
+    /// submit time is what's leaving the engine. A [`SavePurpose::Snapshot`]
+    /// (autosave) save leaves `dirty` alone.
+    fn finish_save_job(&mut self) {
+        let Some(job) = self.active_save_job.take() else {
+            return;
+        };
+        let request = job.request;
+        let Ok(manifest_json) = serde_json::to_vec_pretty(&job.manifest) else {
+            self.reject_request(
+                request,
+                crate::engine::protocol::ProtocolError::engine("save manifest serialize failed"),
+            );
+            return;
+        };
+        let (composite_width, composite_height, composite_rgba) = job.composite.unwrap();
+        let mut blobs: Vec<SaveBlob> = job
+            .pending_blobs
+            .into_iter()
+            .map(|(path, bytes)| SaveBlob {
+                path,
+                bytes: bytes.unwrap_or_default(),
+            })
+            .collect();
+        // Stable ordering for tests + bit-stable output.
+        blobs.sort_by(|a, b| a.path.cmp(&b.path));
+        // Only a real file save means "disk matches" — an autosave snapshot
+        // wrote to OPFS, not the user's file, so it must leave `dirty` set.
+        if job.purpose == SavePurpose::File {
+            self.doc.dirty = false;
+        }
+        let bundle = SaveBundle {
+            manifest_json,
+            composite_width,
+            composite_height,
+            composite_rgba,
+            blobs,
+        };
+        self.resolve_request(request, pack_save_bundle(bundle));
+    }
+}
+
+/// Pack a [`SaveBundle`] into the binary protocol response the JS save flow
+/// unpacks: every byte buffer (manifest ++ composite ++ each blob) concatenated
+/// into the single `bytes` side-channel, with the lengths carried in the JSON
+/// value so the JS edge can slice them back out in order.
+fn pack_save_bundle(bundle: SaveBundle) -> crate::engine::protocol::Response {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&bundle.manifest_json);
+    bytes.extend_from_slice(&bundle.composite_rgba);
+    let blobs: Vec<serde_json::Value> = bundle
+        .blobs
+        .iter()
+        .map(|b| {
+            bytes.extend_from_slice(&b.bytes);
+            serde_json::json!({ "path": b.path, "len": b.bytes.len() })
+        })
+        .collect();
+    let value = serde_json::json!({
+        "manifestLen": bundle.manifest_json.len(),
+        "compositeWidth": bundle.composite_width,
+        "compositeHeight": bundle.composite_height,
+        "compositeLen": bundle.composite_rgba.len(),
+        "blobs": blobs,
+    });
+    crate::engine::protocol::Response::binary(value, bytes)
 }
 
 /// Walk the live document via the layer-kind / modifier registries and
@@ -544,17 +571,11 @@ mod tests {
         engine
             .start_save_document(SavePurpose::File)
             .expect("save kicks off");
-        // Drive readbacks to completion.
-        let mut bundle = None;
-        for _ in 0..16 {
-            engine.test_flush_readbacks();
-            engine.render(0.0);
-            if let Some(b) = engine.poll_save_result() {
-                bundle = Some(b);
-                break;
-            }
-        }
-        bundle.expect("save should complete within 16 frames");
+        // Drive readbacks to completion; the save request resolves with the
+        // packed bundle and clears dirty as part of finishing the job.
+        engine
+            .test_drive_completed(0)
+            .expect("save should complete");
         assert!(
             !engine.is_dirty(),
             "successful save must clear dirty — bundle handoff matches disk"
@@ -574,26 +595,19 @@ mod tests {
         engine
             .start_save_document(SavePurpose::Snapshot)
             .expect("snapshot save kicks off");
-        let mut bundle = None;
-        for _ in 0..16 {
-            engine.test_flush_readbacks();
-            engine.render(0.0);
-            if let Some(b) = engine.poll_save_result() {
-                bundle = Some(b);
-                break;
-            }
-        }
-        bundle.expect("snapshot should complete within 16 frames");
+        engine
+            .test_drive_completed(0)
+            .expect("snapshot should complete");
         assert!(
             engine.is_dirty(),
             "autosave snapshot must NOT clear dirty — nothing reached the user's file"
         );
     }
 
-    /// A snapshot save must be drivable to completion via
-    /// `poll_save_result` alone — no `render()`/present — because a
-    /// backgrounded tab's render loop isn't running. `poll_save_result`
-    /// drains the readback scheduler itself.
+    /// A snapshot save must be drivable to completion by flushing readbacks
+    /// alone — no `render()`/present — because a backgrounded tab's render
+    /// loop isn't running. Completing the readbacks resolves the save request
+    /// with the packed bundle.
     #[test]
     fn snapshot_completes_without_render() {
         let mut engine = headless_engine(32, 32);
@@ -602,28 +616,26 @@ mod tests {
         engine
             .start_save_document(SavePurpose::Snapshot)
             .expect("snapshot save kicks off");
-        let mut bundle = None;
-        for _ in 0..32 {
-            // Native stand-in for the browser event loop: fire the GPU map
-            // callbacks but DON'T poll/dispatch the scheduler here — leave
-            // that to poll_save_result. NO engine.render() — the whole point.
-            engine.test_wait_gpu();
-            if let Some(b) = engine.poll_save_result() {
-                bundle = Some(b);
-                break;
-            }
-        }
-        let bundle = bundle.expect("snapshot must complete via poll alone, without render()");
-        assert!(
-            bundle.composite_width == 32 && bundle.composite_height == 32,
-            "composite dimensions should match the canvas"
+        // `test_drive_completed` drives the readback scheduler (no render()).
+        let resp = engine
+            .test_drive_completed(0)
+            .expect("snapshot must complete via flush alone, without render()");
+        assert_eq!(
+            resp.value["compositeWidth"].as_u64(),
+            Some(32),
+            "composite width should match the canvas"
+        );
+        assert_eq!(
+            resp.value["compositeHeight"].as_u64(),
+            Some(32),
+            "composite height should match the canvas"
         );
     }
 
     /// The save snapshot must survive concurrent edits — the manifest
     /// is built at submit time, GPU textures are refcount-pinned, and
     /// readbacks see GPU command-buffer state at submit time. Adding a
-    /// layer between start_save and poll_save_result must *not* end up
+    /// layer between start_save and the save's completion must *not* end up
     /// in the saved manifest.
     #[test]
     fn save_concurrent_edit_does_not_corrupt() {
@@ -636,18 +648,14 @@ mod tests {
         // Mutate the document mid-save.
         let _added_mid_save = engine.add_raster_layer(None);
 
-        // Drive readbacks to completion.
-        let mut bundle = None;
-        for _ in 0..16 {
-            engine.test_flush_readbacks();
-            engine.render(0.0);
-            if let Some(b) = engine.poll_save_result() {
-                bundle = Some(b);
-                break;
-            }
-        }
-        let bundle = bundle.expect("save should complete within 16 frames");
-        let manifest: Manifest = serde_json::from_slice(&bundle.manifest_json).unwrap();
+        // Drive readbacks to completion and recover the manifest from the
+        // packed bundle (manifest ++ composite ++ blobs in the bytes channel).
+        let resp = engine
+            .test_drive_completed(0)
+            .expect("save should complete");
+        let manifest_len = resp.value["manifestLen"].as_u64().unwrap() as usize;
+        let bytes = resp.bytes.expect("save resolves with packed bytes");
+        let manifest: Manifest = serde_json::from_slice(&bytes[..manifest_len]).unwrap();
 
         let raster_count = manifest
             .nodes

--- a/crates/darkly/src/engine/types.rs
+++ b/crates/darkly/src/engine/types.rs
@@ -364,7 +364,7 @@ pub enum StrokeOp {
 
 /// Data returned to the WASM bridge on copy/cut — always RGBA pixels regardless
 /// of the internal clipboard variant.
-#[derive(serde::Serialize)]
+#[derive(serde::Serialize, serde::Deserialize)]
 pub struct ClipboardExport {
     pub rgba: Vec<u8>,
     pub width: u32,

--- a/crates/darkly/src/format/tests.rs
+++ b/crates/darkly/src/format/tests.rs
@@ -445,20 +445,47 @@ fn populate_kitchen_sink(engine: &mut DarklyEngine) {
     }
 }
 
-/// Pump the engine until a save completes. Caps iterations so a stuck
-/// readback fails the test rather than hanging.
+/// Pump the engine until a save completes, then reconstruct the [`SaveBundle`]
+/// from the packed protocol response (manifest ++ composite ++ blobs in the
+/// bytes channel — the same shape the JS save flow unpacks).
 fn drive_save_to_completion(engine: &mut DarklyEngine) -> SaveBundle {
+    use crate::format::manifest::SaveBlob;
     engine
         .start_save_document(crate::engine::SavePurpose::File)
         .expect("start save");
-    for _ in 0..32 {
-        engine.test_flush_readbacks();
-        engine.render(0.0);
-        if let Some(b) = engine.poll_save_result() {
-            return b;
-        }
+    let resp = engine
+        .test_drive_completed(0)
+        .expect("save did not complete");
+    let v = &resp.value;
+    let bytes = resp.bytes.expect("save resolves with packed bytes");
+    let manifest_len = v["manifestLen"].as_u64().unwrap() as usize;
+    let composite_len = v["compositeLen"].as_u64().unwrap() as usize;
+    let mut off = 0;
+    let manifest_json = bytes[off..off + manifest_len].to_vec();
+    off += manifest_len;
+    let composite_rgba = bytes[off..off + composite_len].to_vec();
+    off += composite_len;
+    let blobs = v["blobs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|b| {
+            let len = b["len"].as_u64().unwrap() as usize;
+            let slice = bytes[off..off + len].to_vec();
+            off += len;
+            SaveBlob {
+                path: b["path"].as_str().unwrap().to_string(),
+                bytes: slice,
+            }
+        })
+        .collect();
+    SaveBundle {
+        manifest_json,
+        composite_width: v["compositeWidth"].as_u64().unwrap() as u32,
+        composite_height: v["compositeHeight"].as_u64().unwrap() as u32,
+        composite_rgba,
+        blobs,
     }
-    panic!("save did not complete within 32 frames");
 }
 
 /// Coarse structural comparison: same canvas size, same number of

--- a/crates/darkly/src/gpu/readback.rs
+++ b/crates/darkly/src/gpu/readback.rs
@@ -220,30 +220,27 @@ impl<C> ReadbackScheduler<C> {
         self.tasks.push((request, context));
     }
 
-    /// Poll all pending readbacks. Returns completed `(context, pixels)` pairs.
-    ///
-    /// Begins mapping for any newly submitted requests, then calls
-    /// `device.poll(Poll)` once to nudge native backends, then checks
-    /// every pending request. Completed tasks are removed; in-flight tasks remain.
-    pub fn poll(&mut self, device: &wgpu::Device) -> Vec<(C, Vec<u8>)> {
-        // Begin mapping for newly submitted requests (deferred from submit()).
+    /// Begin mapping for any newly submitted requests (deferred from `submit`).
+    /// Idempotent — a request whose mapping already started is skipped. Pairs
+    /// with [`harvest`](Self::harvest): a caller drives the device once for
+    /// every scheduler sharing the device, then harvests each.
+    pub fn begin_pending(&mut self) {
         for (req, _) in &mut self.tasks {
             if req.rx.is_none() {
                 req.begin_mapping();
             }
         }
+    }
 
-        // One poll call for all pending readbacks — the device processes all
-        // ready callbacks in a single pass.
-        if !self.tasks.is_empty() {
-            let _ = device.poll(wgpu::PollType::Poll);
-        }
-
+    /// Harvest completed readbacks — `try_recv` each pending request's map
+    /// callback, unmap and extract the pixels of any that fired, and return the
+    /// `(context, pixels)` pairs. **Does not** call `device.poll`; the caller
+    /// must have driven the device (one poll for every scheduler) since the last
+    /// harvest. Completed tasks are removed; in-flight tasks remain.
+    pub fn harvest(&mut self) -> Vec<(C, Vec<u8>)> {
         let mut completed = Vec::new();
         let mut i = 0;
         while i < self.tasks.len() {
-            // Skip the device.poll inside ReadbackRequest::poll — we already
-            // did it above. Just check the channel directly.
             let ready = self.tasks[i]
                 .0
                 .rx
@@ -271,6 +268,23 @@ impl<C> ReadbackScheduler<C> {
         completed
     }
 
+    /// Poll all pending readbacks. Returns completed `(context, pixels)` pairs.
+    ///
+    /// Begins mapping for any newly submitted requests, calls `device.poll(Poll)`
+    /// once to nudge native backends, then harvests. Convenience wrapper over
+    /// [`begin_pending`](Self::begin_pending) + [`harvest`](Self::harvest) for
+    /// callers driving a single scheduler; the engine's [`poll_readbacks`] drives
+    /// both schedulers off one shared `device.poll` instead.
+    ///
+    /// [`poll_readbacks`]: crate::engine::DarklyEngine::poll_readbacks
+    pub fn poll(&mut self, device: &wgpu::Device) -> Vec<(C, Vec<u8>)> {
+        self.begin_pending();
+        if !self.tasks.is_empty() {
+            let _ = device.poll(wgpu::PollType::Poll);
+        }
+        self.harvest()
+    }
+
     /// True if any readbacks are in flight.
     pub fn has_pending(&self) -> bool {
         !self.tasks.is_empty()
@@ -285,10 +299,66 @@ impl<C> ReadbackScheduler<C> {
     pub fn cancel<F: Fn(&C) -> bool>(&mut self, f: F) {
         self.tasks.retain(|(_, ctx)| !f(ctx));
     }
+
+    /// Cancel and remove every pending readback, returning their contexts. The
+    /// readback buffers are dropped (any in-flight mapping is abandoned). Used
+    /// by teardown to mark awaitable slots `Cancelled`.
+    pub fn drain(&mut self) -> Vec<C> {
+        self.tasks.drain(..).map(|(_, ctx)| ctx).collect()
+    }
 }
 
 impl<C> Default for ReadbackScheduler<C> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Awaitable readback — a shared completion slot polled by the frame-driven
+// executor (engine/host).
+// ---------------------------------------------------------------------------
+
+/// Completion state of an awaitable readback. The async-readback scheduler
+/// (`ReadbackScheduler<Rc<RefCell<ReadbackSlot>>>`) writes `Ready` on harvest;
+/// the [`ReadbackFuture`] polled by the executor reads it. `Cancelled` is set on
+/// teardown so a task awaiting a disposed handle resolves to `None` rather than
+/// hanging.
+pub enum ReadbackSlot {
+    Pending,
+    Ready(Vec<u8>),
+    Cancelled,
+}
+
+/// A future over a [`ReadbackSlot`]. Resolves to the readback pixels once the
+/// scheduler fills the slot, or `None` if the slot was cancelled (handle
+/// disposed). Dependency-free: the engine's executor re-polls every task each
+/// frame with a no-op waker, so the slot needs no wakeup channel.
+pub struct ReadbackFuture(std::rc::Rc<std::cell::RefCell<ReadbackSlot>>);
+
+impl ReadbackFuture {
+    /// Wrap a shared slot. The matching `Rc` clone is held by the
+    /// async-readback scheduler, which writes the result on harvest.
+    pub fn new(slot: std::rc::Rc<std::cell::RefCell<ReadbackSlot>>) -> Self {
+        ReadbackFuture(slot)
+    }
+}
+
+impl std::future::Future for ReadbackFuture {
+    type Output = Option<Vec<u8>>;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        use std::task::Poll;
+        // Take the result out of the slot, leaving `Pending` behind so a second
+        // poll after Ready can't double-yield the bytes.
+        let mut slot = self.0.borrow_mut();
+        match std::mem::replace(&mut *slot, ReadbackSlot::Pending) {
+            ReadbackSlot::Ready(pixels) => Poll::Ready(Some(pixels)),
+            ReadbackSlot::Cancelled => Poll::Ready(None),
+            ReadbackSlot::Pending => Poll::Pending,
+        }
     }
 }

--- a/crates/darkly/tests/canvas_resize.rs
+++ b/crates/darkly/tests/canvas_resize.rs
@@ -8,6 +8,7 @@
 
 use darkly::coord::{CanvasPoint, CanvasRect};
 use darkly::document::SelectionMode;
+use darkly::engine::host::EngineHost;
 use darkly::engine::types::StrokeOp;
 use darkly::engine::DarklyEngine;
 use darkly::gpu::context::GpuContext;
@@ -396,14 +397,15 @@ fn copy_selection_after_crop_extracts_plane_pixels_and_offset() {
     // Crop to a NON-ZERO origin window at plane (16, 12); the square is inside.
     engine.resize_canvas(CanvasRect::from_xywh(16, 12, 40, 40));
 
-    // Select the square in plane coords, then copy.
+    // Select the square in plane coords, then copy. Copy spawns a task on the
+    // host's executor, so drive it through an `EngineHost`; the request resolves
+    // with the clipboard export once the readback lands.
     engine.select_rect(30.0, 28.0, 8.0, 8.0, SelectionMode::Replace, false, 0.0);
-    engine.copy(layer_id);
-
-    // Drive the async copy readback to completion; the request resolves with
-    // the clipboard export once the readback lands.
-    let resp = engine
-        .test_drive_completed(0)
+    let host = EngineHost::adopt(engine);
+    host.with(|e| e.copy(layer_id));
+    host.pump_until_idle();
+    let resp = host
+        .with(|e| e.test_take_completed(0))
         .expect("copy readback should complete");
     let export: darkly::engine::ClipboardExport =
         serde_json::from_value(resp.value).expect("copy response is a ClipboardExport");

--- a/crates/darkly/tests/canvas_resize.rs
+++ b/crates/darkly/tests/canvas_resize.rs
@@ -400,17 +400,13 @@ fn copy_selection_after_crop_extracts_plane_pixels_and_offset() {
     engine.select_rect(30.0, 28.0, 8.0, 8.0, SelectionMode::Replace, false, 0.0);
     engine.copy(layer_id);
 
-    // Drive the async copy readback to completion.
-    let mut export = None;
-    for _ in 0..8 {
-        engine.test_flush_readbacks();
-        engine.render(0.0);
-        if let Some(e) = engine.poll_copy_result() {
-            export = Some(e);
-            break;
-        }
-    }
-    let export = export.expect("copy readback should complete");
+    // Drive the async copy readback to completion; the request resolves with
+    // the clipboard export once the readback lands.
+    let resp = engine
+        .test_drive_completed(0)
+        .expect("copy readback should complete");
+    let export: darkly::engine::ClipboardExport =
+        serde_json::from_value(resp.value).expect("copy response is a ClipboardExport");
 
     // Clipboard offset is the PLANE position of the selection (30, 28) — not the
     // window-local (14, 16) the pre-fix code produced.

--- a/crates/darkly/tests/engine.rs
+++ b/crates/darkly/tests/engine.rs
@@ -8,6 +8,7 @@
 use darkly::brush::nodes::pen_input;
 use darkly::brush::wire::BrushWireType;
 use darkly::document::SelectionMode;
+use darkly::engine::host::EngineHost;
 use darkly::engine::types::StrokeOp;
 use darkly::engine::DarklyEngine;
 use darkly::gpu::context::GpuContext;
@@ -44,12 +45,21 @@ fn test_engine(width: u32, height: u32) -> DarklyEngine {
     DarklyEngine::new(gpu, width, height)
 }
 
-/// Drive a directly-called deferred copy/cut/export op to completion and parse
-/// its `ClipboardExport` result. Direct test calls use the default request id 0.
-fn drive_copy_result(engine: &mut DarklyEngine) -> darkly::engine::ClipboardExport {
-    let resp = engine
-        .test_drive_completed(0)
-        .expect("deferred copy/cut should resolve after flushing readbacks");
+/// Drive a copy/cut to completion through an [`EngineHost`] and parse its
+/// `ClipboardExport`. Copy/cut spawn a task on the host's executor, so the
+/// driving (kick selection cache → kick copy readback → resolve) happens via the
+/// host's frame loop, not a bare `test_drive_completed`. Consumes the engine
+/// (the setup is done by the time we copy); direct test calls use request id 0.
+fn drive_copy_result(
+    engine: DarklyEngine,
+    do_copy: impl FnOnce(&mut DarklyEngine),
+) -> darkly::engine::ClipboardExport {
+    let host = EngineHost::adopt(engine);
+    host.with(do_copy);
+    host.pump_until_idle();
+    let resp = host
+        .with(|e| e.test_take_completed(0))
+        .expect("deferred copy/cut should resolve after the host drives it");
     serde_json::from_value(resp.value).expect("copy response deserializes as ClipboardExport")
 }
 
@@ -3428,8 +3438,7 @@ fn copy_selected_mask_region_populates_clipboard() {
     // exactly as the frontend `copy` action does via `copy_layer_rich`.
     engine.select_rect(10.0, 10.0, 24.0, 24.0, SelectionMode::Replace, false, 0.0);
     engine.test_flush_readbacks();
-    engine.copy_layer_rich(mask_id);
-    let result = drive_copy_result(&mut engine);
+    let result = drive_copy_result(engine, |e| e.copy_layer_rich(mask_id));
     assert!(
         result.width > 0 && result.height > 0 && !result.rgba.is_empty(),
         "mask copy must carry the selected region's pixels; got {}x{} ({} bytes)",
@@ -4556,10 +4565,9 @@ fn copy_with_aa_rect_selection_has_no_transparent_border() {
         0.0,
     );
 
-    engine.copy(layer_id);
-    // Drive the async readback to completion (selection-cache resume + copy
+    // Drive the async readback to completion (selection-cache warm + copy
     // readback) and read the resolved clipboard export.
-    let exported = drive_copy_result(&mut engine);
+    let exported = drive_copy_result(engine, |e| e.copy(layer_id));
 
     assert_eq!(
         exported.width, sel_w as u32,

--- a/crates/darkly/tests/engine.rs
+++ b/crates/darkly/tests/engine.rs
@@ -44,6 +44,15 @@ fn test_engine(width: u32, height: u32) -> DarklyEngine {
     DarklyEngine::new(gpu, width, height)
 }
 
+/// Drive a directly-called deferred copy/cut/export op to completion and parse
+/// its `ClipboardExport` result. Direct test calls use the default request id 0.
+fn drive_copy_result(engine: &mut DarklyEngine) -> darkly::engine::ClipboardExport {
+    let resp = engine
+        .test_drive_completed(0)
+        .expect("deferred copy/cut should resolve after flushing readbacks");
+    serde_json::from_value(resp.value).expect("copy response deserializes as ClipboardExport")
+}
+
 /// Paint a horizontal brush stroke across the canvas at vertical center.
 fn paint_full_stroke(engine: &mut DarklyEngine, layer_id: LayerId, w: u32, h: u32) {
     engine.begin_stroke(layer_id);
@@ -3420,11 +3429,7 @@ fn copy_selected_mask_region_populates_clipboard() {
     engine.select_rect(10.0, 10.0, 24.0, 24.0, SelectionMode::Replace, false, 0.0);
     engine.test_flush_readbacks();
     engine.copy_layer_rich(mask_id);
-    engine.test_flush_readbacks();
-
-    let result = engine
-        .poll_copy_result()
-        .expect("copying a selected mask region must produce a clipboard result");
+    let result = drive_copy_result(&mut engine);
     assert!(
         result.width > 0 && result.height > 0 && !result.rgba.is_empty(),
         "mask copy must carry the selected region's pixels; got {}x{} ({} bytes)",
@@ -4242,7 +4247,7 @@ fn long_stabilized_stroke_no_fallback() {
 // Image export — async readback of the composited canvas
 // ============================================================================
 
-/// Verify that `start_export` → readback → `poll_export_result` produces
+/// Verify that `start_export` → readback → deferred resolution produces
 /// RGBA8 pixels that match the same bytes the test-only
 /// `test_readback_canvas` returns from the composited texture. The async
 /// path is what JS uses in production; the blocking path is what tests
@@ -4268,45 +4273,41 @@ fn export_readback_produces_rgba8_matching_composite() {
     let reference = engine.test_readback_canvas();
     assert_eq!(reference.len(), (cw * ch * 4) as usize);
 
-    // Start the export and pump the frame loop until the result lands.
+    // Start the export and drive the readback to completion; the originating
+    // request resolves with `{ width, height }` + the RGBA8 bytes side-channel.
     engine.start_export();
-    let mut result = None;
-    for _ in 0..16 {
-        engine.test_flush_readbacks();
-        engine.render(0.0);
-        if let Some(r) = engine.poll_export_result() {
-            result = Some(r);
-            break;
-        }
-    }
-    let export = result.expect("export readback did not complete within 16 iterations");
+    let resp = engine
+        .test_drive_completed(0)
+        .expect("export readback did not complete");
+    let width = resp.value["width"].as_u64().unwrap() as u32;
+    let height = resp.value["height"].as_u64().unwrap() as u32;
+    let rgba = resp.bytes.expect("export resolves with the RGBA8 bytes");
 
-    assert_eq!(export.width, cw);
-    assert_eq!(export.height, ch);
+    assert_eq!(width, cw);
+    assert_eq!(height, ch);
     assert_eq!(
-        export.rgba.len(),
+        rgba.len(),
         (cw * ch * 4) as usize,
         "export must be tightly packed RGBA8 with no row padding"
     );
     assert_eq!(
-        export.rgba, reference,
+        rgba, reference,
         "async export bytes must equal the blocking composite readback — \
          the production export path would otherwise lie about canvas contents"
     );
 }
 
-/// A pending export readback returns `None` from `poll_export_result`
-/// until completion. The frontend's per-frame poll relies on this for
-/// "result not ready yet, try again next frame".
+/// A pending export readback emits no completion until the readback lands —
+/// the deferred request stays pending across frames rather than resolving early.
 #[test]
-fn poll_export_result_returns_none_before_completion() {
+fn export_request_pends_until_readback_completes() {
     let mut engine = test_engine(8, 8);
     let _layer = engine.add_raster_layer(None);
 
     engine.start_export();
     // No flush yet — the readback is queued but the GPU work isn't drained.
     assert!(
-        engine.poll_export_result().is_none(),
+        engine.test_take_completed(0).is_none(),
         "result must not be available before the readback completes"
     );
 }
@@ -4556,11 +4557,9 @@ fn copy_with_aa_rect_selection_has_no_transparent_border() {
     );
 
     engine.copy(layer_id);
-    // Force the async readback to complete deterministically.
-    engine.test_flush_readbacks();
-    let exported = engine
-        .poll_copy_result()
-        .expect("copy result should be available after flushing readbacks");
+    // Drive the async readback to completion (selection-cache resume + copy
+    // readback) and read the resolved clipboard export.
+    let exported = drive_copy_result(&mut engine);
 
     assert_eq!(
         exported.width, sel_w as u32,

--- a/crates/darkly/tests/engine_host.rs
+++ b/crates/darkly/tests/engine_host.rs
@@ -1,0 +1,218 @@
+//! Tests for the engine host: the frame-driven executor, awaitable readbacks,
+//! and the copy/cut tasks that run on them.
+//!
+//! These exercise the orchestration that drives a deferred op to completion
+//! without a `pending_*` field or a central resume `match`: a copy/cut spawns a
+//! task that awaits the selection cache (if cold) and the masked GPU readback,
+//! re-acquiring the engine between awaits through the scoped `EngineCell::with`.
+//!
+//! Run with: `cargo test -p darkly --test engine_host --features testing -- --test-threads=1`
+
+use std::rc::Rc;
+
+use darkly::document::SelectionMode;
+use darkly::engine::host::EngineHost;
+use darkly::engine::DarklyEngine;
+use darkly::gpu::context::GpuContext;
+use darkly::gpu::test_utils::test_device;
+
+fn test_engine(width: u32, height: u32) -> DarklyEngine {
+    let (device, queue) = test_device();
+    let gpu = GpuContext::new_headless(device, queue);
+    DarklyEngine::new(gpu, width, height)
+}
+
+/// A solid red, fully-opaque RGBA buffer of `w × h`.
+fn solid_red(w: u32, h: u32) -> Vec<u8> {
+    let mut rgba = vec![0u8; (w * h * 4) as usize];
+    for px in rgba.chunks_exact_mut(4) {
+        px[0] = 255;
+        px[3] = 255;
+    }
+    rgba
+}
+
+/// Copy with a **cold** selection CPU cache completes through the host: the task
+/// warms the cache (cold after a boolean combine) before kicking the copy
+/// readback, and the originating request resolves with the masked region.
+#[test]
+fn copy_with_cold_selection_cache_completes() {
+    let (w, h) = (64u32, 64u32);
+    let mut engine = test_engine(w, h);
+    let layer = engine.paste_image(w, h, &solid_red(w, h), 0, 0, None);
+
+    // A `Replace` selection warms the CPU cache directly, but a boolean combine
+    // (`Add`) invalidates it and kicks an async readback — leaving the cache
+    // cold until a frame poll lands it. The second rect sits inside the first,
+    // so the union region is unchanged at [16,16,16,16].
+    engine.select_rect(16.0, 16.0, 16.0, 16.0, SelectionMode::Replace, false, 0.0);
+    engine.select_rect(20.0, 20.0, 8.0, 8.0, SelectionMode::Add, false, 0.0);
+    assert!(
+        engine.test_selection_cpu_cache().is_none(),
+        "precondition: a combine leaves the selection CPU cache cold"
+    );
+
+    let host = EngineHost::adopt(engine);
+    host.with(|e| e.copy(layer));
+    host.pump_until_idle();
+
+    let resp = host
+        .with(|e| e.test_take_completed(0))
+        .expect("cold-cache copy must resolve once the host drives its task");
+    let export: darkly::engine::ClipboardExport =
+        serde_json::from_value(resp.value).expect("copy resolves with a ClipboardExport");
+
+    assert_eq!((export.width, export.height), (16, 16));
+    assert_eq!((export.offset_x, export.offset_y), (16, 16));
+    assert!(
+        export.rgba.chunks_exact(4).all(|p| p[3] == 255),
+        "every copied pixel inside the selection is opaque red"
+    );
+}
+
+/// The cut GPU-math invariant: extracted (clipboard) + remaining (layer) ==
+/// original. With a hard-edged selection, every selected pixel moves to the
+/// clipboard (alpha 255) and leaves the layer transparent (alpha 0); unselected
+/// pixels stay on the layer. Exercises the chained `.await` (cache → readback)
+/// that replaced `pending_copy`.
+#[test]
+fn cut_extracted_plus_remaining_equals_original() {
+    let (w, h) = (64u32, 64u32);
+    let mut engine = test_engine(w, h);
+    let layer = engine.paste_image(w, h, &solid_red(w, h), 0, 0, None);
+
+    // Hard-edged (antialias=false) selection of the left-centre square.
+    engine.select_rect(16.0, 16.0, 16.0, 16.0, SelectionMode::Replace, false, 0.0);
+
+    let host = EngineHost::adopt(engine);
+    host.with(|e| e.cut(layer));
+    host.pump_until_idle();
+
+    let resp = host
+        .with(|e| e.test_take_completed(0))
+        .expect("cut must resolve once the host drives its task");
+    let export: darkly::engine::ClipboardExport =
+        serde_json::from_value(resp.value).expect("cut resolves with a ClipboardExport");
+
+    // Extracted: the 16×16 selected square, fully opaque.
+    assert_eq!((export.width, export.height), (16, 16));
+    assert!(
+        export.rgba.chunks_exact(4).all(|p| p[3] == 255),
+        "extracted square is fully opaque"
+    );
+
+    // Remaining: the layer is cleared inside the selection, intact outside.
+    let engine = host.into_engine();
+    let remaining = engine.test_readback_layer(layer);
+    let alpha = |x: u32, y: u32| remaining[((y * w + x) * 4 + 3) as usize];
+    assert_eq!(
+        alpha(24, 24),
+        0,
+        "selected pixel must be cut from the layer"
+    );
+    assert_eq!(
+        alpha(4, 4),
+        255,
+        "unselected pixel must remain on the layer"
+    );
+}
+
+/// A task awaiting a readback must not block the frame loop. A single `tick`
+/// with a copy in flight returns (the borrow-across-await deadlock would hang
+/// here), and the copy still resolves once driven to completion.
+#[test]
+fn awaiting_task_does_not_block_the_frame_loop() {
+    let (w, h) = (64u32, 64u32);
+    let mut engine = test_engine(w, h);
+    let layer = engine.paste_image(w, h, &solid_red(w, h), 0, 0, None);
+
+    let host = EngineHost::adopt(engine);
+    host.with(|e| e.copy(layer));
+
+    // One frame with the task in flight: must return, not deadlock.
+    let outcome = host.tick(0.0, |_| {}, |_| Vec::new());
+    assert!(!outcome.busy, "a plain frame should not report busy");
+
+    host.pump_until_idle();
+    assert!(
+        host.with(|e| e.test_take_completed(0)).is_some(),
+        "copy resolves after the frame loop drives it"
+    );
+}
+
+/// Keepalive: a copy kicked with nothing else animating keeps `needsMore` true
+/// until its task completes — otherwise the rAF loop would sleep and the promise
+/// would hang (the readback is only driven by a frame).
+#[test]
+fn keepalive_holds_frames_until_copy_completes() {
+    let (w, h) = (64u32, 64u32);
+    let mut engine = test_engine(w, h);
+    let layer = engine.paste_image(w, h, &solid_red(w, h), 0, 0, None);
+
+    let host = EngineHost::adopt(engine);
+    host.with(|e| e.copy(layer));
+
+    // With the task in flight and no animation, the frame must report needsMore.
+    let outcome = host.tick(0.0, |_| {}, |_| Vec::new());
+    assert!(
+        outcome.needs_more,
+        "a copy in flight must keep frames coming"
+    );
+    assert!(host.has_pending_tasks(), "the copy task is still in flight");
+
+    host.pump_until_idle();
+    assert!(
+        host.with(|e| e.test_take_completed(0)).is_some(),
+        "the copy eventually resolves"
+    );
+}
+
+/// A re-entrant `EngineCell::with` while another burst holds the cell yields
+/// `None` (the re-entrancy yield) instead of panicking and poisoning the cell.
+/// Models the competing-borrow class headless; the real browser event-pump
+/// re-entry is the manual repro.
+#[test]
+fn reentrant_with_yields_without_panic() {
+    let host = EngineHost::adopt(test_engine(16, 16));
+    let cell = host.cell().clone();
+
+    let outer = cell.with(|_outer| {
+        // Re-entrant acquire while the outer burst holds the borrow.
+        cell.with(|_inner| 1)
+    });
+
+    assert_eq!(
+        outer,
+        Some(None),
+        "outer burst runs (Some); the re-entrant burst yields (None)"
+    );
+}
+
+/// Handle teardown with an in-flight task rejects its request (no dangling JS
+/// promise) and drops the task, freeing the engine — the captured
+/// `Rc<EngineCell>` is released, so the `Weak` no longer upgrades.
+#[test]
+fn dispose_rejects_inflight_task_and_frees_engine() {
+    let (w, h) = (64u32, 64u32);
+    let mut engine = test_engine(w, h);
+    let layer = engine.paste_image(w, h, &solid_red(w, h), 0, 0, None);
+    engine.select_rect(16.0, 16.0, 16.0, 16.0, SelectionMode::Replace, false, 0.0);
+
+    let host = EngineHost::adopt(engine);
+    let weak = Rc::downgrade(host.cell());
+
+    // Spawn the copy task (request id 0) but do not drive it to completion.
+    host.with(|e| e.copy(layer));
+
+    let outcomes = host.dispose();
+    assert!(
+        outcomes.iter().any(|o| o.id == 0 && o.result.is_err()),
+        "dispose rejects the in-flight copy's request"
+    );
+
+    drop(host);
+    assert!(
+        weak.upgrade().is_none(),
+        "no task holds the engine cell after dispose — the engine is freed"
+    );
+}

--- a/crates/darkly/tests/layer_clipboard.rs
+++ b/crates/darkly/tests/layer_clipboard.rs
@@ -6,6 +6,7 @@
 //!
 //! Run with: `cargo test -p darkly --test layer_clipboard -- --test-threads=1`
 
+use darkly::engine::host::EngineHost;
 use darkly::engine::types::{LayerInfo, StrokeOp};
 use darkly::engine::DarklyEngine;
 use darkly::gpu::context::GpuContext;
@@ -38,12 +39,16 @@ fn paint_dot(engine: &mut DarklyEngine, layer_id: LayerId, x: f32, y: f32) {
     engine.render(0.0);
 }
 
-/// Drive the rich-copy readback to completion and return its `LayerClipboard`
-/// JSON, folded into the copy response's `rich` field. Direct test calls use
-/// the default request id 0.
-fn drain_rich_copy(engine: &mut DarklyEngine) -> String {
-    let resp = engine
-        .test_drive_completed(0)
+/// Drive a rich copy to completion through an [`EngineHost`] and return its
+/// `LayerClipboard` JSON, folded into the copy response's `rich` field. Rich
+/// copy spawns a task, so it's driven via the host's frame loop. Consumes the
+/// engine; direct test calls use the default request id 0.
+fn drain_rich_copy(engine: DarklyEngine, do_copy: impl FnOnce(&mut DarklyEngine)) -> String {
+    let host = EngineHost::adopt(engine);
+    host.with(do_copy);
+    host.pump_until_idle();
+    let resp = host
+        .with(|e| e.test_take_completed(0))
         .expect("rich copy never produced a result");
     resp.value
         .get("rich")
@@ -89,8 +94,7 @@ fn rich_copy_paste_preserves_blend_mode_opacity_and_pixels() {
     source.set_blend_mode(layer, "multiply");
     source.set_layer_name(layer, "Source layer");
 
-    source.copy_layer_rich(layer);
-    let json = drain_rich_copy(&mut source);
+    let json = drain_rich_copy(source, |e| e.copy_layer_rich(layer));
 
     // Sanity-check the JSON envelope.
     assert!(json.contains("\"blend_mode\":\"multiply\""));
@@ -134,8 +138,7 @@ fn rich_paste_records_mask_presence_v1() {
     paint_dot(&mut source, layer, 16.0, 16.0);
     source.add_mask(layer);
 
-    source.copy_layer_rich(layer);
-    let json = drain_rich_copy(&mut source);
+    let json = drain_rich_copy(source, |e| e.copy_layer_rich(layer));
     assert!(
         json.contains("\"mask\":{"),
         "mask metadata should be in JSON"

--- a/crates/darkly/tests/layer_clipboard.rs
+++ b/crates/darkly/tests/layer_clipboard.rs
@@ -38,14 +38,18 @@ fn paint_dot(engine: &mut DarklyEngine, layer_id: LayerId, x: f32, y: f32) {
     engine.render(0.0);
 }
 
-/// Block until the rich-copy readback completes and return its JSON. Uses
-/// the engine's test-only `test_flush_readbacks` helper, which calls
-/// `device.poll(Wait)` to drive WebGPU mapping callbacks synchronously.
+/// Drive the rich-copy readback to completion and return its `LayerClipboard`
+/// JSON, folded into the copy response's `rich` field. Direct test calls use
+/// the default request id 0.
 fn drain_rich_copy(engine: &mut DarklyEngine) -> String {
-    engine.test_flush_readbacks();
-    engine
-        .poll_copy_rich_result()
-        .expect("rich copy never produced a result")
+    let resp = engine
+        .test_drive_completed(0)
+        .expect("rich copy never produced a result");
+    resp.value
+        .get("rich")
+        .and_then(|v| v.as_str())
+        .expect("rich copy response carries the LayerClipboard JSON in `rich`")
+        .to_string()
 }
 
 /// Find a top-level raster layer by id in the engine's serializable tree.

--- a/crates/darkly/tests/protocol.rs
+++ b/crates/darkly/tests/protocol.rs
@@ -143,3 +143,50 @@ fn binary_side_channel_round_trips() {
     assert_eq!(resp.bytes, Some(payload));
     assert_eq!(resp.value.get("len").and_then(|v| v.as_u64()), Some(5));
 }
+
+/// Regression: a one-shot readback op (`copy`) defers — the request that kicked
+/// the readback is the request that resolves with the result, on a *later*
+/// drain, with no separate `poll_*` round-trip. Under the old poll model the
+/// kicking dispatch resolved immediately with `null`; this test pins the
+/// deferred-resolution contract Phase A introduced.
+#[test]
+fn deferred_copy_resolves_originating_request_on_a_later_drain() {
+    use darkly::engine::protocol::Transport;
+    use darkly::engine::ClipboardExport;
+
+    let mut engine = test_engine(32, 32);
+    // `paste_image` allocates the raster layer's GPU texture and uploads
+    // pixels, so the copy readback has something real to read back.
+    let rgba = vec![128u8; (32 * 32 * 4) as usize];
+    let layer = engine.paste_image(32, 32, &rgba, 0, 0, None);
+
+    let transport = Transport::new();
+    const REQ: u64 = 4242;
+    transport.enqueue(REQ, "copy", json!({ "id": layer.to_ffi() }), Vec::new());
+
+    // First drain dispatches `copy`, which kicks the readback and defers: no
+    // outcome for REQ yet (the poll model would have resolved it now, with
+    // null).
+    let first = transport.drain_with(&mut engine);
+    assert!(
+        !first.iter().any(|o| o.id == REQ),
+        "copy must defer — no outcome on the drain that kicked the readback"
+    );
+
+    // Drive the readback, then drain again: the originating request resolves
+    // with the ClipboardExport — no `poll_copy_result` hop.
+    engine.test_flush_readbacks();
+    let second = transport.drain_with(&mut engine);
+    let outcome = second
+        .iter()
+        .find(|o| o.id == REQ)
+        .expect("copy resolves the originating request on a later drain");
+    let resp = outcome
+        .result
+        .as_ref()
+        .expect("copy resolved, not rejected");
+    let export: ClipboardExport =
+        serde_json::from_value(resp.value.clone()).expect("copy response is a ClipboardExport");
+    assert_eq!(export.width, 32, "copied region spans the full canvas");
+    assert_eq!(export.height, 32);
+}

--- a/crates/darkly/tests/protocol.rs
+++ b/crates/darkly/tests/protocol.rs
@@ -1,9 +1,9 @@
-//! Request/response protocol dispatch tests (Plan step 2 + step 7 verification).
+//! Request/response protocol dispatch tests.
 //!
 //! These run native (headless `GpuContext`) and prove the registry routes,
 //! handlers decode/encode, and the binary side-channel round-trips. They
 //! cannot reproduce the *browser* event-pump re-entrancy panic — that is the
-//! manual browser repro's job (see plan Verification).
+//! manual browser repro's job.
 //!
 //! Run with: `cargo test -p darkly --test protocol --features testing`
 
@@ -146,11 +146,12 @@ fn binary_side_channel_round_trips() {
 
 /// Regression: a one-shot readback op (`copy`) defers — the request that kicked
 /// the readback is the request that resolves with the result, on a *later*
-/// drain, with no separate `poll_*` round-trip. Under the old poll model the
-/// kicking dispatch resolved immediately with `null`; this test pins the
-/// deferred-resolution contract Phase A introduced.
+/// drain, with no separate `poll_*` round-trip. `copy` spawns a task on the
+/// engine host's executor; the dispatch emits no outcome (`Response::deferred`),
+/// and the task resolves the originating request once the host drives it.
 #[test]
 fn deferred_copy_resolves_originating_request_on_a_later_drain() {
+    use darkly::engine::host::EngineHost;
     use darkly::engine::protocol::Transport;
     use darkly::engine::ClipboardExport;
 
@@ -160,23 +161,24 @@ fn deferred_copy_resolves_originating_request_on_a_later_drain() {
     let rgba = vec![128u8; (32 * 32 * 4) as usize];
     let layer = engine.paste_image(32, 32, &rgba, 0, 0, None);
 
+    let host = EngineHost::adopt(engine);
     let transport = Transport::new();
     const REQ: u64 = 4242;
     transport.enqueue(REQ, "copy", json!({ "id": layer.to_ffi() }), Vec::new());
 
-    // First drain dispatches `copy`, which kicks the readback and defers: no
-    // outcome for REQ yet (the poll model would have resolved it now, with
-    // null).
-    let first = transport.drain_with(&mut engine);
+    // Dispatch `copy` (without driving its task): the deferred handler spawns
+    // the task and emits no outcome for REQ — the poll model would have resolved
+    // it now, with null.
+    let first = host.with(|e| transport.drain_with(e));
     assert!(
         !first.iter().any(|o| o.id == REQ),
         "copy must defer — no outcome on the drain that kicked the readback"
     );
 
-    // Drive the readback, then drain again: the originating request resolves
-    // with the ClipboardExport — no `poll_copy_result` hop.
-    engine.test_flush_readbacks();
-    let second = transport.drain_with(&mut engine);
+    // Drive the task to completion, then drain again: the originating request
+    // resolves with the ClipboardExport — no `poll_copy_result` hop.
+    host.pump_until_idle();
+    let second = host.with(|e| transport.drain_with(e));
     let outcome = second
         .iter()
         .find(|o| o.id == REQ)

--- a/frontend/src/actions/__tests__/clipboard.test.ts
+++ b/frontend/src/actions/__tests__/clipboard.test.ts
@@ -15,7 +15,6 @@ const { engine, fakeApp, fakeConfig, fakeBrushGraph } = vi.hoisted(() => {
         activeToolId: 'brush',
         docW: 100,
         docH: 100,
-        onCopyResult: vi.fn(),
         requestFrame: vi.fn(),
         selectLayer: vi.fn(),
         refreshLayerTree: vi.fn().mockResolvedValue(undefined),
@@ -41,7 +40,6 @@ import { registerClipboardActions } from '../clipboard';
 beforeEach(() => {
     engine.post.mockClear();
     engine.send.mockClear();
-    fakeApp.onCopyResult.mockClear();
     fakeApp.activeLayerId = 42;
 });
 
@@ -61,10 +59,10 @@ describe('clipboard action registration', () => {
 // mismatch surfaced as `bad_payload missing field \`id\`` on Ctrl+C and made
 // copy/cut silently fail. These pin the field name so it can't drift back.
 describe('copy/cut send the layer id under the `id` field (not `layer_id`)', () => {
-    it('copy posts copy_layer_rich with { id }', () => {
+    it('copy sends copy_layer_rich with { id }', async () => {
         registerClipboardActions();
-        actions.get('copy')!.handler({});
-        expect(engine.post).toHaveBeenCalledWith('copy_layer_rich', { id: 42 });
+        await actions.get('copy')!.handler({});
+        expect(engine.send).toHaveBeenCalledWith('copy_layer_rich', { id: 42 });
     });
 
     it('cut sends cut with { id }', async () => {
@@ -73,10 +71,10 @@ describe('copy/cut send the layer id under the `id` field (not `layer_id`)', () 
         expect(engine.send).toHaveBeenCalledWith('cut', { id: 42 });
     });
 
-    it('copy is a no-op when no layer is active', () => {
+    it('copy is a no-op when no layer is active', async () => {
         registerClipboardActions();
         fakeApp.activeLayerId = null;
-        actions.get('copy')!.handler({});
-        expect(engine.post).not.toHaveBeenCalled();
+        await actions.get('copy')!.handler({});
+        expect(engine.send).not.toHaveBeenCalled();
     });
 });

--- a/frontend/src/actions/clipboard.ts
+++ b/frontend/src/actions/clipboard.ts
@@ -37,21 +37,18 @@ export function registerClipboardActions(): void {
         description: 'Copy the active layer to the clipboard.',
         icon: 'fa6-solid:copy',
         menuPath: ['Edit:40'],
-        handler: () => {
+        handler: async () => {
             const engine = app.engine;
             if (!engine || app.activeLayerId == null) return;
             // `copy_layer_rich` snapshots metadata up front and then drives
             // the same async pixel readback that `copy` does — it's a
-            // superset, so we don't need to call both.
-            engine.post('copy_layer_rich', { id: app.activeLayerId });
-            app.onCopyResult(async (result) => {
-                if (!result?.rgba) return;
-                // The rich JSON lands one frame later, on the same readback
-                // completion path. Polling here is safe because we got the
-                // pixel result; the rich result is set before this callback.
-                const richJson = (await engine.send('poll_copy_rich_result')) ?? undefined;
-                copyToSystemClipboard(result.rgba, result.width, result.height, richJson);
-            });
+            // superset, so we don't need to call both. The request resolves
+            // once the readback lands, with the pixel result plus the rich
+            // JSON folded in as `rich`.
+            app.requestFrame();
+            const result = await engine.send('copy_layer_rich', { id: app.activeLayerId });
+            if (!result?.rgba) return;
+            copyToSystemClipboard(result.rgba, result.width, result.height, result.rich ?? undefined);
         },
     });
     actions.register({
@@ -67,13 +64,12 @@ export function registerClipboardActions(): void {
             // No `cut_layer_rich` yet — fall back to the pixels-only path
             // for cut. Cross-tab paste of a cut layer still works (PNG
             // fallback restores the bitmap) but loses blend mode/opacity.
-            // Worth a follow-up.
-            await engine.send('cut', { id: app.activeLayerId });
-            app.onCopyResult((result) => {
-                if (result?.rgba) {
-                    copyToSystemClipboard(result.rgba, result.width, result.height);
-                }
-            });
+            // Worth a follow-up. The request resolves once the readback lands.
+            app.requestFrame();
+            const result = await engine.send('cut', { id: app.activeLayerId });
+            if (result?.rgba) {
+                copyToSystemClipboard(result.rgba, result.width, result.height);
+            }
             app.requestFrame();
         },
     });

--- a/frontend/src/engine/protocol.ts
+++ b/frontend/src/engine/protocol.ts
@@ -125,8 +125,15 @@ export class Engine {
         return this.handle.engine_default_thumb_size();
     }
 
-    /** Release the underlying wasm handle (wasm-bindgen destructor). */
+    /** Release the underlying wasm handle (wasm-bindgen destructor). Any
+     *  in-flight requests — including deferred readbacks (copy / export / save)
+     *  whose result can no longer land once the engine is gone — are rejected
+     *  so their promises never dangle. */
     free(): void {
+        for (const [, p] of this.pending) {
+            p.reject({ kind: 'engine_error', message: 'engine disposed' });
+        }
+        this.pending.clear();
         this.handle.free();
     }
 

--- a/frontend/src/engine/protocol_gen.ts
+++ b/frontend/src/engine/protocol_gen.ts
@@ -108,11 +108,7 @@ export type RequestKind =
     | 'paste_in_place_floating'
     | 'paste_layer_rich'
     | 'pick_color'
-    | 'poll_copy_result'
-    | 'poll_copy_rich_result'
-    | 'poll_export_result'
     | 'poll_preview'
-    | 'poll_save_result'
     | 'redo'
     | 'refresh_brush_cursor_preview'
     | 'remove_layer'
@@ -271,11 +267,7 @@ export const REQUEST_KINDS: readonly RequestKind[] = [
     'paste_in_place_floating',
     'paste_layer_rich',
     'pick_color',
-    'poll_copy_result',
-    'poll_copy_rich_result',
-    'poll_export_result',
     'poll_preview',
-    'poll_save_result',
     'redo',
     'refresh_brush_cursor_preview',
     'remove_layer',

--- a/frontend/src/state/app.svelte.ts
+++ b/frontend/src/state/app.svelte.ts
@@ -1,5 +1,4 @@
 import type { Engine, EngineState } from '../engine/protocol';
-import type { SaveBundle } from '../storage/saveDocument';
 import { compute_view_matrices } from '../../wasm/pkg/darkly_wasm';
 import { toolRegistry } from '../tools/registry';
 import { pollPick } from '../tools/color_pick_sync';
@@ -8,39 +7,6 @@ import { CameraSource } from '../lib/cameraSource';
 
 export interface Color {
     r: number; g: number; b: number; a: number;
-}
-
-/** Packed `poll_save_result` payload: every byte blob concatenated into one
- *  `bytes` buffer, with the lengths needed to slice them back out. */
-interface PackedSaveResult {
-    manifestLen: number;
-    compositeWidth: number;
-    compositeHeight: number;
-    compositeLen: number;
-    blobs: Array<{ path: string; len: number }>;
-    bytes: Uint8Array;
-}
-
-/** Reconstruct the {@link SaveBundle} `saveDocument.ts` expects from the packed
- *  protocol result (manifest ++ composite ++ blob0 ++ blob1 ++ … in `bytes`). */
-function unpackSaveBundle(p: PackedSaveResult): SaveBundle {
-    let off = 0;
-    const manifestJson = p.bytes.subarray(off, off + p.manifestLen);
-    off += p.manifestLen;
-    const compositeRgba = p.bytes.subarray(off, off + p.compositeLen);
-    off += p.compositeLen;
-    const blobs = p.blobs.map((b) => {
-        const bytes = p.bytes.subarray(off, off + b.len);
-        off += b.len;
-        return { path: b.path, bytes };
-    });
-    return {
-        manifestJson,
-        compositeWidth: p.compositeWidth,
-        compositeHeight: p.compositeHeight,
-        compositeRgba,
-        blobs,
-    };
 }
 
 /**
@@ -742,41 +708,6 @@ export class DarklyInstance {
         this.veilList = Array.isArray(list) ? list : [];
     }
 
-    // --- Async copy result callback ---
-
-    private _copyCallback: ((result: any) => void) | null = null;
-
-    /** Register a one-shot callback for when the async copy readback completes. */
-    onCopyResult(cb: (result: any) => void) {
-        this._copyCallback = cb;
-        this.requestFrame();
-    }
-
-    // --- Async export result callback ---
-
-    private _exportCallback:
-        | ((result: { width: number; height: number; rgba: Uint8Array }) => void)
-        | null = null;
-
-    /** Register a one-shot callback for when the async export readback completes. */
-    onExportResult(cb: (result: { width: number; height: number; rgba: Uint8Array }) => void) {
-        this._exportCallback = cb;
-        this.requestFrame();
-    }
-
-    // --- Async save result callback ---
-
-    private _saveCallback: ((bundle: SaveBundle) => void) | null = null;
-
-    /** Register a one-shot callback for when the async `.darkly` save
-     *  readback completes (manifest JSON + composite RGBA + per-blob
-     *  bytes arrive together). The caller PNG-encodes the composite +
-     *  thumbnail and assembles the zip; see `storage/saveDocument.ts`. */
-    onSaveResult(cb: (bundle: SaveBundle) => void) {
-        this._saveCallback = cb;
-        this.requestFrame();
-    }
-
     // --- Demand-driven rendering ---
 
     private _framePending = false;
@@ -865,52 +796,14 @@ export class DarklyInstance {
             // committed by `pollPick`. Cheap when nothing changed.
             tickColorPickerCursor();
 
-            // Check for completed async copy/cut readback.
-            if (this._copyCallback) {
-                engine.send('poll_copy_result').then((result) => {
-                    if (result && this._copyCallback) {
-                        const cb = this._copyCallback;
-                        this._copyCallback = null;
-                        cb(result);
-                    }
-                });
-            }
-
-            // Check for completed async export readback.
-            if (this._exportCallback) {
-                engine
-                    .send<{ width: number; height: number; bytes: Uint8Array }>('poll_export_result')
-                    .then((result) => {
-                        if (result && this._exportCallback) {
-                            const cb = this._exportCallback;
-                            this._exportCallback = null;
-                            cb({ width: result.width, height: result.height, rgba: result.bytes });
-                        }
-                    });
-            }
-
-            // Check for completed async `.darkly` save readbacks. The bundle's
-            // byte blobs arrive concatenated in `bytes`; slice them back out
-            // into the per-blob shape `saveDocument.ts` expects.
-            if (this._saveCallback) {
-                engine.send<PackedSaveResult>('poll_save_result').then((packed) => {
-                    if (!packed || !this._saveCallback) return;
-                    const cb = this._saveCallback;
-                    this._saveCallback = null;
-                    cb(unpackSaveBundle(packed));
-                });
-            }
-
             // Continue animation loop only when no UI interaction is
             // monopolizing the main thread.  One-shot renders (tool
             // actions, resize, etc.) always go through — only the
-            // self-scheduling continuous loop is suppressed.
-            const shouldContinue =
-                frame.needsMore ||
-                this._copyCallback ||
-                this._exportCallback ||
-                this._saveCallback;
-            if (shouldContinue && this._interactionCount === 0) {
+            // self-scheduling continuous loop is suppressed. `needsMore`
+            // stays true while any async readback (copy / export / save) is
+            // in flight, so the loop keeps driving them to completion and the
+            // deferred request promises resolve on their own.
+            if (frame.needsMore && this._interactionCount === 0) {
                 this.requestFrame();
             }
         });

--- a/frontend/src/state/autosave.svelte.ts
+++ b/frontend/src/state/autosave.svelte.ts
@@ -3,8 +3,9 @@
  * tab (when dirty and idle) to OPFS for crash recovery, and it snapshots a
  * tab when you switch away from it so every open document is covered. The
  * snapshot bytes come from `produceDarklyBytes`, which keeps the tab's
- * render loop alive (via `onSaveResult`) until the readback lands — so even
- * a backgrounded tab completes without the user looking at it.
+ * render loop alive until the save's readbacks land (the in-flight save keeps
+ * `needsMore` true) — so even a backgrounded tab completes without the user
+ * looking at it.
  *
  * Snapshots reuse the exact `.darkly` save pipeline and are marked
  * `'snapshot'` so they leave the document's dirty flag set (nothing

--- a/frontend/src/storage/saveDocument.ts
+++ b/frontend/src/storage/saveDocument.ts
@@ -23,8 +23,8 @@ import { sessionId } from '../state/recoverySession';
  *  clears it. */
 export type SavePurpose = 'file' | 'snapshot';
 
-/** Wire shape reconstructed from the `poll_save_result` request (the engine
- *  packs it; `app.svelte.ts::unpackSaveBundle` slices it back out). Mirrors
+/** Wire shape reconstructed from the `start_save_document` response (the engine
+ *  packs it; {@link unpackSaveBundle} slices it back out). Mirrors
  *  `crates/darkly/src/format/manifest.rs::SaveBundle`. */
 export interface SaveBundle {
     manifestJson: Uint8Array;
@@ -32,6 +32,39 @@ export interface SaveBundle {
     compositeHeight: number;
     compositeRgba: Uint8Array;
     blobs: Array<{ path: string; bytes: Uint8Array }>;
+}
+
+/** Packed `start_save_document` response: every byte blob concatenated into one
+ *  `bytes` buffer, with the lengths needed to slice them back out. */
+interface PackedSaveResult {
+    manifestLen: number;
+    compositeWidth: number;
+    compositeHeight: number;
+    compositeLen: number;
+    blobs: Array<{ path: string; len: number }>;
+    bytes: Uint8Array;
+}
+
+/** Reconstruct the {@link SaveBundle} from the packed protocol result
+ *  (manifest ++ composite ++ blob0 ++ blob1 ++ … in `bytes`). */
+function unpackSaveBundle(p: PackedSaveResult): SaveBundle {
+    let off = 0;
+    const manifestJson = p.bytes.subarray(off, off + p.manifestLen);
+    off += p.manifestLen;
+    const compositeRgba = p.bytes.subarray(off, off + p.compositeLen);
+    off += p.compositeLen;
+    const blobs = p.blobs.map((b) => {
+        const bytes = p.bytes.subarray(off, off + b.len);
+        off += b.len;
+        return { path: b.path, bytes };
+    });
+    return {
+        manifestJson,
+        compositeWidth: p.compositeWidth,
+        compositeHeight: p.compositeHeight,
+        compositeRgba,
+        blobs,
+    };
 }
 
 const THUMBNAIL_MAX_DIM = 256;
@@ -80,11 +113,11 @@ export async function saveDocument({ forceAs = false }: { forceAs?: boolean } = 
 /**
  * Drive a `.darkly` save for `instance` to completion and return the
  * assembled zip bytes — the destination-agnostic core shared by file-save
- * (above) and autosave snapshots. It kicks `start_save_document` over the
- * async transport and awaits the `poll_save_result` callback, which the
- * instance's render loop drives to completion (`onSaveResult` keeps that
- * loop alive even for a backgrounded tab; the Rust `poll_save_result`
- * drains the readback scheduler itself).
+ * (above) and autosave snapshots. It kicks `start_save_document`, whose
+ * promise resolves with the packed `SaveBundle` once every readback lands.
+ * The instance's render loop drives those readbacks to completion (the save
+ * keeps `needsMore` true while it's in flight, so the loop self-schedules —
+ * even a backgrounded tab completes on its own render loop).
  *
  * Rejects if a save is already in flight on the engine
  * (`SaveError::InProgress`) — autosave catches this and skips the tick so
@@ -118,25 +151,21 @@ async function acquireHandle(forceAs: boolean): Promise<FileSystemFileHandle | n
     return handle;
 }
 
-/** Kick `start_save_document` on `instance` and await the
- *  `poll_save_result` callback. `snapshot` marks an autosave save (which
- *  must not clear the document's dirty flag — see the Rust `SavePurpose`).
- *  The instance's render loop polls `poll_save_result` until the bundle
- *  lands; `onSaveResult` keeps that loop alive even for a backgrounded tab. */
-function runSaveBundle(instance: DarklyInstance, snapshot: boolean): Promise<SaveBundle> {
-    return new Promise((resolve, reject) => {
-        const engine = instance.engine;
-        if (!engine) {
-            reject(new Error('no engine handle'));
-            return;
-        }
-        instance.onSaveResult((bundle: SaveBundle) => resolve(bundle));
-        // `start_save_document` rejects on error; surface that as the save
-        // failure rather than waiting forever for a callback that won't fire.
-        engine
-            .send('start_save_document', { snapshot })
-            .catch((e) => reject(e instanceof Error ? e : new Error(String(e))));
-    });
+/** Kick `start_save_document` on `instance` and await its deferred result.
+ *  The request's promise resolves with the packed bundle once every readback
+ *  lands — the instance's render loop drives them to completion (the save
+ *  keeps the loop alive while in flight, even for a backgrounded tab).
+ *  `snapshot` marks an autosave save (which must not clear the document's
+ *  dirty flag — see the Rust `SavePurpose`). Rejects on `SaveError::InProgress`
+ *  or any transport failure. */
+async function runSaveBundle(instance: DarklyInstance, snapshot: boolean): Promise<SaveBundle> {
+    const engine = instance.engine;
+    if (!engine) throw new Error('no engine handle');
+    // Keep the render loop ticking so the save's readbacks get driven to
+    // completion even if nothing else requests frames.
+    instance.requestFrame();
+    const packed = await engine.send<PackedSaveResult>('start_save_document', { snapshot });
+    return unpackSaveBundle(packed);
 }
 
 /** Build the .darkly zip bytes from a SaveBundle. */

--- a/frontend/src/ui/ExportImageModal.svelte
+++ b/frontend/src/ui/ExportImageModal.svelte
@@ -43,24 +43,25 @@
         downloadBlob(blob, filename);
     }
 
-    function confirm() {
+    async function confirm() {
         if (!app.engine || exporting) return;
         exporting = true;
         const engine = app.engine;
-        app.onExportResult(async (result) => {
-            try {
-                if (result?.rgba) {
-                    await encodeAndDownload(result.width, result.height, result.rgba);
-                }
-            } catch (e) {
-                console.error('[export-image] encode failed', e);
-                alert('Export failed — see console for details.');
-            } finally {
-                exporting = false;
-                exportImage.open = false;
+        app.requestFrame();
+        try {
+            const result = await engine.send<{ width: number; height: number; bytes: Uint8Array }>(
+                'start_export',
+            );
+            if (result?.bytes) {
+                await encodeAndDownload(result.width, result.height, result.bytes);
             }
-        });
-        engine.post('start_export');
+        } catch (e) {
+            console.error('[export-image] encode failed', e);
+            alert('Export failed — see console for details.');
+        } finally {
+            exporting = false;
+            exportImage.open = false;
+        }
     }
 </script>
 

--- a/frontend/src/ui/ResizeCanvasModal.svelte
+++ b/frontend/src/ui/ResizeCanvasModal.svelte
@@ -78,22 +78,24 @@
     // Reuse the async export readback (offscreen composite → GPU readback →
     // poll). The result is the current canvas window at oldW×oldH, so it maps
     // 1:1 onto the content rect.
-    function requestComposite() {
-        if (!app.engine) return;
-        app.engine.post('start_export');
-        app.onExportResult((result) => {
-            if (!resizeCanvas.open) return; // modal closed before it landed
-            const cv = document.createElement('canvas');
-            cv.width = result.width;
-            cv.height = result.height;
-            const cctx = cv.getContext('2d');
-            if (!cctx) return;
-            const clamped = new Uint8ClampedArray(result.rgba.length);
-            clamped.set(result.rgba);
-            cctx.putImageData(new ImageData(clamped, result.width, result.height), 0, 0);
-            compositeCanvas = cv;
-            compositeVersion++;
-        });
+    async function requestComposite() {
+        const engine = app.engine;
+        if (!engine) return;
+        app.requestFrame();
+        const result = await engine.send<{ width: number; height: number; bytes: Uint8Array }>(
+            'start_export',
+        );
+        if (!resizeCanvas.open || !result?.bytes) return; // modal closed before it landed
+        const cv = document.createElement('canvas');
+        cv.width = result.width;
+        cv.height = result.height;
+        const cctx = cv.getContext('2d');
+        if (!cctx) return;
+        const clamped = new Uint8ClampedArray(result.bytes.length);
+        clamped.set(result.bytes);
+        cctx.putImageData(new ImageData(clamped, result.width, result.height), 0, 0);
+        compositeCanvas = cv;
+        compositeVersion++;
     }
 
     // --- Numeric / anchor controls --------------------------------------

--- a/frontend/wasm/src/api.rs
+++ b/frontend/wasm/src/api.rs
@@ -13,17 +13,20 @@
 //! Chromium pumps the browser event queue *inside* `queue.submit()` /
 //! `device.poll()`. The old bridge held `engine.borrow_mut()` across a method
 //! and a re-entrant pointer/rAF callback took a competing borrow → permanent
-//! `RefCell` poison. Now there are **exactly two** engine borrow sites:
+//! `RefCell` poison. Now every engine access goes through the core
+//! [`EngineHost`], whose sole sanctioned borrow is `EngineCell::with` —
+//! `try_borrow_mut` that yields instead of panicking. The bridge holds no engine
+//! `RefCell` of its own:
 //!
-//! - [`render`] — `try_borrow_mut`; drains the FIFO then composites, all in one
-//!   borrow. Returns `false`-equivalent (`busy: true`) and reschedules if it
-//!   can't get the borrow.
-//! - [`drain`] — `Transport::try_drain`, which `try_borrow_mut`s and yields
-//!   `busy` instead of panicking when render holds the borrow.
+//! - [`render`] — `host.tick`, which orchestrates drain → drive tasks →
+//!   composite as scoped bursts and yields `busy: true` if a re-entrant frame
+//!   can't acquire the engine.
+//! - [`drain`] — `host.pump`, the macrotask path; same try-acquire-or-yield.
 //!
 //! [`enqueue`] borrows nothing (it only appends to the FIFO), so a re-entrant
 //! request fired inside `submit()` is safe by construction. A CI grep gate
-//! enforces that no third `engine.borrow*()` site appears.
+//! enforces that `EngineCell::with` is the only engine borrow — no raw
+//! `borrow*()` on a `RefCell<DarklyEngine>` outside `engine/host/cell.rs`.
 //!
 //! `frame_count` / `thumbnail_version` are no longer separate borrowing reads —
 //! [`render`] returns them as a downhill projection of its single borrow.
@@ -31,7 +34,8 @@
 use std::cell::RefCell;
 use std::sync::Arc;
 
-use darkly::engine::protocol::{DrainOutcome, RequestOutcome, Transport};
+use darkly::engine::host::EngineHost;
+use darkly::engine::protocol::{RequestOutcome, Transport};
 use darkly::engine::DarklyEngine;
 use darkly::gpu::context::{GpuContext, GpuDevice};
 use darkly::layer::LayerId;
@@ -191,9 +195,13 @@ struct PendingExternalImage {
 
 #[wasm_bindgen]
 pub struct DarklyHandle {
-    engine: RefCell<DarklyEngine>,
+    /// The core orchestration host — owns the engine cell and the frame-driven
+    /// executor. The bridge holds no engine `RefCell` of its own; all access is
+    /// through the host's scoped bursts.
+    host: EngineHost,
     /// The deferred request transport (FIFO + dispatch registry). Enqueue-only
-    /// from JS; drained here.
+    /// from JS; lives bridge-side and is drained into the host via the injected
+    /// drain closure.
     transport: Transport,
     /// Side-FIFO for the OffscreenCanvas upload exception (see
     /// [`PendingExternalImage`]). Enqueue-only; applied at drain/render time.
@@ -203,7 +211,7 @@ pub struct DarklyHandle {
 impl DarklyHandle {
     fn from_engine(engine: DarklyEngine) -> Self {
         DarklyHandle {
-            engine: RefCell::new(engine),
+            host: EngineHost::adopt(engine),
             transport: Transport::new(),
             pending_images: RefCell::new(Vec::new()),
         }
@@ -266,22 +274,20 @@ impl DarklyHandle {
             .enqueue(id as u64, kind, value, bytes.unwrap_or_default());
     }
 
-    /// Non-blocking drain (the scheduler path). Returns `{ busy: true }` if the
-    /// engine is borrowed (render in flight — caller reschedules), else
-    /// `{ busy: false, results: [...] }` with one entry per dispatched request.
+    /// Non-blocking drain (the scheduler / macrotask path). Returns
+    /// `{ busy: true }` if the engine is borrowed (render in flight — caller
+    /// reschedules), else `{ busy: false, results: [...] }` with one entry per
+    /// dispatched request. Also drives in-flight deferred tasks so they can
+    /// progress between frames.
     pub fn drain(&self) -> JsValue {
-        // Apply deferred OffscreenCanvas uploads first, under the same borrow,
-        // without panicking if render holds it.
-        let outcome = {
-            let Ok(mut e) = self.engine.try_borrow_mut() else {
-                return busy_result();
-            };
-            self.apply_pending_images(&mut e);
-            DrainOutcome::Drained(self.transport.drain_with(&mut e))
-        };
-        match outcome {
-            DrainOutcome::Busy => busy_result(),
-            DrainOutcome::Drained(outcomes) => drained_result(outcomes),
+        let outcome = self.host.pump(
+            |e| self.apply_pending_images(e),
+            |e| self.transport.drain_with(e),
+        );
+        if outcome.busy {
+            busy_result()
+        } else {
+            drained_result(outcome.outcomes)
         }
     }
 
@@ -292,53 +298,48 @@ impl DarklyHandle {
     /// true when a re-entrant render couldn't get the borrow (caller must not
     /// reschedule another rAF — the outer render handles everything).
     pub fn render(&self, time_secs: f32) -> JsValue {
-        let Ok(mut e) = self.engine.try_borrow_mut() else {
-            return busy_result();
-        };
-
         let frame_start = web_time::Instant::now();
-        let drain_start = web_time::Instant::now();
-        self.apply_pending_images(&mut e);
-        let mut outcomes = self.transport.drain_with(&mut e);
-        let drain_us = drain_start.elapsed().as_micros() as u64;
 
-        let render_start = web_time::Instant::now();
-        let needs_more = e.render(time_secs);
-        let render_us = render_start.elapsed().as_micros() as u64;
-
-        // Deferred readbacks (copy / export / save) complete inside `render`'s
-        // poll — flush their terminal outcomes so they resolve this frame
-        // rather than waiting for the next drain.
-        outcomes.extend(e.take_completed_requests());
-
-        let frame_us = frame_start.elapsed().as_micros() as u64;
-        if frame_us > 25_000 {
-            let p = e.last_render_phases();
-            log::warn!(
-                "[frame-perf] slow frame={:.2}ms drain={:.2}ms render={:.2}ms \
-                 [render breakdown: poll={:.2}ms thumb={:.2}ms anim={:.2}ms composite={:.2}ms]",
-                frame_us as f32 / 1000.0,
-                drain_us as f32 / 1000.0,
-                render_us as f32 / 1000.0,
-                p.poll_us as f32 / 1000.0,
-                p.thumb_us as f32 / 1000.0,
-                p.anim_us as f32 / 1000.0,
-                p.compositor_us as f32 / 1000.0,
-            );
+        // The host orchestrates drain → drive tasks → composite as scoped
+        // bursts; a re-entrant frame that can't acquire the engine yields busy.
+        let outcome = self.host.tick(
+            time_secs,
+            |e| self.apply_pending_images(e),
+            |e| self.transport.drain_with(e),
+        );
+        if outcome.busy {
+            return busy_result();
         }
 
-        // The frontend's synchronously-readable engine-state mirror — one struct
-        // for every value the UI caches (frame/thumbnail counters + document
-        // bools), built from cheap CPU reads under the borrow render already
-        // holds (no extra query / per-frame poll). Grows as the UI needs more.
-        let state = serde_wasm_bindgen::to_value(&e.engine_state()).unwrap_or(JsValue::NULL);
-        drop(e);
+        let frame_us = frame_start.elapsed().as_micros() as u64;
+
+        // The frontend's synchronously-readable engine-state mirror plus the
+        // slow-frame perf log — both cheap CPU reads through a scoped burst.
+        let state = self
+            .host
+            .cell()
+            .with(|e| {
+                if frame_us > 25_000 {
+                    let p = e.last_render_phases();
+                    log::warn!(
+                        "[frame-perf] slow frame={:.2}ms \
+                         [render breakdown: poll={:.2}ms thumb={:.2}ms anim={:.2}ms composite={:.2}ms]",
+                        frame_us as f32 / 1000.0,
+                        p.poll_us as f32 / 1000.0,
+                        p.thumb_us as f32 / 1000.0,
+                        p.anim_us as f32 / 1000.0,
+                        p.compositor_us as f32 / 1000.0,
+                    );
+                }
+                serde_wasm_bindgen::to_value(&e.engine_state()).unwrap_or(JsValue::NULL)
+            })
+            .unwrap_or(JsValue::NULL);
 
         let obj = js_sys::Object::new();
         set(&obj, "busy", JsValue::FALSE);
-        set(&obj, "needsMore", JsValue::from_bool(needs_more));
+        set(&obj, "needsMore", JsValue::from_bool(outcome.needs_more));
         set(&obj, "state", state);
-        set(&obj, "results", outcomes_to_js(outcomes).into());
+        set(&obj, "results", outcomes_to_js(outcome.outcomes).into());
         obj.into()
     }
 

--- a/frontend/wasm/src/api.rs
+++ b/frontend/wasm/src/api.rs
@@ -299,12 +299,17 @@ impl DarklyHandle {
         let frame_start = web_time::Instant::now();
         let drain_start = web_time::Instant::now();
         self.apply_pending_images(&mut e);
-        let outcomes = self.transport.drain_with(&mut e);
+        let mut outcomes = self.transport.drain_with(&mut e);
         let drain_us = drain_start.elapsed().as_micros() as u64;
 
         let render_start = web_time::Instant::now();
         let needs_more = e.render(time_secs);
         let render_us = render_start.elapsed().as_micros() as u64;
+
+        // Deferred readbacks (copy / export / save) complete inside `render`'s
+        // poll — flush their terminal outcomes so they resolve this frame
+        // rather than waiting for the next drain.
+        outcomes.extend(e.take_completed_requests());
 
         let frame_us = frame_start.elapsed().as_micros() as u64;
         if frame_us > 25_000 {


### PR DESCRIPTION
Starts to clean up the slightly questionable engine bridge and prepares the way for a bigger and cleaner refactor.

---

## Phase A — Deferred FFI resolution (transport unification)

Every async GPU op (copy, cut, export, save) used to carry a hand-written deferral state machine: a `pending_*_result` field, a `poll_*` method, a `poll_*` protocol kind, a frontend `_xCallback` + `onXResult` registrar, and a per-frame `if (this._xCallback) engine.send('poll_…')` block. This PR makes the request that kicks a readback the request that resolves with its result, and deletes that whole family.

### Mechanism
- **`Response.deferred`** — a handler that kicked an async readback returns `Response::deferred()`; the transport emits no outcome for it that drain. Only the readback-kicking handlers changed; the other ~155 are untouched.
- **`current_request_id` + `completed_requests`** on `DarklyEngine` — `Transport::drain_with` records the id being dispatched so a deferring op can stash it in its `ReadbackContext`/`PendingCopy`/`SaveJob`; the readback's completion handler pushes the terminal outcome (`resolve_request`/`reject_request`) onto `completed_requests`, which `drain_with` and the WASM `render` flush into the existing id→promise table.
- **Exactly one terminal outcome per deferred request** — resolve on completion, or immediate `null` when there's nothing to read back. `Engine.free()` rejects all in-flight promises so handle disposal never dangles.

### Converted
`copy`, `cut`, `copy_layer_rich` (rich-layer JSON now folds into the single copy promise as a `rich` field — the second poll hop is removed), `start_export`, `start_save_document` (resolves with the packed `SaveBundle` once every readback lands; finished by `complete_save_readback`/`finish_save_job`).

### Deleted
- Rust: `pending_copy_result`, `pending_layer_clip`, `pending_export_result`, `ExportImageResult`, and the `poll_copy_result`/`poll_copy_rich_result`/`poll_export_result`/`poll_save_result` methods + protocol kinds.
- Frontend: `_copyCallback`/`_exportCallback`/`_saveCallback`, `onCopyResult`/`onExportResult`/`onSaveResult`, and the three per-frame poll blocks. Call sites collapse to `const r = await engine.send('copy_layer_rich', { id })` etc. Save still completes on a backgrounded tab via `render()`'s `needsMore` loop.

### Tests
- New protocol-level regression test: `copy` defers (no outcome on the kicking drain) and resolves the originating id with the `ClipboardExport` on a later drain — no `poll_*`.
- Updated the engine/save/format/clipboard/canvas-resize tests to drive deferred completions via new test helpers (`test_set_request_id`, `test_take_completed`, `test_drive_completed`).
- Full CLAUDE.md suite passes: fmt, clippy (workspace + wasm), `cargo test --test-threads=1`, wasm-pack, `tsc --noEmit`, frontend build + vitest (243).

### Scope boundary
One-shot readbacks only. Streaming/animated previews (`poll_preview`) are unchanged. Phases B (awaitable-readback executor spike) and C (ts-rs typed client) are separate PRs.
