### PR TITLE
Blur brush

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For a feature to count, it must be:
     - [x] Watercolor
     - [x] Liquify
     - [ ] Clone
-    - [ ] Blur
+    - [x] Blur
     - [ ] Dodge/burn
     - [ ] Calligraphy
     - [ ] Oil / Impasto

--- a/crates/darkly/brushes/blur.yaml
+++ b/crates/darkly/brushes/blur.yaml
@@ -1,0 +1,24 @@
+name: Blur
+category: Effects
+nodes:
+  1:
+    type: pen_input
+    port_defaults:
+      spacing: 0.01
+      stabilize: 0.4
+  2:
+    type: shape
+    port_defaults:
+      softness: 1.0
+  3:
+    type: blur
+connections:
+- '1.position -> 3.position'
+- '1.pressure -> 3.size_input'
+- '2.mask -> 3.mask'
+exposed_ports:
+  "1.stabilize": {}
+  "3.size": {}
+  "2.softness": {}
+  "3.strength": {}
+  "3.opacity": {}

--- a/crates/darkly/src/brush/mod.rs
+++ b/crates/darkly/src/brush/mod.rs
@@ -17,6 +17,7 @@ pub mod paint_target_ext;
 pub mod pipeline;
 pub mod portable;
 pub mod preview_renderer;
+pub mod read_mirror_terminal;
 pub mod save_points;
 pub mod scratch;
 pub mod spacing;

--- a/crates/darkly/src/brush/nodes/blur.rs
+++ b/crates/darkly/src/brush/nodes/blur.rs
@@ -1,0 +1,278 @@
+//! Blur terminal — per-dab fragment-pass neighborhood average with a
+//! per-brush compiled WGSL shader.
+//!
+//! Rides the shared [read-mirror terminal](crate::brush::read_mirror_terminal)
+//! infrastructure (the per-brush pipeline, dab-meta queue, flush loop,
+//! and `copy_origin` plumbing it shares with `smudge` and `liquify`).
+//! This file owns only what's blur-specific: the read half-extent, the
+//! per-dab kernel size, and the variant WGSL.
+//!
+//! Each blur dab samples a golden-angle disc of the scratch read mirror
+//! around `target_pos`, averages the taps, and mixes the result over the
+//! original by `mask × selection × opacity`. The disc radius is
+//! `blur_px = strength × radius`.
+//!
+//! ## Dwell-compounding (intentional — do not "optimize" away)
+//!
+//! A neighborhood average has no inter-dab data dependency, so blur does
+//! **not** *need* per-dab serialization for correctness. It
+//! rides the per-dab serialized path *deliberately*: each dab reads the
+//! *cumulative* scratch (the prior dab's writeback, seen through the
+//! mirror), so overlapping dabs and scrubbing back-and-forth
+//! progressively re-blur already-blurred pixels — like Photoshop's Blur
+//! tool and Krita's blur paintop. Collapsing the flush into a single
+//! instanced pass would silently remove that dwell-compounding behavior.
+//!
+//! ## Size-variant (intentional — the opposite of liquify)
+//!
+//! `blur_px = strength × radius`, so a bigger brush blurs *more*. This is
+//! the deliberate opposite of [`liquify`](super::liquify)'s size-invariant
+//! push, where the size slider scales only the warped extent, not the
+//! intensity.
+
+use std::sync::Arc;
+
+use crate::brush::eval::{BrushNodeEvaluator, EvalContext};
+use crate::brush::gpu_context::BrushGpuContext;
+use crate::brush::node::BrushNodeRegistration;
+use crate::brush::read_mirror_terminal::{
+    self as rmt, insert_slot_output, read_mirror_pipeline_reg, ReadMirrorTerminal,
+};
+use crate::brush::wgsl::{CompileWgslCtx, DabField, NodeWgsl, WgslType};
+use crate::brush::wire::{BrushWireType, ScalarValue};
+use crate::nodegraph::{NodeRegistration, PortDef, UnitType};
+
+/// Per-dab strength below which the dab is dropped — `mix(orig, blurred, 0)`
+/// is an identity write.
+const STRENGTH_EPSILON: f32 = 1.0e-4;
+
+/// Brush radius below which the dab is dropped — a sub-pixel disc has no
+/// neighborhood to average.
+const MIN_RADIUS_PX: f32 = 1.0;
+
+/// Number of golden-angle disc taps the kernel averages (plus the centre
+/// tap). 24 fills the disc densely enough to read as a smooth blur
+/// without making each per-dab fragment pass expensive.
+const BLUR_TAPS: u32 = 24;
+
+/// Kernel radius at full strength, as a fraction of the brush radius.
+/// `blur_px = strength × radius × MAX_KERNEL_FRACTION`, so the slider's
+/// full 0–100% travel maps onto a useful band — past ~25% of the radius
+/// each touch reaches so far it smears rather than softens.
+const MAX_KERNEL_FRACTION: f32 = 0.25;
+
+pub const TYPE_ID: &str = "blur";
+
+pub fn register() -> BrushNodeRegistration {
+    BrushNodeRegistration {
+        pipelines: vec![read_mirror_pipeline_reg("blur")],
+        evaluator: || Box::new(BlurEvaluator),
+        lifecycle: crate::brush::node::Lifecycle::SeedScratchFromPreStroke,
+        node: NodeRegistration {
+            type_id: TYPE_ID,
+            category: "output",
+            display_name: "Blur",
+            description: "Output that softens existing canvas pixels under the stroke by averaging a neighborhood, compounding where the brush dwells.",
+            ports: vec![
+                PortDef::input("position", BrushWireType::Vec2)
+                    .with_description("Canvas-pixel pen tip for this dab"),
+                PortDef::input("size_input", BrushWireType::Scalar)
+                    .with_range(0.0, 1.0, 1.0)
+                    .with_natural_range(0.0, 1.0)
+                    .with_label("Size Input")
+                    .with_unit(UnitType::Percent)
+                    .with_description(
+                        "Per-touch size multiplier (wire pressure here for pressure-sensitive size).",
+                    ),
+                PortDef::input("size", BrushWireType::Scalar)
+                    .with_range(0.0, 4.0, 0.2)
+                    .with_label("Size")
+                    .with_unit(UnitType::Percent)
+                    .with_icon("fa6-solid:up-right-and-down-left-from-center")
+                    .exposed()
+                    .with_preview_value(0.1)
+                    .with_description("Overall brush size. A bigger brush blurs over a wider neighborhood."),
+                PortDef::input("strength", BrushWireType::Scalar)
+                    .with_range(0.0, 1.0, 0.05)
+                    .with_natural_range(0.0, 1.0)
+                    .with_label("Strength")
+                    .with_unit(UnitType::Percent)
+                    .with_icon("fa6-solid:gauge-high")
+                    .exposed()
+                    .with_description(
+                        "How wide a neighborhood each touch averages, as a fraction of the brush \
+                         radius. Higher values soften more per touch.",
+                    ),
+                PortDef::input("opacity", BrushWireType::Scalar)
+                    .with_range(0.0, 1.0, 1.0)
+                    .with_natural_range(0.0, 1.0)
+                    .with_label("Opacity")
+                    .with_unit(UnitType::Percent)
+                    .with_icon("fa6-solid:droplet")
+                    .exposed()
+                    .with_description(
+                        "Overall stroke strength. Lower values blend less of the blurred result \
+                         over the original.",
+                    ),
+                PortDef::input("mask", BrushWireType::Scalar).with_description(
+                    "Per-fragment shape mask (typically wired from shape.mask)",
+                ),
+                PortDef::output("dab_size", BrushWireType::Vec2)
+                    .with_description("Brush mark size in canvas pixels"),
+            ],
+            params: &[],
+            is_gpu: true,
+            is_terminal: true,
+            supports_erase: false,
+        },
+    }
+}
+
+pub struct BlurEvaluator;
+
+impl ReadMirrorTerminal for BlurEvaluator {
+    const PIPELINE_ID: &'static str = "blur";
+    const LABEL: &'static str = "blur";
+
+    fn read_half(&self, ctx: &EvalContext, radius: f32, bbox_radius: f32) -> Option<[f32; 2]> {
+        let strength = ctx.input_f32("strength").clamp(0.0, 1.0);
+        if strength < STRENGTH_EPSILON || radius < MIN_RADIUS_PX {
+            return None;
+        }
+        // Kernel disc radius. The `+ 1.0` covers the bilinear sampler's
+        // half-texel reach past the max tap offset; the shared
+        // `read_half.max(write_half)` clamp then handles a tiny `blur_px`
+        // where `bbox_radius` dominates.
+        let blur_px = strength * radius * MAX_KERNEL_FRACTION;
+        let half = bbox_radius + blur_px + 1.0;
+        Some([half, half])
+    }
+
+    fn pack_extra(&self, ctx: &EvalContext, gpu: &mut BrushGpuContext, node_id: u32, radius: f32) {
+        // Per-dab kernel radius, so a pressure-wired strength rides the
+        // dab record. Inserted before `queue_dab` packs the record.
+        let strength = ctx.input_f32("strength").clamp(0.0, 1.0);
+        let blur_px = strength * radius * MAX_KERNEL_FRACTION;
+        insert_slot_output(gpu, node_id, "blur_px", ScalarValue::Scalar(blur_px));
+    }
+
+    fn compile_body(
+        &self,
+        cctx: &CompileWgslCtx,
+        copy_origin_field: &str,
+    ) -> Result<NodeWgsl, String> {
+        let mut wgsl = NodeWgsl::default();
+
+        let mask_expr = cctx.input("mask").as_f32();
+        let opacity_expr = cctx.input("opacity").as_f32();
+
+        // Per-dab kernel radius (canvas px). `evaluate_gpu`'s `pack_extra`
+        // inserts the value into `dab_batch.slot_outputs`; the packer
+        // reads it through the standard `pack_dab_record` path.
+        let blur_field = cctx.dab_field_name("blur_px");
+        let key = blur_field.clone();
+        wgsl.dab_fields.push(DabField {
+            name: blur_field.clone(),
+            ty: WgslType::F32,
+            pack: Arc::new(move |outputs, bytes| {
+                let v = outputs.get(&key).map(|s| s.as_f32()).unwrap_or(0.0);
+                bytes.extend_from_slice(bytemuck::bytes_of(&v));
+            }),
+        });
+
+        // Golden-angle spiral disc of taps over the scratch read mirror,
+        // averaged into `blurred`. Each tap's UV is clamped inside the
+        // mirror bounds so high-strength edge dabs never sample undefined
+        // texels.
+        //
+        // Golden-angle bokeh / sunflower-disc sampling technique adapted
+        // from the `lens_blur` veil — Shadertoy bokeh by Dave Hoskins
+        // et al., https://www.shadertoy.com/playlist/fXlGDN
+        let taps = BLUR_TAPS;
+        let taps_f = format!("{:.1}", taps as f32);
+        wgsl.body = format!(
+            "    let mask = clamp({mask_expr}, 0.0, 1.0);\n\
+             \x20   let stroke_opacity = clamp({opacity_expr}, 0.0, 1.0);\n\
+             \x20   let amount = clamp(mask * sel * stroke_opacity, 0.0, 1.0);\n\
+             \x20   let mirror_dims = vec2<f32>(textureDimensions(scratch_mirror_tex));\n\
+             \x20   let centre_local = target_pos - d.{copy_origin_field};\n\
+             \x20   let centre_uv = clamp(centre_local, vec2<f32>(0.5), mirror_dims - vec2<f32>(0.5)) / mirror_dims;\n\
+             \x20   let original = textureSampleLevel(scratch_mirror_tex, scratch_mirror_smp, centre_uv, 0.0);\n\
+             \x20   if (amount <= 0.0) {{ return original; }}\n\
+             \x20   let blur_px = d.{blur_field};\n\
+             \x20   // Golden angle ≈ 137.508°: cos ≈ -0.7374, sin ≈ 0.6755.\n\
+             \x20   let ga_cos = -0.7374;\n\
+             \x20   let ga_sin = 0.6755;\n\
+             \x20   var p = vec2<f32>(1.0, 0.0);\n\
+             \x20   var acc = original;\n\
+             \x20   var count = 1.0;\n\
+             \x20   for (var i = 0u; i < {taps}u; i = i + 1u) {{\n\
+             \x20       p = vec2<f32>(p.x * ga_cos - p.y * ga_sin, p.x * ga_sin + p.y * ga_cos);\n\
+             \x20       // sqrt distributes taps evenly over the disc area.\n\
+             \x20       let r = blur_px * sqrt((f32(i) + 1.0) / {taps_f});\n\
+             \x20       let sample_local = centre_local + p * r;\n\
+             \x20       let uv = clamp(sample_local, vec2<f32>(0.5), mirror_dims - vec2<f32>(0.5)) / mirror_dims;\n\
+             \x20       acc = acc + textureSampleLevel(scratch_mirror_tex, scratch_mirror_smp, uv, 0.0);\n\
+             \x20       count = count + 1.0;\n\
+             \x20   }}\n\
+             \x20   let blurred = acc / count;\n\
+             \x20   return mix(original, blurred, amount);\n",
+        );
+
+        Ok(wgsl)
+    }
+
+    /// Preview body — show the footprint, not the blur: neutral gray
+    /// modulated by the upstream shape mask so the cursor reads the
+    /// brush's actual coverage area. (The stroke body's `scratch_mirror`
+    /// bindings are omitted in preview mode.)
+    fn compile_cursor_preview_body(&self, cctx: &CompileWgslCtx) -> Result<NodeWgsl, String> {
+        let mut wgsl = NodeWgsl::default();
+        let mask_expr = cctx.input("mask").as_f32();
+        wgsl.body = format!(
+            "    let mask = clamp({mask_expr}, 0.0, 1.0);\n\
+             \x20   if (mask <= 0.0) {{ discard; }}\n\
+             \x20   let preview_color = vec3<f32>(0.6, 0.6, 0.6);\n\
+             \x20   return vec4<f32>(preview_color * mask, mask);\n"
+        );
+        Ok(wgsl)
+    }
+}
+
+impl BrushNodeEvaluator for BlurEvaluator {
+    fn evaluate_cpu(&self, _ctx: &EvalContext) -> Vec<(String, ScalarValue)> {
+        vec![]
+    }
+
+    fn evaluate_gpu(
+        &self,
+        ctx: &EvalContext,
+        gpu: &mut BrushGpuContext,
+    ) -> Vec<(String, ScalarValue)> {
+        rmt::evaluate_gpu(self, ctx, gpu)
+    }
+
+    fn flush_dabs(&self, _ctx: &EvalContext, gpu: &mut BrushGpuContext) {
+        rmt::flush_dabs::<Self>(gpu)
+    }
+
+    fn commit(&self, _ctx: &EvalContext, gpu: &mut BrushGpuContext) {
+        rmt::commit(gpu)
+    }
+
+    fn render_cursor_preview(
+        &self,
+        ctx: &EvalContext,
+        gpu: &mut BrushGpuContext,
+    ) -> Vec<(String, ScalarValue)> {
+        rmt::render_cursor_preview(ctx, gpu)
+    }
+
+    fn compile_wgsl(&self, cctx: &CompileWgslCtx) -> Result<NodeWgsl, String> {
+        rmt::compile_wgsl(self, cctx)
+    }
+
+    fn compile_cursor_preview_body(&self, cctx: &CompileWgslCtx) -> Result<NodeWgsl, String> {
+        ReadMirrorTerminal::compile_cursor_preview_body(self, cctx)
+    }
+}

--- a/crates/darkly/src/brush/nodes/liquify.rs
+++ b/crates/darkly/src/brush/nodes/liquify.rs
@@ -1,12 +1,17 @@
 //! Liquify terminal — per-dab fragment-pass warp with a per-brush
 //! compiled WGSL shader.
 //!
-//! Same overall outline as [`smudge`](super::smudge).
+//! Rides the shared [read-mirror terminal](crate::brush::read_mirror_terminal)
+//! infrastructure (the per-brush pipeline, dab-meta queue, flush loop,
+//! and `copy_origin` plumbing it shares with `smudge` and `blur`). This
+//! file owns only what's liquify-specific: the read half-extent and the
+//! variant WGSL (including the softness falloff helper).
+//!
 //! Per dab the fragment shader samples the scratch read mirror at a
 //! *displaced* UV inside a circular brush disc and writes the warped
 //! sample back into the scratch. Successive dabs compound because each
-//! reads the cumulatively-warped scratch — the per-dab serialization
-//! is semantically required, not a perf bug.
+//! reads the cumulatively-warped scratch — the per-dab serialization is
+//! semantically required, not a perf bug.
 //!
 //! Displacement magnitude is `strength × |pen.motion|` — the cursor's
 //! per-dab travel scaled by strength. With the Liquify brush's fixed
@@ -19,21 +24,9 @@
 //!     the *intensity*.
 //!
 //! Pen speed enters only via dab density along the path; the per-dab
-//! push is identical for slow and fast drags.
-//!
-//! ## Stroke lifecycle
-//!
-//! - `begin_stroke` — copies `pre_stroke_texture` → scratch so warps
-//!   start against a stable layer snapshot.
-//! - `evaluate_gpu` (per dab) — queues a record + meta; skipped dabs
-//!   (`radius < 1`, `strength < 1e-4`, `distance < 0.5`) never reach
-//!   the queue, so the flush loop doesn't iterate them.
-//! - `flush_dabs` — for each queued dab, `prepare_dab_canvas_copy`
-//!   syncs the read mirror over a symmetric `radius + displacement`
-//!   half-extent (bilinear sampler reaches into the padding); then
-//!   one render pass with instance index `i..i+1`.
-//! - `commit` — `commit_scratch_blit(scratch → layer)`; `blend_mode`
-//!   ignored — warping isn't paint.
+//! push is identical for slow and fast drags. **Liquify is deliberately
+//! size-invariant** — the size slider scales the warped extent, not the
+//! push strength.
 //!
 //! ## Softness waveshape
 //!
@@ -48,29 +41,17 @@
 //!   0.6  → linear saw            (helper input `0.4`)
 //!   1    → spike (`pow(1-d, 8)`) (helper input `0.0`)
 
-use std::any::Any;
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use crate::brush::eval::{BrushNodeEvaluator, EvalContext};
-use crate::brush::gpu_context::{BrushGpuContext, MAX_DABS_PER_PHASE};
+use crate::brush::gpu_context::BrushGpuContext;
 use crate::brush::node::BrushNodeRegistration;
-use crate::brush::paint_target_ext::BrushPaintTargetExt;
-use crate::brush::pipeline::{
-    BrushPipelineEntry, BrushPipelineRegistration, BuildContext, DynamicUniformRing,
+use crate::brush::read_mirror_terminal::{
+    self as rmt, read_mirror_pipeline_reg, ReadMirrorTerminal,
 };
-use crate::brush::wgsl::{
-    pack_intrinsic_uniforms, pack_uniforms, CompileWgslCtx, CompiledBrush, DabField, NodeWgsl,
-    WgslType, INTRINSIC_UNIFORMS_SIZE,
-};
+use crate::brush::wgsl::{CompileWgslCtx, NodeWgsl};
 use crate::brush::wire::{BrushWireType, ScalarValue};
 use crate::nodegraph::{NodeRegistration, PortDef, UnitType};
 
 // ── Constants ───────────────────────────────────────────────────────────
-
-const SIZE_REFERENCE_PX: f32 = crate::brush::DAB_REFERENCE_SIZE as f32;
-const MAX_UNIFORM_BYTES: usize = 1024;
 
 /// Dab spacing for the Liquify brush, in canvas pixels. The brush
 /// pins `pen_input.spacing_min_px` to this value (and sets ratio to
@@ -101,202 +82,11 @@ const MIN_RADIUS_PX: f32 = 1.0;
 /// (default `drawing_angle = 0`).
 const MIN_DISTANCE_PX: f32 = 0.5;
 
-// ── Per-dab CPU meta ────────────────────────────────────────────────────
-
-#[repr(C)]
-#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-struct LiquifyDabMeta {
-    position: [f32; 2],
-    /// Symmetric half-extent of the read region (`radius + displacement`).
-    half: [f32; 2],
-}
-
-const LIQUIFY_DAB_META_SIZE: usize = std::mem::size_of::<LiquifyDabMeta>();
-
-// ── Per-brush pipeline ──────────────────────────────────────────────────
-
-struct PerBrushPipeline {
-    pipeline: wgpu::RenderPipeline,
-    uniform_ring: DynamicUniformRing,
-    uniform_bind_group: wgpu::BindGroup,
-    dabs_buffer: wgpu::Buffer,
-    dabs_bind_group: wgpu::BindGroup,
-    uniform_size: usize,
-}
-
-impl PerBrushPipeline {
-    fn build(ctx: &BuildContext, compiled: &CompiledBrush) -> Self {
-        let shader = ctx
-            .device
-            .create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: Some("liquify-brush"),
-                source: wgpu::ShaderSource::Wgsl(compiled.stroke_wgsl.clone().into()),
-            });
-
-        let dabs_bgl = ctx
-            .device
-            .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: Some("liquify-dabs-bgl"),
-                entries: &[wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: true },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                }],
-            });
-
-        let layout = ctx
-            .device
-            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: Some("liquify-layout"),
-                bind_group_layouts: &[
-                    Some(ctx.uniform_bgl),
-                    Some(&dabs_bgl),
-                    Some(ctx.selection_bgl),
-                    Some(ctx.canvas_copy_bgl),
-                ],
-                immediate_size: 0,
-            });
-
-        let pipeline = ctx
-            .device
-            .create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some("liquify"),
-                layout: Some(&layout),
-                vertex: wgpu::VertexState {
-                    module: &shader,
-                    entry_point: Some("vs_main"),
-                    buffers: &[],
-                    compilation_options: Default::default(),
-                },
-                fragment: Some(wgpu::FragmentState {
-                    module: &shader,
-                    entry_point: Some("fs_main"),
-                    targets: &[Some(wgpu::ColorTargetState {
-                        format: wgpu::TextureFormat::Rgba8Unorm,
-                        blend: Some(wgpu::BlendState::REPLACE),
-                        write_mask: wgpu::ColorWrites::ALL,
-                    })],
-                    compilation_options: Default::default(),
-                }),
-                primitive: wgpu::PrimitiveState {
-                    topology: wgpu::PrimitiveTopology::TriangleList,
-                    ..Default::default()
-                },
-                depth_stencil: None,
-                multisample: wgpu::MultisampleState::default(),
-                multiview_mask: None,
-                cache: None,
-            });
-
-        let uniform_size =
-            (INTRINSIC_UNIFORMS_SIZE + compiled.uniform_size).max(INTRINSIC_UNIFORMS_SIZE);
-        let uniform_ring = DynamicUniformRing::new(
-            ctx.device,
-            "liquify-uniforms",
-            uniform_size as u64,
-            ctx.min_uniform_align,
-        );
-        let uniform_bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("liquify-uniform-bg"),
-            layout: ctx.uniform_bgl,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: &uniform_ring.buffer,
-                    offset: 0,
-                    size: Some(uniform_ring.binding_size()),
-                }),
-            }],
-        });
-
-        let dab_record_size = compiled.dab_record_size.max(16);
-        let dabs_buffer_size = (MAX_DABS_PER_PHASE as u64) * (dab_record_size as u64);
-        let dabs_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("liquify-dabs-buffer"),
-            size: dabs_buffer_size,
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-        let dabs_bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("liquify-dabs-bg"),
-            layout: &dabs_bgl,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: dabs_buffer.as_entire_binding(),
-            }],
-        });
-
-        Self {
-            pipeline,
-            uniform_ring,
-            uniform_bind_group,
-            dabs_buffer,
-            dabs_bind_group,
-            uniform_size,
-        }
-    }
-}
-
-// ── Pipeline registry entry ─────────────────────────────────────────────
-
-pub struct LiquifyPipeline {
-    cache: RefCell<HashMap<u64, PerBrushPipeline>>,
-}
-
-impl LiquifyPipeline {
-    fn build(_ctx: &BuildContext) -> Self {
-        Self {
-            cache: RefCell::new(HashMap::new()),
-        }
-    }
-
-    fn ensure_pipeline(&self, ctx: &BuildContext, compiled: &CompiledBrush) {
-        let mut cache = self.cache.borrow_mut();
-        cache
-            .entry(compiled.topology_hash)
-            .or_insert_with(|| PerBrushPipeline::build(ctx, compiled));
-    }
-
-    fn with_pipeline<R>(&self, hash: u64, f: impl FnOnce(&PerBrushPipeline) -> R) -> R {
-        let cache = self.cache.borrow();
-        let p = cache
-            .get(&hash)
-            .expect("ensure_pipeline must run before with_pipeline");
-        f(p)
-    }
-}
-
-impl BrushPipelineEntry for LiquifyPipeline {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn ring(&self) -> Option<&DynamicUniformRing> {
-        None
-    }
-    fn rings(&self) -> Vec<&DynamicUniformRing> {
-        Vec::new()
-    }
-}
-
-fn liquify_pipeline_reg() -> BrushPipelineRegistration {
-    BrushPipelineRegistration {
-        id: "liquify",
-        build: |ctx| Box::new(LiquifyPipeline::build(ctx)),
-    }
-}
-
-// ── Node ────────────────────────────────────────────────────────────────
-
 pub const TYPE_ID: &str = "liquify";
 
 pub fn register() -> BrushNodeRegistration {
     BrushNodeRegistration {
-        pipelines: vec![liquify_pipeline_reg()],
+        pipelines: vec![read_mirror_pipeline_reg("liquify")],
         evaluator: || Box::new(LiquifyEvaluator),
         lifecycle: crate::brush::node::Lifecycle::SeedScratchFromPreStroke,
         node: NodeRegistration {
@@ -383,272 +173,42 @@ pub fn register() -> BrushNodeRegistration {
 
 pub struct LiquifyEvaluator;
 
-impl LiquifyEvaluator {
-    fn effective_radius(ctx: &EvalContext) -> f32 {
-        let size_input = ctx.input_f32("size_input").max(0.0);
-        let size = ctx.input_f32("size").max(0.0);
-        let effective_size = size_input * size;
-        (effective_size * SIZE_REFERENCE_PX * 0.5).max(0.5)
-    }
+impl ReadMirrorTerminal for LiquifyEvaluator {
+    const PIPELINE_ID: &'static str = "liquify";
+    const LABEL: &'static str = "liquify";
 
-    fn insert_copy_origin(gpu: &mut BrushGpuContext, node_id: u32, value: [f32; 2]) {
-        if let Some(outputs) = gpu.dab_batch.slot_outputs.as_mut() {
-            outputs.insert(
-                format!("n{}_copy_origin", node_id),
-                ScalarValue::Vec2(value),
-            );
-        }
-    }
-}
-
-impl BrushNodeEvaluator for LiquifyEvaluator {
-    fn evaluate_cpu(&self, _ctx: &EvalContext) -> Vec<(String, ScalarValue)> {
-        vec![]
-    }
-
-    fn evaluate_gpu(
-        &self,
-        ctx: &EvalContext,
-        gpu: &mut BrushGpuContext,
-    ) -> Vec<(String, ScalarValue)> {
-        let Some(compiled) = gpu.dab_batch.compiled_brush.clone() else {
-            debug_assert!(false, "liquify requires compiled_brush on gpu_context");
-            return vec![];
-        };
-        let Some(stroke) = gpu.stroke.as_ref() else {
-            return vec![];
-        };
-        let paint_target = &stroke.paint_target;
-        let position = ctx.input("position").as_vec2();
+    fn read_half(&self, ctx: &EvalContext, radius: f32, _bbox_radius: f32) -> Option<[f32; 2]> {
         let strength = ctx.input_f32("strength").clamp(0.0, 1.0);
         let distance = ctx.input_f32("distance");
         let motion = ctx.input("motion").as_vec2();
         let motion_mag = (motion[0] * motion[0] + motion[1] * motion[1]).sqrt();
-        let radius = Self::effective_radius(ctx);
-        let diameter = radius * 2.0;
 
-        // Three early-outs — skip stationary or sub-pixel dabs whose
-        // warp would be a no-op.
-        if radius < MIN_RADIUS_PX {
-            return vec![("dab_size".into(), ScalarValue::Vec2([diameter, diameter]))];
-        }
-        if strength < STRENGTH_EPSILON {
-            return vec![("dab_size".into(), ScalarValue::Vec2([diameter, diameter]))];
-        }
-        if distance < MIN_DISTANCE_PX {
-            return vec![("dab_size".into(), ScalarValue::Vec2([diameter, diameter]))];
+        // Three early-outs — skip stationary or sub-pixel dabs whose warp
+        // would be a no-op.
+        if radius < MIN_RADIUS_PX || strength < STRENGTH_EPSILON || distance < MIN_DISTANCE_PX {
+            return None;
         }
 
-        // Per-dab displacement magnitude — the cursor's per-dab
-        // motion scaled by strength. `strength = 1` pushes pixels by
-        // the full cursor step (lock), `strength = 0.5` pushes them
-        // by half (drag), regardless of brush size. CPU and shader
-        // compute the same value (the shader reads motion + strength
-        // from the dab record).
+        // Symmetric read region — disc inflated by `displacement` per axis
+        // so the warped sample at
+        // `target_pos - direction × displacement × falloff(d)` always lies
+        // inside the mirror snapshot (the bilinear sampler reaches into
+        // the inflation margin too). `displacement = strength × |motion|`,
+        // recomputed identically by the shader from motion + strength.
         let displacement = motion_mag * strength;
-
-        let bbox_radius = radius * compiled.brush_extent_factor + compiled.brush_extent_extra_px;
-        let canvas_ext = paint_target.canvas_extent();
-        // Near-edge of the layer extent — reused below for the read-region copy
-        // origin (a one-sided clamp, distinct from the dab footprint clamp).
-        let layer_x0 = canvas_ext.x0() as f32;
-        let layer_y0 = canvas_ext.y0() as f32;
-        // Clamp the dab footprint to the layer extent; a dab entirely
-        // off-extent has no pixels to draw and is skipped.
-        let canvas_bbox = match canvas_ext.clamp_f32(
-            position[0] - bbox_radius,
-            position[1] - bbox_radius,
-            position[0] + bbox_radius,
-            position[1] + bbox_radius,
-        ) {
-            Some(r) => r,
-            None => return vec![("dab_size".into(), ScalarValue::Vec2([diameter, diameter]))],
-        };
-        let local = paint_target
-            .canvas_frame()
-            .canvas_to_layer_rect(canvas_bbox)
-            .expect("canvas_bbox came from canvas_ext.clamp_f32, so it overlaps the extent");
-        gpu.dab_batch.push_write_bbox(canvas_bbox);
-        gpu.dab_batch.bbox = Some(match gpu.dab_batch.bbox {
-            Some([x0, y0, x1, y1]) => [
-                x0.min(local.x0()),
-                y0.min(local.y0()),
-                x1.max(local.x1()),
-                y1.max(local.y1()),
-            ],
-            None => [local.x0(), local.y0(), local.x1(), local.y1()],
-        });
-
-        // Symmetric read region — disc inflated by `displacement` per
-        // axis so the warped sample at
-        // `target_pos - direction × displacement × falloff(d)` always
-        // lies inside the mirror snapshot (bilinear sampler reaches
-        // into the inflation margin too).
         let read_half = radius + displacement;
-
-        let read_x0 = (position[0] - read_half).max(layer_x0);
-        let read_y0 = (position[1] - read_half).max(layer_y0);
-        let copy_canvas_x = read_x0.floor();
-        let copy_canvas_y = read_y0.floor();
-        Self::insert_copy_origin(gpu, ctx.node_id.0 as u32, [copy_canvas_x, copy_canvas_y]);
-
-        gpu.dab_batch
-            .queue_dab(&compiled, position, bbox_radius, radius);
-
-        let meta = LiquifyDabMeta {
-            position,
-            half: [read_half, read_half],
-        };
-        gpu.dab_batch
-            .meta_bytes
-            .extend_from_slice(bytemuck::bytes_of(&meta));
-
-        vec![("dab_size".into(), ScalarValue::Vec2([diameter, diameter]))]
+        Some([read_half, read_half])
     }
 
-    fn flush_dabs(&self, _ctx: &EvalContext, gpu: &mut BrushGpuContext) {
-        if gpu.dab_batch.count == 0 {
-            return;
-        }
-        let Some(compiled) = gpu.dab_batch.compiled_brush.clone() else {
-            debug_assert!(false, "liquify::flush_dabs requires compiled_brush");
-            return;
-        };
-
-        let bbox = gpu.dab_batch.bbox.unwrap_or([0, 0, 0, 0]);
-        let union_w = bbox[2].saturating_sub(bbox[0]);
-        let union_h = bbox[3].saturating_sub(bbox[1]);
-        let (dab_bytes, total_dabs) = gpu.dab_batch.take();
-        let meta_bytes = gpu.dab_batch.take_meta();
-        if total_dabs == 0 {
-            return;
-        }
-        debug_assert_eq!(
-            meta_bytes.len(),
-            (total_dabs as usize) * LIQUIFY_DAB_META_SIZE,
-            "liquify meta queue out of sync with dab queue"
-        );
-        let metas: Vec<LiquifyDabMeta> = bytemuck::cast_slice(&meta_bytes).to_vec();
-        gpu.perf
-            .record_dab_flush_workload(total_dabs, union_w, union_h);
-
-        let pipeline_ref = gpu.pipelines.get::<LiquifyPipeline>("liquify");
-        ensure_per_brush_pipeline(gpu, pipeline_ref, &compiled);
-
-        let stroke = gpu
-            .stroke
-            .as_ref()
-            .expect("liquify::flush_dabs requires stroke resources");
-        let paint_target = &stroke.paint_target;
-        let canvas_ext = paint_target.canvas_extent();
-        let layer_offset = [canvas_ext.x0(), canvas_ext.y0()];
-        let layer_size = [canvas_ext.width, canvas_ext.height];
-
-        let mut uniform_bytes: Vec<u8> = Vec::with_capacity(MAX_UNIFORM_BYTES);
-        pack_intrinsic_uniforms(
-            &mut uniform_bytes,
-            gpu.intrinsic_header(layer_offset, layer_size),
-        );
-        let outputs = gpu
-            .dab_batch
-            .slot_outputs
-            .as_ref()
-            .expect("liquify::flush_dabs requires dab_batch.slot_outputs");
-        pack_uniforms(&compiled, outputs, &mut uniform_bytes);
-
-        pipeline_ref.with_pipeline(compiled.topology_hash, |per_brush| {
-            if uniform_bytes.len() < per_brush.uniform_size {
-                uniform_bytes.resize(per_brush.uniform_size, 0);
-            }
-            per_brush.uniform_ring.reset();
-            let uniform_offset = per_brush.uniform_ring.write(gpu.queue, &uniform_bytes);
-            gpu.queue
-                .write_buffer(&per_brush.dabs_buffer, 0, &dab_bytes);
-
-            for (i, meta) in metas.iter().enumerate() {
-                let _ = gpu.prepare_dab_canvas_copy(
-                    meta.position,
-                    meta.half[0],
-                    meta.half[1],
-                    meta.half[0],
-                    meta.half[1],
-                );
-
-                let scratch_ref = &*gpu
-                    .stroke
-                    .as_ref()
-                    .expect("liquify::flush_dabs requires stroke resources")
-                    .scratch;
-                let read_bg = scratch_ref.read_mirror_bind_group();
-                let write_view = scratch_ref.write_view();
-
-                let mut pass = gpu.encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                    label: Some("liquify-flush"),
-                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                        view: write_view,
-                        resolve_target: None,
-                        depth_slice: None,
-                        ops: wgpu::Operations {
-                            load: wgpu::LoadOp::Load,
-                            store: wgpu::StoreOp::Store,
-                        },
-                    })],
-                    ..Default::default()
-                });
-                pass.set_viewport(
-                    0.0,
-                    0.0,
-                    layer_size[0] as f32,
-                    layer_size[1] as f32,
-                    0.0,
-                    1.0,
-                );
-                pass.set_pipeline(&per_brush.pipeline);
-                pass.set_bind_group(0, &per_brush.uniform_bind_group, &[uniform_offset]);
-                pass.set_bind_group(1, &per_brush.dabs_bind_group, &[]);
-                pass.set_bind_group(2, gpu.selection_bind_group, &[]);
-                pass.set_bind_group(3, read_bg, &[]);
-                let ii = i as u32;
-                pass.draw(0..6, ii..ii + 1);
-            }
-        });
-
-        gpu.perf.record_dab_flush(total_dabs);
-    }
-
-    fn commit(&self, _ctx: &EvalContext, gpu: &mut BrushGpuContext) {
-        let Some(stroke) = gpu.stroke.as_ref() else {
-            return;
-        };
-        stroke.paint_target.commit_scratch_blit(
-            gpu.device,
-            &mut gpu.encoder,
-            gpu.pipelines,
-            stroke.scratch.write_view(),
-            stroke.scratch.write_texture(),
-        );
-    }
-
-    /// Hover-cursor preview. Routes through the shared preview helper.
-    /// Liquify's preview is a soft disc with the same softness
-    /// falloff the stroke applies — scrubbing the softness slider
-    /// visibly reshapes the cursor. Rotation is 0 (the preview is
-    /// radially symmetric).
-    fn render_cursor_preview(
+    fn compile_body(
         &self,
-        ctx: &EvalContext,
-        gpu: &mut BrushGpuContext,
-    ) -> Vec<(String, ScalarValue)> {
-        let radius = Self::effective_radius(ctx);
-        let _ = crate::brush::wgsl::render_compiled_cursor_preview(gpu, radius);
-        vec![]
-    }
-
-    fn compile_wgsl(&self, cctx: &CompileWgslCtx) -> Result<NodeWgsl, String> {
+        cctx: &CompileWgslCtx,
+        copy_origin_field: &str,
+    ) -> Result<NodeWgsl, String> {
         let mut wgsl = NodeWgsl::default();
 
-        // `mask` defaults to 1.0 when unwired — uniform warp inside
-        // the disc.
+        // `mask` defaults to 1.0 when unwired — uniform warp inside the
+        // disc.
         let mask_expr = if cctx.input_is_wired("mask") {
             cctx.input("mask").as_f32()
         } else {
@@ -658,21 +218,6 @@ impl BrushNodeEvaluator for LiquifyEvaluator {
         let softness_expr = cctx.input("softness").as_f32();
         let direction_expr = cctx.input("direction").as_f32();
         let motion_expr = cctx.input("motion").as_vec2();
-
-        let copy_origin_field = cctx.dab_field_name("copy_origin");
-        let key = copy_origin_field.clone();
-        wgsl.dab_fields.push(DabField {
-            name: copy_origin_field.clone(),
-            ty: WgslType::Vec2,
-            pack: Arc::new(move |outputs, bytes| {
-                let v = outputs.get(&key).map(|s| s.as_vec2()).unwrap_or([0.0; 2]);
-                bytes.extend_from_slice(bytemuck::bytes_of(&v));
-            }),
-        });
-
-        wgsl.terminal_bindings = "@group(3) @binding(0) var scratch_mirror_tex: texture_2d<f32>;\n\
-             @group(3) @binding(1) var scratch_mirror_smp: sampler;\n"
-            .to_string();
 
         // Per-node falloff fn — suffixed by node id so two liquify
         // terminals (hypothetical) in the same brush don't collide.
@@ -701,16 +246,11 @@ impl BrushNodeEvaluator for LiquifyEvaluator {
         // Fragment body: `local_dist` and `target_pos` come from the
         // framework wrapper; the framework already discards past
         // `d.bbox_target_px`. We additionally discard past
-        // `local_dist >= 1.0` so the warp stays inside the disc (the
-        // framework's discard kicks in for `bbox_target_px < radius`
-        // cases too, but when extent contribution lands at 1.0 the
-        // two conditions coincide).
+        // `local_dist >= 1.0` so the warp stays inside the disc.
         // The falloff helper takes `0 = spike` / `1 = square`. The
         // user-facing slider is labelled "Softness" with the opposite
-        // intuition — `1 = soft / feathery` (only the brush centre
-        // pushes, edges fade to nothing), `0 = hard / sharp` (uniform
-        // displacement, square step at the disc edge). Invert before
-        // passing to the helper so the slider matches the label.
+        // intuition — `1 = soft / feathery`, `0 = hard / sharp`. Invert
+        // before passing to the helper so the slider matches the label.
         wgsl.body = format!(
             "    if (local_dist >= 1.0) {{ discard; }}\n\
              \x20   let warp_mask = clamp({mask_expr}, 0.0, 1.0);\n\
@@ -729,26 +269,21 @@ impl BrushNodeEvaluator for LiquifyEvaluator {
              \x20   let original_uv = (target_pos  - d.{copy_origin_field}) / mirror_dims;\n\
              \x20   let original   = textureSampleLevel(scratch_mirror_tex, scratch_mirror_smp, original_uv, 0.0);\n\
              \x20   return mix(original, warped, sel * warp_mask);\n",
-            copy_origin_field = copy_origin_field,
         );
 
         Ok(wgsl)
     }
 
-    /// Preview-mode body. The stroke body samples `scratch_mirror`
-    /// (bound at `@group(3)` in stroke mode, omitted in preview);
-    /// preview emits the falloff disc so scrubbing the softness slider
-    /// visibly reshapes the cursor — helpful side-effect of reusing
-    /// the same `falloff_fn` the stroke decls emit.
+    /// Preview body — emit the falloff disc so scrubbing the softness
+    /// slider visibly reshapes the cursor (a side-effect of reusing the
+    /// same `falloff_fn` the stroke decls emit). The stroke body's
+    /// `scratch_mirror` bindings are omitted in preview mode.
     ///
-    /// The overlay's `KIND_MASKED_STAMP` reads only the `.r` channel
-    /// of this mask as coverage; the displayed colour comes from
-    /// `fs_snapshot`'s background-shift math, not from anything we
-    /// write here. So `.r = f` puts liquify's peak coverage on par
-    /// with paint's at the centre. An earlier version multiplied by
-    /// `0.6` thinking that emitted "neutral gray", which actually
-    /// just capped peak coverage at 60% — visibly fainter than other
-    /// brushes.
+    /// The overlay's `KIND_MASKED_STAMP` reads only the `.r` channel of
+    /// this mask as coverage; the displayed colour comes from
+    /// `fs_snapshot`'s background-shift math, not anything written here.
+    /// So `.r = f` puts liquify's peak coverage on par with paint's at
+    /// the centre.
     fn compile_cursor_preview_body(&self, cctx: &CompileWgslCtx) -> Result<NodeWgsl, String> {
         let mut wgsl = NodeWgsl::default();
         let softness_expr = cctx.input("softness").as_f32();
@@ -763,25 +298,40 @@ impl BrushNodeEvaluator for LiquifyEvaluator {
     }
 }
 
-// ── Per-brush pipeline build helper ─────────────────────────────────────
-
-fn ensure_per_brush_pipeline(
-    gpu: &BrushGpuContext,
-    pipe: &LiquifyPipeline,
-    compiled: &CompiledBrush,
-) {
-    if pipe.cache.borrow().contains_key(&compiled.topology_hash) {
-        return;
+impl BrushNodeEvaluator for LiquifyEvaluator {
+    fn evaluate_cpu(&self, _ctx: &EvalContext) -> Vec<(String, ScalarValue)> {
+        vec![]
     }
-    let ctx = BuildContext {
-        device: gpu.device,
-        queue: gpu.queue,
-        uniform_bgl: gpu.pipelines.uniform_bind_group_layout(),
-        selection_bgl: gpu.pipelines.selection_bind_group_layout(),
-        canvas_copy_bgl: gpu.pipelines.canvas_copy_bind_group_layout(),
-        canvas_copy_sampler: gpu.pipelines.canvas_copy_sampler(),
-        min_uniform_align: gpu.device.limits().min_uniform_buffer_offset_alignment,
-        texture_registry: gpu.pipelines.texture_registry(),
-    };
-    pipe.ensure_pipeline(&ctx, compiled);
+
+    fn evaluate_gpu(
+        &self,
+        ctx: &EvalContext,
+        gpu: &mut BrushGpuContext,
+    ) -> Vec<(String, ScalarValue)> {
+        rmt::evaluate_gpu(self, ctx, gpu)
+    }
+
+    fn flush_dabs(&self, _ctx: &EvalContext, gpu: &mut BrushGpuContext) {
+        rmt::flush_dabs::<Self>(gpu)
+    }
+
+    fn commit(&self, _ctx: &EvalContext, gpu: &mut BrushGpuContext) {
+        rmt::commit(gpu)
+    }
+
+    fn render_cursor_preview(
+        &self,
+        ctx: &EvalContext,
+        gpu: &mut BrushGpuContext,
+    ) -> Vec<(String, ScalarValue)> {
+        rmt::render_cursor_preview(ctx, gpu)
+    }
+
+    fn compile_wgsl(&self, cctx: &CompileWgslCtx) -> Result<NodeWgsl, String> {
+        rmt::compile_wgsl(self, cctx)
+    }
+
+    fn compile_cursor_preview_body(&self, cctx: &CompileWgslCtx) -> Result<NodeWgsl, String> {
+        ReadMirrorTerminal::compile_cursor_preview_body(self, cctx)
+    }
 }

--- a/crates/darkly/src/brush/nodes/mod.rs
+++ b/crates/darkly/src/brush/nodes/mod.rs
@@ -2,6 +2,7 @@
 // To add a new module, create a .rs file in this directory
 // that exports `pub fn register() -> crate::brush::BrushNodeRegistration`.
 
+pub mod blur;
 pub mod curve;
 pub mod image;
 pub mod levels;
@@ -24,6 +25,7 @@ use crate::brush::BrushNodeRegistration;
 #[rustfmt::skip]
 pub fn registrations() -> Vec<BrushNodeRegistration> {
     vec![
+        blur::register(),
         curve::register(),
         image::register(),
         levels::register(),

--- a/crates/darkly/src/brush/nodes/smudge.rs
+++ b/crates/darkly/src/brush/nodes/smudge.rs
@@ -1,282 +1,45 @@
 //! Smudge terminal — per-dab fragment-pass smear with a per-brush
 //! compiled WGSL shader.
 //!
-//! Same outline as [`paint`](super::paint), but with
-//! a per-dab flush loop instead of a single instanced draw. Each smudge
-//! dab samples the scratch read mirror twice — once at `target_pos`
-//! (current background) and once at `target_pos − motion` (the smear
-//! sample, what was under the brush at the previous dab) — and mixes
-//! the two by `rate × mask × selection × stroke_opacity`. Per-dab
-//! serialization is *semantically required*: each dab must see the
-//! prior dab's output, which a single instanced draw can't express.
+//! Rides the shared [read-mirror terminal](crate::brush::read_mirror_terminal)
+//! infrastructure (the per-brush pipeline, dab-meta queue, flush loop,
+//! and `copy_origin` plumbing it shares with `liquify` and `blur`). This
+//! file owns only what's smudge-specific: the read half-extent and the
+//! variant WGSL.
 //!
-//! ## Per-dab flush
+//! Each smudge dab samples the scratch read mirror twice — once at
+//! `target_pos` (current background) and once at `target_pos − motion`
+//! (the smear sample, what was under the brush at the previous dab) — and
+//! mixes the two by `rate × mask × selection × stroke_opacity`. Per-dab
+//! serialization is *semantically required*: each dab must see the prior
+//! dab's output, which a single instanced draw can't express.
 //!
-//! 1. `evaluate_gpu` packs one record into [`BrushGpuContext::dab_batch`]'s
-//!    `bytes` *and* one [`SmudgeDabMeta`] into the parallel CPU-side
-//!    `meta_bytes` queue, plus the pre-computed canvas-space
-//!    `copy_origin` into `dab_batch.slot_outputs`
-//!    so the framework's `pack_dab_record` picks it up via this node's
-//!    `copy_origin` dab field. Stationary dabs (`|motion| < 0.5 px`)
-//!    are skipped before queueing — `mix(bg, src, _)` collapses to
-//!    identity in that regime.
-//! 2. `flush_dabs` walks the queue in lockstep. For each dab it calls
-//!    `prepare_dab_canvas_copy` (asymmetric read region around
-//!    the dab's footprint by `±|motion|` per axis) to sync the
-//!    scratch read mirror, then issues one render pass with instance
-//!    index `i..i+1` so the vertex stage reads `dab_records[i]`.
-//!    `wgpu` serializes encoder commands in submission order; the
-//!    `copy_texture_to_texture` between passes carries an implicit
-//!    barrier so each draw sees the prior draw's output once it lands
-//!    in scratch — no `queue.submit()` between dabs needed.
-//!
-//! The read mirror's bind group is re-queried fresh each iteration
-//! because [`crate::brush::scratch::Scratch::sync_read_mirror`] can
-//! grow the mirror and rebuild the bind group mid-phase.
-//!
-//! ## Blend state
-//!
-//! REPLACE — the fragment shader fully composes its output
-//! (`mix(bg, src, amount)`) and writes it straight to scratch. The
-//! framework's `LoadOp::Load` keeps prior scratch pixels intact outside
-//! the dab footprint; the fragment shader discards past `d.bbox_target_px`.
-
-use std::any::Any;
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::sync::Arc;
+//! Stationary dabs (`|motion| < 0.5 px`) are dropped before queueing —
+//! `mix(bg, src, _)` collapses to identity in that regime. The read
+//! region is expanded by `|motion|` per axis (ceiled for the bilinear
+//! sampler's half-texel reach) so the smear sample at `target_pos −
+//! motion` always lies inside the mirror snapshot.
 
 use crate::brush::eval::{BrushNodeEvaluator, EvalContext};
-use crate::brush::gpu_context::{BrushGpuContext, MAX_DABS_PER_PHASE};
+use crate::brush::gpu_context::BrushGpuContext;
 use crate::brush::node::BrushNodeRegistration;
-use crate::brush::paint_target_ext::BrushPaintTargetExt;
-use crate::brush::pipeline::{
-    BrushPipelineEntry, BrushPipelineRegistration, BuildContext, DynamicUniformRing,
+use crate::brush::read_mirror_terminal::{
+    self as rmt, read_mirror_pipeline_reg, ReadMirrorTerminal,
 };
-use crate::brush::wgsl::{
-    pack_intrinsic_uniforms, pack_uniforms, CompileWgslCtx, CompiledBrush, DabField, NodeWgsl,
-    WgslType, INTRINSIC_UNIFORMS_SIZE,
-};
+use crate::brush::wgsl::{CompileWgslCtx, NodeWgsl};
 use crate::brush::wire::{BrushWireType, ScalarValue};
 use crate::nodegraph::{NodeRegistration, PortDef, UnitType};
-
-// ── Constants ───────────────────────────────────────────────────────────
-
-const SIZE_REFERENCE_PX: f32 = crate::brush::DAB_REFERENCE_SIZE as f32;
-
-const MAX_UNIFORM_BYTES: usize = 1024;
 
 /// Motion magnitude (canvas pixels) below which the dab is treated as
 /// stationary and dropped before queueing — `mix(bg, src, _)` is an
 /// identity write when `src == bg`.
 const STATIONARY_THRESHOLD_PX: f32 = 0.5;
 
-// ── Per-dab CPU meta ────────────────────────────────────────────────────
-
-/// CPU-side per-dab footprint info, packed by `evaluate_gpu` in
-/// lockstep with the GPU dab record and drained by `flush_dabs`. Lets
-/// the flush loop call `prepare_dab_canvas_copy` without re-deriving
-/// the asymmetric footprint from the upload buffer.
-#[repr(C)]
-#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
-struct SmudgeDabMeta {
-    position: [f32; 2],
-    write_half: [f32; 2],
-    read_half: [f32; 2],
-}
-
-const SMUDGE_DAB_META_SIZE: usize = std::mem::size_of::<SmudgeDabMeta>();
-
-// ── Per-brush pipeline ──────────────────────────────────────────────────
-
-struct PerBrushPipeline {
-    pipeline: wgpu::RenderPipeline,
-    uniform_ring: DynamicUniformRing,
-    uniform_bind_group: wgpu::BindGroup,
-    dabs_buffer: wgpu::Buffer,
-    dabs_bind_group: wgpu::BindGroup,
-    uniform_size: usize,
-}
-
-impl PerBrushPipeline {
-    fn build(ctx: &BuildContext, compiled: &CompiledBrush) -> Self {
-        let shader = ctx
-            .device
-            .create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: Some("smudge-brush"),
-                source: wgpu::ShaderSource::Wgsl(compiled.stroke_wgsl.clone().into()),
-            });
-
-        let dabs_bgl = ctx
-            .device
-            .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-                label: Some("smudge-dabs-bgl"),
-                entries: &[wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: true },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                }],
-            });
-
-        // group(0..2) standard; group(3) is the scratch read mirror —
-        // same layout as `watercolor`'s atlas binding, only
-        // the binding semantics differ.
-        let layout = ctx
-            .device
-            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-                label: Some("smudge-layout"),
-                bind_group_layouts: &[
-                    Some(ctx.uniform_bgl),
-                    Some(&dabs_bgl),
-                    Some(ctx.selection_bgl),
-                    Some(ctx.canvas_copy_bgl),
-                ],
-                immediate_size: 0,
-            });
-
-        // REPLACE blend — the fragment shader writes the final smeared
-        // pixel; outside the disc it discards so LoadOp::Load preserves
-        // the scratch.
-        let pipeline = ctx
-            .device
-            .create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: Some("smudge"),
-                layout: Some(&layout),
-                vertex: wgpu::VertexState {
-                    module: &shader,
-                    entry_point: Some("vs_main"),
-                    buffers: &[],
-                    compilation_options: Default::default(),
-                },
-                fragment: Some(wgpu::FragmentState {
-                    module: &shader,
-                    entry_point: Some("fs_main"),
-                    targets: &[Some(wgpu::ColorTargetState {
-                        format: wgpu::TextureFormat::Rgba8Unorm,
-                        blend: Some(wgpu::BlendState::REPLACE),
-                        write_mask: wgpu::ColorWrites::ALL,
-                    })],
-                    compilation_options: Default::default(),
-                }),
-                primitive: wgpu::PrimitiveState {
-                    topology: wgpu::PrimitiveTopology::TriangleList,
-                    ..Default::default()
-                },
-                depth_stencil: None,
-                multisample: wgpu::MultisampleState::default(),
-                multiview_mask: None,
-                cache: None,
-            });
-
-        let uniform_size =
-            (INTRINSIC_UNIFORMS_SIZE + compiled.uniform_size).max(INTRINSIC_UNIFORMS_SIZE);
-        let uniform_ring = DynamicUniformRing::new(
-            ctx.device,
-            "smudge-uniforms",
-            uniform_size as u64,
-            ctx.min_uniform_align,
-        );
-        let uniform_bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("smudge-uniform-bg"),
-            layout: ctx.uniform_bgl,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
-                    buffer: &uniform_ring.buffer,
-                    offset: 0,
-                    size: Some(uniform_ring.binding_size()),
-                }),
-            }],
-        });
-
-        let dab_record_size = compiled.dab_record_size.max(16);
-        let dabs_buffer_size = (MAX_DABS_PER_PHASE as u64) * (dab_record_size as u64);
-        let dabs_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("smudge-dabs-buffer"),
-            size: dabs_buffer_size,
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-        let dabs_bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("smudge-dabs-bg"),
-            layout: &dabs_bgl,
-            entries: &[wgpu::BindGroupEntry {
-                binding: 0,
-                resource: dabs_buffer.as_entire_binding(),
-            }],
-        });
-
-        Self {
-            pipeline,
-            uniform_ring,
-            uniform_bind_group,
-            dabs_buffer,
-            dabs_bind_group,
-            uniform_size,
-        }
-    }
-}
-
-// ── Pipeline registry entry ─────────────────────────────────────────────
-
-pub struct SmudgePipeline {
-    cache: RefCell<HashMap<u64, PerBrushPipeline>>,
-}
-
-impl SmudgePipeline {
-    fn build(_ctx: &BuildContext) -> Self {
-        Self {
-            cache: RefCell::new(HashMap::new()),
-        }
-    }
-
-    fn ensure_pipeline(&self, ctx: &BuildContext, compiled: &CompiledBrush) {
-        let mut cache = self.cache.borrow_mut();
-        cache
-            .entry(compiled.topology_hash)
-            .or_insert_with(|| PerBrushPipeline::build(ctx, compiled));
-    }
-
-    fn with_pipeline<R>(&self, hash: u64, f: impl FnOnce(&PerBrushPipeline) -> R) -> R {
-        let cache = self.cache.borrow();
-        let p = cache
-            .get(&hash)
-            .expect("ensure_pipeline must run before with_pipeline");
-        f(p)
-    }
-}
-
-impl BrushPipelineEntry for SmudgePipeline {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-    fn ring(&self) -> Option<&DynamicUniformRing> {
-        None
-    }
-    fn rings(&self) -> Vec<&DynamicUniformRing> {
-        Vec::new()
-    }
-}
-
-fn smudge_pipeline_reg() -> BrushPipelineRegistration {
-    BrushPipelineRegistration {
-        id: "smudge",
-        build: |ctx| Box::new(SmudgePipeline::build(ctx)),
-    }
-}
-
-// ── Node ────────────────────────────────────────────────────────────────
-
 pub const TYPE_ID: &str = "smudge";
 
 pub fn register() -> BrushNodeRegistration {
     BrushNodeRegistration {
-        pipelines: vec![smudge_pipeline_reg()],
+        pipelines: vec![read_mirror_pipeline_reg("smudge")],
         evaluator: || Box::new(SmudgeEvaluator),
         lifecycle: crate::brush::node::Lifecycle::SeedScratchFromPreStroke,
         node: NodeRegistration {
@@ -343,302 +106,37 @@ pub fn register() -> BrushNodeRegistration {
 
 pub struct SmudgeEvaluator;
 
-impl SmudgeEvaluator {
-    fn effective_radius(ctx: &EvalContext) -> f32 {
-        let size_input = ctx.input_f32("size_input").max(0.0);
-        let size = ctx.input_f32("size").max(0.0);
-        let effective_size = size_input * size;
-        (effective_size * SIZE_REFERENCE_PX * 0.5).max(0.5)
-    }
+impl ReadMirrorTerminal for SmudgeEvaluator {
+    const PIPELINE_ID: &'static str = "smudge";
+    const LABEL: &'static str = "smudge";
 
-    /// Insert `copy_origin` into `dab_batch.slot_outputs` under this
-    /// node's dab-field key so the framework's `pack_dab_record`
-    /// picks it up via the `copy_origin` `DabField` declared in
-    /// `compile_wgsl`.
-    fn insert_copy_origin(gpu: &mut BrushGpuContext, node_id: u32, value: [f32; 2]) {
-        if let Some(outputs) = gpu.dab_batch.slot_outputs.as_mut() {
-            outputs.insert(
-                format!("n{}_copy_origin", node_id),
-                ScalarValue::Vec2(value),
-            );
-        }
-    }
-}
-
-impl BrushNodeEvaluator for SmudgeEvaluator {
-    fn evaluate_cpu(&self, _ctx: &EvalContext) -> Vec<(String, ScalarValue)> {
-        vec![]
-    }
-
-    fn evaluate_gpu(
-        &self,
-        ctx: &EvalContext,
-        gpu: &mut BrushGpuContext,
-    ) -> Vec<(String, ScalarValue)> {
-        let Some(compiled) = gpu.dab_batch.compiled_brush.clone() else {
-            debug_assert!(false, "smudge requires compiled_brush on gpu_context");
-            return vec![];
-        };
-        let Some(stroke) = gpu.stroke.as_ref() else {
-            return vec![];
-        };
-        let paint_target = &stroke.paint_target;
-        let position = ctx.input("position").as_vec2();
+    fn read_half(&self, ctx: &EvalContext, _radius: f32, bbox_radius: f32) -> Option<[f32; 2]> {
         let motion = ctx.input("motion").as_vec2();
-        let radius = Self::effective_radius(ctx);
-        let diameter = radius * 2.0;
-        if diameter <= 0.0 {
-            return vec![("dab_size".into(), ScalarValue::Vec2([diameter, diameter]))];
-        }
-
-        // Stationary-dab early-out — `mix(bg, src, _)` is identity in
-        // this regime. Skipping the queue saves a render pass and a
-        // mirror copy.
+        // Stationary-dab early-out — `mix(bg, src, _)` is identity in this
+        // regime. Skipping the queue saves a render pass and a mirror copy.
         if motion[0].abs() < STATIONARY_THRESHOLD_PX && motion[1].abs() < STATIONARY_THRESHOLD_PX {
-            return vec![("dab_size".into(), ScalarValue::Vec2([diameter, diameter]))];
+            return None;
         }
-
-        // Per-brush extent: composed by the framework at compile time.
-        // For smudge this is `1.0` when the upstream is a plain disc.
-        let bbox_radius = radius * compiled.brush_extent_factor + compiled.brush_extent_extra_px;
-        let canvas_ext = paint_target.canvas_extent();
-        // Near-edge of the layer extent — reused below for the read-region copy
-        // origin (a one-sided clamp, distinct from the dab footprint clamp).
-        let layer_x0 = canvas_ext.x0() as f32;
-        let layer_y0 = canvas_ext.y0() as f32;
-        // Clamp the dab footprint to the layer extent; a dab entirely
-        // off-extent has no pixels to draw and is skipped.
-        let canvas_bbox = match canvas_ext.clamp_f32(
-            position[0] - bbox_radius,
-            position[1] - bbox_radius,
-            position[0] + bbox_radius,
-            position[1] + bbox_radius,
-        ) {
-            Some(r) => r,
-            None => return vec![("dab_size".into(), ScalarValue::Vec2([diameter, diameter]))],
-        };
-        let local = paint_target
-            .canvas_frame()
-            .canvas_to_layer_rect(canvas_bbox)
-            .expect("canvas_bbox came from canvas_ext.clamp_f32, so it overlaps the extent");
-        gpu.dab_batch.push_write_bbox(canvas_bbox);
-        gpu.dab_batch.bbox = Some(match gpu.dab_batch.bbox {
-            Some([x0, y0, x1, y1]) => [
-                x0.min(local.x0()),
-                y0.min(local.y0()),
-                x1.max(local.x1()),
-                y1.max(local.y1()),
-            ],
-            None => [local.x0(), local.y0(), local.x1(), local.y1()],
-        });
-
-        // Asymmetric read region — expanded by `|motion|` per axis so
-        // the smear sample at `target_pos − motion` always lies inside
-        // the mirror snapshot. Symmetric expansion (~2× per axis vs. a
-        // signed-motion tight fit) keeps the math simple; the cost is
-        // negligible compared to the per-dab pass.
-        let write_half_w = bbox_radius;
-        let write_half_h = bbox_radius;
-        let read_half_w = write_half_w + motion[0].abs().ceil();
-        let read_half_h = write_half_h + motion[1].abs().ceil();
-
-        // Pre-compute `copy_origin` (canvas-space top-left of the
-        // mirror snapshot) using the same formula
-        // `prepare_dab_canvas_copy` will use at flush time. The
-        // CPU compute is deterministic from `position` + `read_half`;
-        // the flush-time call re-derives the same value before issuing
-        // the actual sync.
-        let read_x0 = (position[0] - read_half_w).max(layer_x0);
-        let read_y0 = (position[1] - read_half_h).max(layer_y0);
-        let copy_canvas_x = read_x0.floor();
-        let copy_canvas_y = read_y0.floor();
-        Self::insert_copy_origin(gpu, ctx.node_id.0 as u32, [copy_canvas_x, copy_canvas_y]);
-
-        gpu.dab_batch
-            .queue_dab(&compiled, position, bbox_radius, radius);
-
-        // Pack the CPU-side meta in lockstep.
-        let meta = SmudgeDabMeta {
-            position,
-            write_half: [write_half_w, write_half_h],
-            read_half: [read_half_w, read_half_h],
-        };
-        gpu.dab_batch
-            .meta_bytes
-            .extend_from_slice(bytemuck::bytes_of(&meta));
-
-        vec![("dab_size".into(), ScalarValue::Vec2([diameter, diameter]))]
+        // Expand the read region by `|motion|` per axis so the smear
+        // sample at `target_pos − motion` always lies inside the mirror
+        // snapshot. Ceil to cover the bilinear sampler's half-texel reach.
+        Some([
+            bbox_radius + motion[0].abs().ceil(),
+            bbox_radius + motion[1].abs().ceil(),
+        ])
     }
 
-    fn flush_dabs(&self, _ctx: &EvalContext, gpu: &mut BrushGpuContext) {
-        if gpu.dab_batch.count == 0 {
-            return;
-        }
-        let Some(compiled) = gpu.dab_batch.compiled_brush.clone() else {
-            debug_assert!(false, "smudge::flush_dabs requires compiled_brush");
-            return;
-        };
-
-        let bbox = gpu.dab_batch.bbox.unwrap_or([0, 0, 0, 0]);
-        let union_w = bbox[2].saturating_sub(bbox[0]);
-        let union_h = bbox[3].saturating_sub(bbox[1]);
-        let (dab_bytes, total_dabs) = gpu.dab_batch.take();
-        let meta_bytes = gpu.dab_batch.take_meta();
-        if total_dabs == 0 {
-            return;
-        }
-        debug_assert_eq!(
-            meta_bytes.len(),
-            (total_dabs as usize) * SMUDGE_DAB_META_SIZE,
-            "smudge meta queue out of sync with dab queue"
-        );
-        let metas: Vec<SmudgeDabMeta> = bytemuck::cast_slice(&meta_bytes).to_vec();
-        gpu.perf
-            .record_dab_flush_workload(total_dabs, union_w, union_h);
-
-        let pipeline_ref = gpu.pipelines.get::<SmudgePipeline>("smudge");
-        ensure_per_brush_pipeline(gpu, pipeline_ref, &compiled);
-
-        let stroke = gpu
-            .stroke
-            .as_ref()
-            .expect("smudge::flush_dabs requires stroke resources");
-        let paint_target = &stroke.paint_target;
-        let canvas_ext = paint_target.canvas_extent();
-        let layer_offset = [canvas_ext.x0(), canvas_ext.y0()];
-        let layer_size = [canvas_ext.width, canvas_ext.height];
-
-        let mut uniform_bytes: Vec<u8> = Vec::with_capacity(MAX_UNIFORM_BYTES);
-        pack_intrinsic_uniforms(
-            &mut uniform_bytes,
-            gpu.intrinsic_header(layer_offset, layer_size),
-        );
-        let outputs = gpu
-            .dab_batch
-            .slot_outputs
-            .as_ref()
-            .expect("smudge::flush_dabs requires dab_batch.slot_outputs");
-        pack_uniforms(&compiled, outputs, &mut uniform_bytes);
-
-        pipeline_ref.with_pipeline(compiled.topology_hash, |per_brush| {
-            if uniform_bytes.len() < per_brush.uniform_size {
-                uniform_bytes.resize(per_brush.uniform_size, 0);
-            }
-            per_brush.uniform_ring.reset();
-            let uniform_offset = per_brush.uniform_ring.write(gpu.queue, &uniform_bytes);
-            gpu.queue
-                .write_buffer(&per_brush.dabs_buffer, 0, &dab_bytes);
-
-            for (i, meta) in metas.iter().enumerate() {
-                // Sync the mirror snapshot for this dab. The implicit
-                // barrier from this `copy_texture_to_texture` makes
-                // the subsequent render pass see prior dab writes.
-                let _ = gpu.prepare_dab_canvas_copy(
-                    meta.position,
-                    meta.write_half[0],
-                    meta.write_half[1],
-                    meta.read_half[0],
-                    meta.read_half[1],
-                );
-
-                // Fresh read-mirror bind group each iteration — a
-                // mid-loop grow can rebuild it.
-                let scratch_ref = &*gpu
-                    .stroke
-                    .as_ref()
-                    .expect("smudge::flush_dabs requires stroke resources")
-                    .scratch;
-                let read_bg = scratch_ref.read_mirror_bind_group();
-                let write_view = scratch_ref.write_view();
-
-                let mut pass = gpu.encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                    label: Some("smudge-flush"),
-                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                        view: write_view,
-                        resolve_target: None,
-                        depth_slice: None,
-                        ops: wgpu::Operations {
-                            load: wgpu::LoadOp::Load,
-                            store: wgpu::StoreOp::Store,
-                        },
-                    })],
-                    ..Default::default()
-                });
-                pass.set_viewport(
-                    0.0,
-                    0.0,
-                    layer_size[0] as f32,
-                    layer_size[1] as f32,
-                    0.0,
-                    1.0,
-                );
-                pass.set_pipeline(&per_brush.pipeline);
-                pass.set_bind_group(0, &per_brush.uniform_bind_group, &[uniform_offset]);
-                pass.set_bind_group(1, &per_brush.dabs_bind_group, &[]);
-                pass.set_bind_group(2, gpu.selection_bind_group, &[]);
-                pass.set_bind_group(3, read_bg, &[]);
-                let ii = i as u32;
-                pass.draw(0..6, ii..ii + 1);
-            }
-        });
-
-        gpu.perf.record_dab_flush(total_dabs);
-    }
-
-    /// Direct blit scratch → layer. The scratch already holds the
-    /// finished image; commit just copies it across. `gpu.blend_mode`
-    /// is ignored — erase semantics aren't meaningful for a smear.
-    fn commit(&self, _ctx: &EvalContext, gpu: &mut BrushGpuContext) {
-        let Some(stroke) = gpu.stroke.as_ref() else {
-            return;
-        };
-        stroke.paint_target.commit_scratch_blit(
-            gpu.device,
-            &mut gpu.encoder,
-            gpu.pipelines,
-            stroke.scratch.write_view(),
-            stroke.scratch.write_texture(),
-        );
-    }
-
-    /// Hover-cursor preview. Routes through the shared preview helper.
-    /// Smudge has no rotation port — the cursor is symmetric, and
-    /// rotating it wouldn't carry meaningful information for the user.
-    fn render_cursor_preview(
+    fn compile_body(
         &self,
-        ctx: &EvalContext,
-        gpu: &mut BrushGpuContext,
-    ) -> Vec<(String, ScalarValue)> {
-        let radius = Self::effective_radius(ctx);
-        let _ = crate::brush::wgsl::render_compiled_cursor_preview(gpu, radius);
-        vec![]
-    }
-
-    fn compile_wgsl(&self, cctx: &CompileWgslCtx) -> Result<NodeWgsl, String> {
+        cctx: &CompileWgslCtx,
+        copy_origin_field: &str,
+    ) -> Result<NodeWgsl, String> {
         let mut wgsl = NodeWgsl::default();
 
         let mask_expr = cctx.input("mask").as_f32();
         let motion_expr = cctx.input("motion").as_vec2();
         let rate_expr = cctx.input("rate").as_f32();
         let opacity_expr = cctx.input("opacity").as_f32();
-
-        // Per-dab `copy_origin` field. The terminal's `evaluate_gpu`
-        // inserts this into `dab_batch.slot_outputs` so the packer reads
-        // it through the standard `pack_dab_record` path.
-        let copy_origin_field = cctx.dab_field_name("copy_origin");
-        let key = copy_origin_field.clone();
-        wgsl.dab_fields.push(DabField {
-            name: copy_origin_field.clone(),
-            ty: WgslType::Vec2,
-            pack: Arc::new(move |outputs, bytes| {
-                let v = outputs.get(&key).map(|s| s.as_vec2()).unwrap_or([0.0; 2]);
-                bytes.extend_from_slice(bytemuck::bytes_of(&v));
-            }),
-        });
-
-        wgsl.terminal_bindings = "@group(3) @binding(0) var scratch_mirror_tex: texture_2d<f32>;\n\
-             @group(3) @binding(1) var scratch_mirror_smp: sampler;\n"
-            .to_string();
 
         wgsl.body = format!(
             "    let mask = clamp({mask_expr}, 0.0, 1.0);\n\
@@ -652,17 +150,15 @@ impl BrushNodeEvaluator for SmudgeEvaluator {
              \x20   let src = textureSampleLevel(scratch_mirror_tex, scratch_mirror_smp, src_uv, 0.0);\n\
              \x20   let amount = clamp(rate * mask * sel * stroke_opacity, 0.0, 1.0);\n\
              \x20   return mix(bg, src, amount);\n",
-            copy_origin_field = copy_origin_field,
         );
 
         Ok(wgsl)
     }
 
-    /// Preview-mode body. The stroke body samples `scratch_mirror`
-    /// (bound at `@group(3)` in stroke mode, omitted in preview).
-    /// Semantic for the preview: "show the footprint, not the smear"
-    /// — neutral gray, modulated by the upstream shape mask so the
-    /// cursor still reads the brush's actual coverage area.
+    /// Preview body — show the footprint, not the smear: neutral gray
+    /// modulated by the upstream shape mask so the cursor reads the
+    /// brush's actual coverage area. (The stroke body's `scratch_mirror`
+    /// bindings are omitted in preview mode.)
     fn compile_cursor_preview_body(&self, cctx: &CompileWgslCtx) -> Result<NodeWgsl, String> {
         let mut wgsl = NodeWgsl::default();
         let mask_expr = cctx.input("mask").as_f32();
@@ -676,25 +172,40 @@ impl BrushNodeEvaluator for SmudgeEvaluator {
     }
 }
 
-// ── Per-brush pipeline build helper ─────────────────────────────────────
-
-fn ensure_per_brush_pipeline(
-    gpu: &BrushGpuContext,
-    pipe: &SmudgePipeline,
-    compiled: &CompiledBrush,
-) {
-    if pipe.cache.borrow().contains_key(&compiled.topology_hash) {
-        return;
+impl BrushNodeEvaluator for SmudgeEvaluator {
+    fn evaluate_cpu(&self, _ctx: &EvalContext) -> Vec<(String, ScalarValue)> {
+        vec![]
     }
-    let ctx = BuildContext {
-        device: gpu.device,
-        queue: gpu.queue,
-        uniform_bgl: gpu.pipelines.uniform_bind_group_layout(),
-        selection_bgl: gpu.pipelines.selection_bind_group_layout(),
-        canvas_copy_bgl: gpu.pipelines.canvas_copy_bind_group_layout(),
-        canvas_copy_sampler: gpu.pipelines.canvas_copy_sampler(),
-        min_uniform_align: gpu.device.limits().min_uniform_buffer_offset_alignment,
-        texture_registry: gpu.pipelines.texture_registry(),
-    };
-    pipe.ensure_pipeline(&ctx, compiled);
+
+    fn evaluate_gpu(
+        &self,
+        ctx: &EvalContext,
+        gpu: &mut BrushGpuContext,
+    ) -> Vec<(String, ScalarValue)> {
+        rmt::evaluate_gpu(self, ctx, gpu)
+    }
+
+    fn flush_dabs(&self, _ctx: &EvalContext, gpu: &mut BrushGpuContext) {
+        rmt::flush_dabs::<Self>(gpu)
+    }
+
+    fn commit(&self, _ctx: &EvalContext, gpu: &mut BrushGpuContext) {
+        rmt::commit(gpu)
+    }
+
+    fn render_cursor_preview(
+        &self,
+        ctx: &EvalContext,
+        gpu: &mut BrushGpuContext,
+    ) -> Vec<(String, ScalarValue)> {
+        rmt::render_cursor_preview(ctx, gpu)
+    }
+
+    fn compile_wgsl(&self, cctx: &CompileWgslCtx) -> Result<NodeWgsl, String> {
+        rmt::compile_wgsl(self, cctx)
+    }
+
+    fn compile_cursor_preview_body(&self, cctx: &CompileWgslCtx) -> Result<NodeWgsl, String> {
+        ReadMirrorTerminal::compile_cursor_preview_body(self, cctx)
+    }
 }

--- a/crates/darkly/src/brush/pipeline.rs
+++ b/crates/darkly/src/brush/pipeline.rs
@@ -22,8 +22,8 @@
 //! Look-up is by `(id, type)`:
 //!
 //! ```ignore
-//! let liq = pipelines.get::<LiquifyPipeline>("liquify");
-//! pass.set_pipeline(liq.pipeline());
+//! let paint = pipelines.get::<PaintPipeline>("paint");
+//! pass.set_pipeline(paint.pipeline());
 //! ```
 
 use std::any::Any;

--- a/crates/darkly/src/brush/read_mirror_terminal.rs
+++ b/crates/darkly/src/brush/read_mirror_terminal.rs
@@ -1,0 +1,668 @@
+//! Shared infrastructure for per-dab fragment-pass terminals that read
+//! the scratch read mirror, transform it, and write it back —
+//! [`smudge`](super::nodes::smudge), [`liquify`](super::nodes::liquify),
+//! and [`blur`](super::nodes::blur).
+//!
+//! All three share one mechanical shape: each dab samples the scratch
+//! read mirror (bound at `@group(3)`), produces a new pixel, and writes
+//! it straight back under REPLACE blend. Dabs run one render pass each
+//! (`i..i+1`) with a `copy_texture_to_texture` between them, so every dab
+//! sees the prior dab's output through the mirror — the implicit barrier
+//! that makes the per-dab serialization real. The only thing that varies
+//! per terminal is *how* the fragment shader transforms the sample and
+//! how wide a read region each dab needs; everything else — the per-brush
+//! pipeline, the dab-meta queue, the flush loop, the `copy_origin`
+//! plumbing, the cursor preview — is identical and lives here.
+//!
+//! A terminal opts in by implementing [`ReadMirrorTerminal`] (its read
+//! half-extent math + variant WGSL) and delegating each
+//! [`BrushNodeEvaluator`](crate::brush::eval::BrushNodeEvaluator) method
+//! to the free functions below.
+//!
+//! ## Blend state
+//!
+//! REPLACE — the fragment shader fully composes its output and writes it
+//! straight to scratch. `LoadOp::Load` keeps prior scratch pixels intact
+//! outside the dab footprint; the fragment shader discards past
+//! `d.bbox_target_px`.
+
+use std::any::Any;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::brush::eval::EvalContext;
+use crate::brush::gpu_context::{BrushGpuContext, MAX_DABS_PER_PHASE};
+use crate::brush::paint_target_ext::BrushPaintTargetExt;
+use crate::brush::pipeline::{
+    BrushPipelineEntry, BrushPipelineRegistration, BuildContext, DynamicUniformRing,
+};
+use crate::brush::wgsl::{
+    pack_intrinsic_uniforms, pack_uniforms, CompileWgslCtx, CompiledBrush, DabField, NodeWgsl,
+    WgslType, INTRINSIC_UNIFORMS_SIZE,
+};
+use crate::brush::wire::ScalarValue;
+
+// ── Constants ───────────────────────────────────────────────────────────
+
+const SIZE_REFERENCE_PX: f32 = crate::brush::DAB_REFERENCE_SIZE as f32;
+
+const MAX_UNIFORM_BYTES: usize = 1024;
+
+/// The `@group(3)` scratch read-mirror bindings every read-mirror
+/// terminal samples. Owned here so variants never declare the layout
+/// themselves — the per-brush pipeline below must match it exactly.
+const SCRATCH_MIRROR_BINDINGS: &str =
+    "@group(3) @binding(0) var scratch_mirror_tex: texture_2d<f32>;\n\
+     @group(3) @binding(1) var scratch_mirror_smp: sampler;\n";
+
+// ── Per-variant surface ─────────────────────────────────────────────────
+
+/// The only per-terminal surface. A read-mirror terminal supplies its
+/// read half-extent (how wide a mirror snapshot each dab needs) and its
+/// variant WGSL; the free functions below own everything else.
+pub trait ReadMirrorTerminal {
+    /// Registry id of this terminal's [`ReadMirrorPipeline`] —
+    /// `"smudge"` | `"liquify"` | `"blur"`.
+    const PIPELINE_ID: &'static str;
+    /// Human-readable label prefix for GPU debug labels.
+    const LABEL: &'static str;
+
+    /// Desired read half-extent (canvas px, per axis), or `None` to drop
+    /// this dab before it reaches the queue. `None` is the terminal's
+    /// early-out: a stationary smudge, a sub-threshold liquify push, a
+    /// zero-strength blur — all collapse to an identity write, so the
+    /// per-dab pass and its mirror copy are pure waste.
+    ///
+    /// The framework clamps the returned half-extent up to at least the
+    /// dab's write footprint (`bbox_radius`), so a terminal may return a
+    /// value smaller than the footprint without breaking the
+    /// read-encloses-write invariant.
+    fn read_half(&self, ctx: &EvalContext, radius: f32, bbox_radius: f32) -> Option<[f32; 2]>;
+
+    /// Insert any extra per-dab `slot_outputs` this terminal's WGSL reads
+    /// through a [`DabField`] (e.g. blur's `blur_px`). Called immediately
+    /// before `queue_dab`, so the value packs into *this* dab's record —
+    /// the same ordering `copy_origin` relies on. Default: no extra slots.
+    fn pack_extra(
+        &self,
+        _ctx: &EvalContext,
+        _gpu: &mut BrushGpuContext,
+        _node_id: u32,
+        _radius: f32,
+    ) {
+    }
+
+    /// Variant WGSL: the fragment body, plus any module-scope `decls` and
+    /// extra `dab_fields` the body references. The wrapper appends the
+    /// shared `copy_origin` dab field and owns `terminal_bindings`; the
+    /// variant must **not** set `terminal_bindings`. `copy_origin_field`
+    /// is the dab-record field name to read the mirror snapshot origin
+    /// from.
+    fn compile_body(
+        &self,
+        cctx: &CompileWgslCtx,
+        copy_origin_field: &str,
+    ) -> Result<NodeWgsl, String>;
+
+    /// Variant preview-mode body — the cursor footprint, sampling no
+    /// `@group(3)` bindings (preview omits them).
+    fn compile_cursor_preview_body(&self, cctx: &CompileWgslCtx) -> Result<NodeWgsl, String>;
+}
+
+// ── Per-dab CPU meta ────────────────────────────────────────────────────
+
+/// CPU-side per-dab footprint info, packed by [`evaluate_gpu`] in
+/// lockstep with the GPU dab record and drained by [`flush_dabs`]. Lets
+/// the flush loop call `prepare_dab_canvas_copy` without re-deriving the
+/// footprint from the upload buffer.
+#[repr(C)]
+#[derive(Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+struct ReadMirrorDabMeta {
+    position: [f32; 2],
+    /// Half-extent of the write region (the dab footprint).
+    write_half: [f32; 2],
+    /// Half-extent of the read region (the mirror snapshot the shader
+    /// samples). Always encloses `write_half`.
+    read_half: [f32; 2],
+}
+
+const READ_MIRROR_DAB_META_SIZE: usize = std::mem::size_of::<ReadMirrorDabMeta>();
+
+// ── Per-brush pipeline ──────────────────────────────────────────────────
+
+struct PerBrushPipeline {
+    pipeline: wgpu::RenderPipeline,
+    uniform_ring: DynamicUniformRing,
+    uniform_bind_group: wgpu::BindGroup,
+    dabs_buffer: wgpu::Buffer,
+    dabs_bind_group: wgpu::BindGroup,
+    uniform_size: usize,
+}
+
+impl PerBrushPipeline {
+    fn build(ctx: &BuildContext, compiled: &CompiledBrush, label: &str) -> Self {
+        let shader = ctx
+            .device
+            .create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some(&format!("{label}-brush")),
+                source: wgpu::ShaderSource::Wgsl(compiled.stroke_wgsl.clone().into()),
+            });
+
+        let dabs_bgl = ctx
+            .device
+            .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some(&format!("{label}-dabs-bgl")),
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            });
+
+        // group(0..2) standard; group(3) is the scratch read mirror —
+        // same layout as `watercolor`'s atlas binding, only the binding
+        // semantics differ.
+        let layout = ctx
+            .device
+            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some(&format!("{label}-layout")),
+                bind_group_layouts: &[
+                    Some(ctx.uniform_bgl),
+                    Some(&dabs_bgl),
+                    Some(ctx.selection_bgl),
+                    Some(ctx.canvas_copy_bgl),
+                ],
+                immediate_size: 0,
+            });
+
+        // REPLACE blend — the fragment shader writes the final pixel;
+        // outside the disc it discards so LoadOp::Load preserves the
+        // scratch.
+        let pipeline = ctx
+            .device
+            .create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some(label),
+                layout: Some(&layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("vs_main"),
+                    buffers: &[],
+                    compilation_options: Default::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some("fs_main"),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: wgpu::TextureFormat::Rgba8Unorm,
+                        blend: Some(wgpu::BlendState::REPLACE),
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                    compilation_options: Default::default(),
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    ..Default::default()
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview_mask: None,
+                cache: None,
+            });
+
+        let uniform_size =
+            (INTRINSIC_UNIFORMS_SIZE + compiled.uniform_size).max(INTRINSIC_UNIFORMS_SIZE);
+        let uniform_ring = DynamicUniformRing::new(
+            ctx.device,
+            &format!("{label}-uniforms"),
+            uniform_size as u64,
+            ctx.min_uniform_align,
+        );
+        let uniform_bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some(&format!("{label}-uniform-bg")),
+            layout: ctx.uniform_bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(wgpu::BufferBinding {
+                    buffer: &uniform_ring.buffer,
+                    offset: 0,
+                    size: Some(uniform_ring.binding_size()),
+                }),
+            }],
+        });
+
+        let dab_record_size = compiled.dab_record_size.max(16);
+        let dabs_buffer_size = (MAX_DABS_PER_PHASE as u64) * (dab_record_size as u64);
+        let dabs_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some(&format!("{label}-dabs-buffer")),
+            size: dabs_buffer_size,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let dabs_bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some(&format!("{label}-dabs-bg")),
+            layout: &dabs_bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: dabs_buffer.as_entire_binding(),
+            }],
+        });
+
+        Self {
+            pipeline,
+            uniform_ring,
+            uniform_bind_group,
+            dabs_buffer,
+            dabs_bind_group,
+            uniform_size,
+        }
+    }
+}
+
+// ── Pipeline registry entry ─────────────────────────────────────────────
+
+/// Per-brush pipeline cache shared by every read-mirror terminal. One
+/// instance is registered per terminal id (`"smudge"`, `"liquify"`,
+/// `"blur"`); they are the same Rust type, distinguished only by their
+/// registry key.
+pub struct ReadMirrorPipeline {
+    cache: RefCell<HashMap<u64, PerBrushPipeline>>,
+}
+
+impl ReadMirrorPipeline {
+    fn build(_ctx: &BuildContext) -> Self {
+        Self {
+            cache: RefCell::new(HashMap::new()),
+        }
+    }
+
+    fn ensure_pipeline(&self, ctx: &BuildContext, compiled: &CompiledBrush, label: &str) {
+        let mut cache = self.cache.borrow_mut();
+        cache
+            .entry(compiled.topology_hash)
+            .or_insert_with(|| PerBrushPipeline::build(ctx, compiled, label));
+    }
+
+    fn with_pipeline<R>(&self, hash: u64, f: impl FnOnce(&PerBrushPipeline) -> R) -> R {
+        let cache = self.cache.borrow();
+        let p = cache
+            .get(&hash)
+            .expect("ensure_pipeline must run before with_pipeline");
+        f(p)
+    }
+}
+
+impl BrushPipelineEntry for ReadMirrorPipeline {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn ring(&self) -> Option<&DynamicUniformRing> {
+        None
+    }
+    fn rings(&self) -> Vec<&DynamicUniformRing> {
+        Vec::new()
+    }
+}
+
+/// Build a pipeline registration for a read-mirror terminal under the
+/// given registry id. Drop one of these in a terminal's `register()`
+/// `pipelines` list.
+pub fn read_mirror_pipeline_reg(id: &'static str) -> BrushPipelineRegistration {
+    BrushPipelineRegistration {
+        id,
+        build: |ctx| Box::new(ReadMirrorPipeline::build(ctx)),
+    }
+}
+
+// ── Shared helpers ───────────────────────────────────────────────────────
+
+/// Effective dab radius in canvas pixels from the `size_input` × `size`
+/// inputs. Floored at 0.5 px so a dab always has positive area.
+pub fn effective_radius(ctx: &EvalContext) -> f32 {
+    let size_input = ctx.input_f32("size_input").max(0.0);
+    let size = ctx.input_f32("size").max(0.0);
+    let effective_size = size_input * size;
+    (effective_size * SIZE_REFERENCE_PX * 0.5).max(0.5)
+}
+
+/// Insert a per-dab value into `dab_batch.slot_outputs` under this node's
+/// dab-field key (`n{node_id}_{base}`), so the framework's
+/// `pack_dab_record` picks it up via the matching [`DabField`] declared
+/// in [`compile_wgsl`]. Used for `copy_origin` (always) and any terminal
+/// extras (e.g. blur's `blur_px`, via [`ReadMirrorTerminal::pack_extra`]).
+pub fn insert_slot_output(gpu: &mut BrushGpuContext, node_id: u32, base: &str, value: ScalarValue) {
+    if let Some(outputs) = gpu.dab_batch.slot_outputs.as_mut() {
+        outputs.insert(format!("n{}_{}", node_id, base), value);
+    }
+}
+
+/// Per-dab `evaluate_gpu`. Computes the dab geometry, calls
+/// [`ReadMirrorTerminal::read_half`] (dropping the dab on `None`), clamps
+/// the footprint to the layer extent, records the write bbox + bbox
+/// union, pre-computes `copy_origin`, then packs the dab record + meta in
+/// lockstep. Returns `dab_size` for downstream spacing.
+pub fn evaluate_gpu<T: ReadMirrorTerminal>(
+    term: &T,
+    ctx: &EvalContext,
+    gpu: &mut BrushGpuContext,
+) -> Vec<(String, ScalarValue)> {
+    let Some(compiled) = gpu.dab_batch.compiled_brush.clone() else {
+        debug_assert!(false, "{} requires compiled_brush on gpu_context", T::LABEL);
+        return vec![];
+    };
+    let Some(stroke) = gpu.stroke.as_ref() else {
+        return vec![];
+    };
+    let paint_target = &stroke.paint_target;
+    let position = ctx.input("position").as_vec2();
+    let radius = effective_radius(ctx);
+    let diameter = radius * 2.0;
+    let dab_size = || vec![("dab_size".into(), ScalarValue::Vec2([diameter, diameter]))];
+    if diameter <= 0.0 {
+        return dab_size();
+    }
+
+    // Per-brush extent: composed by the framework at compile time. For a
+    // plain disc upstream this is `radius`.
+    let bbox_radius = radius * compiled.brush_extent_factor + compiled.brush_extent_extra_px;
+
+    // Terminal's desired read half-extent — `None` is the early-out for
+    // dabs whose transform is an identity write.
+    let Some(read_half) = term.read_half(ctx, radius, bbox_radius) else {
+        return dab_size();
+    };
+
+    let canvas_ext = paint_target.canvas_extent();
+    // Near-edge of the layer extent — reused below for the read-region
+    // copy origin (a one-sided clamp, distinct from the dab footprint
+    // clamp).
+    let layer_x0 = canvas_ext.x0() as f32;
+    let layer_y0 = canvas_ext.y0() as f32;
+    // Clamp the dab footprint to the layer extent; a dab entirely
+    // off-extent has no pixels to draw and is skipped.
+    let canvas_bbox = match canvas_ext.clamp_f32(
+        position[0] - bbox_radius,
+        position[1] - bbox_radius,
+        position[0] + bbox_radius,
+        position[1] + bbox_radius,
+    ) {
+        Some(r) => r,
+        None => return dab_size(),
+    };
+    let local = paint_target
+        .canvas_frame()
+        .canvas_to_layer_rect(canvas_bbox)
+        .expect("canvas_bbox came from canvas_ext.clamp_f32, so it overlaps the extent");
+    gpu.dab_batch.push_write_bbox(canvas_bbox);
+    gpu.dab_batch.bbox = Some(match gpu.dab_batch.bbox {
+        Some([x0, y0, x1, y1]) => [
+            x0.min(local.x0()),
+            y0.min(local.y0()),
+            x1.max(local.x1()),
+            y1.max(local.y1()),
+        ],
+        None => [local.x0(), local.y0(), local.x1(), local.y1()],
+    });
+
+    // The write region is the dab footprint; the read region is the
+    // mirror snapshot. Clamp the read half up to at least the write half
+    // per axis so `prepare_dab_canvas_copy`'s read-encloses-write
+    // debug-assert always holds, even when `bbox_radius` dominates a tiny
+    // requested read extent.
+    let write_half = [bbox_radius, bbox_radius];
+    let read_half = [
+        read_half[0].max(write_half[0]),
+        read_half[1].max(write_half[1]),
+    ];
+
+    // Pre-compute `copy_origin` (canvas-space top-left of the mirror
+    // snapshot) with the same formula `prepare_dab_canvas_copy` will use
+    // at flush time; the per-dab record carries it so the shader can map
+    // `target_pos` into mirror UVs.
+    let read_x0 = (position[0] - read_half[0]).max(layer_x0);
+    let read_y0 = (position[1] - read_half[1]).max(layer_y0);
+    let copy_origin = [read_x0.floor(), read_y0.floor()];
+    let node_id = ctx.node_id.0 as u32;
+    insert_slot_output(gpu, node_id, "copy_origin", ScalarValue::Vec2(copy_origin));
+
+    // Extra per-dab slots (blur's kernel size, …) must be inserted before
+    // `queue_dab` packs the record.
+    term.pack_extra(ctx, gpu, node_id, radius);
+
+    gpu.dab_batch
+        .queue_dab(&compiled, position, bbox_radius, radius);
+
+    // Pack the CPU-side meta in lockstep with the GPU record.
+    let meta = ReadMirrorDabMeta {
+        position,
+        write_half,
+        read_half,
+    };
+    gpu.dab_batch
+        .meta_bytes
+        .extend_from_slice(bytemuck::bytes_of(&meta));
+
+    dab_size()
+}
+
+/// Per-phase flush. Walks the dab-meta queue in lockstep: for each dab it
+/// syncs the mirror snapshot (`prepare_dab_canvas_copy`, whose
+/// `copy_texture_to_texture` carries the implicit barrier that lets each
+/// draw see the prior draw's output) and issues one render pass with
+/// instance index `i..i+1`.
+pub fn flush_dabs<T: ReadMirrorTerminal>(gpu: &mut BrushGpuContext) {
+    if gpu.dab_batch.count == 0 {
+        return;
+    }
+    let Some(compiled) = gpu.dab_batch.compiled_brush.clone() else {
+        debug_assert!(false, "{}::flush_dabs requires compiled_brush", T::LABEL);
+        return;
+    };
+
+    let bbox = gpu.dab_batch.bbox.unwrap_or([0, 0, 0, 0]);
+    let union_w = bbox[2].saturating_sub(bbox[0]);
+    let union_h = bbox[3].saturating_sub(bbox[1]);
+    let (dab_bytes, total_dabs) = gpu.dab_batch.take();
+    let meta_bytes = gpu.dab_batch.take_meta();
+    if total_dabs == 0 {
+        return;
+    }
+    debug_assert_eq!(
+        meta_bytes.len(),
+        (total_dabs as usize) * READ_MIRROR_DAB_META_SIZE,
+        "{} meta queue out of sync with dab queue",
+        T::LABEL
+    );
+    let metas: Vec<ReadMirrorDabMeta> = bytemuck::cast_slice(&meta_bytes).to_vec();
+    gpu.perf
+        .record_dab_flush_workload(total_dabs, union_w, union_h);
+
+    let pipeline_ref = gpu.pipelines.get::<ReadMirrorPipeline>(T::PIPELINE_ID);
+    ensure_per_brush_pipeline(gpu, pipeline_ref, &compiled, T::LABEL);
+
+    let stroke = gpu
+        .stroke
+        .as_ref()
+        .expect("read-mirror flush_dabs requires stroke resources");
+    let paint_target = &stroke.paint_target;
+    let canvas_ext = paint_target.canvas_extent();
+    let layer_offset = [canvas_ext.x0(), canvas_ext.y0()];
+    let layer_size = [canvas_ext.width, canvas_ext.height];
+
+    let mut uniform_bytes: Vec<u8> = Vec::with_capacity(MAX_UNIFORM_BYTES);
+    pack_intrinsic_uniforms(
+        &mut uniform_bytes,
+        gpu.intrinsic_header(layer_offset, layer_size),
+    );
+    let outputs = gpu
+        .dab_batch
+        .slot_outputs
+        .as_ref()
+        .expect("read-mirror flush_dabs requires dab_batch.slot_outputs");
+    pack_uniforms(&compiled, outputs, &mut uniform_bytes);
+
+    let pass_label = format!("{}-flush", T::LABEL);
+    pipeline_ref.with_pipeline(compiled.topology_hash, |per_brush| {
+        if uniform_bytes.len() < per_brush.uniform_size {
+            uniform_bytes.resize(per_brush.uniform_size, 0);
+        }
+        per_brush.uniform_ring.reset();
+        let uniform_offset = per_brush.uniform_ring.write(gpu.queue, &uniform_bytes);
+        gpu.queue
+            .write_buffer(&per_brush.dabs_buffer, 0, &dab_bytes);
+
+        for (i, meta) in metas.iter().enumerate() {
+            // Invalidate the per-dab read-mirror origin cache so this dab
+            // re-copies the scratch even when it shares an origin with the
+            // previous dab. Without this, two dabs at the same spot would
+            // reuse the prior snapshot and the dab would read stale pixels
+            // instead of the previous dab's writeback — which would break
+            // dwell-compounding (scrub-in-place re-blur / re-smear) and the
+            // per-dab barrier for any same-origin pair.
+            if let Some(stroke) = gpu.stroke.as_mut() {
+                stroke.reset_per_dab_read_cache();
+            }
+
+            // Sync the mirror snapshot for this dab. The implicit barrier
+            // from this `copy_texture_to_texture` makes the subsequent
+            // render pass see prior dab writes.
+            let _ = gpu.prepare_dab_canvas_copy(
+                meta.position,
+                meta.write_half[0],
+                meta.write_half[1],
+                meta.read_half[0],
+                meta.read_half[1],
+            );
+
+            // Fresh read-mirror bind group each iteration — a mid-loop
+            // grow can rebuild it.
+            let scratch_ref = &*gpu
+                .stroke
+                .as_ref()
+                .expect("read-mirror flush_dabs requires stroke resources")
+                .scratch;
+            let read_bg = scratch_ref.read_mirror_bind_group();
+            let write_view = scratch_ref.write_view();
+
+            let mut pass = gpu.encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some(&pass_label),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: write_view,
+                    resolve_target: None,
+                    depth_slice: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Load,
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                ..Default::default()
+            });
+            pass.set_viewport(
+                0.0,
+                0.0,
+                layer_size[0] as f32,
+                layer_size[1] as f32,
+                0.0,
+                1.0,
+            );
+            pass.set_pipeline(&per_brush.pipeline);
+            pass.set_bind_group(0, &per_brush.uniform_bind_group, &[uniform_offset]);
+            pass.set_bind_group(1, &per_brush.dabs_bind_group, &[]);
+            pass.set_bind_group(2, gpu.selection_bind_group, &[]);
+            pass.set_bind_group(3, read_bg, &[]);
+            let ii = i as u32;
+            pass.draw(0..6, ii..ii + 1);
+        }
+    });
+
+    gpu.perf.record_dab_flush(total_dabs);
+}
+
+/// Direct blit scratch → layer. The scratch already holds the finished
+/// image; commit just copies it across. `gpu.blend_mode` is ignored —
+/// erase semantics aren't meaningful for these read-back transforms.
+pub fn commit(gpu: &mut BrushGpuContext) {
+    let Some(stroke) = gpu.stroke.as_ref() else {
+        return;
+    };
+    stroke.paint_target.commit_scratch_blit(
+        gpu.device,
+        &mut gpu.encoder,
+        gpu.pipelines,
+        stroke.scratch.write_view(),
+        stroke.scratch.write_texture(),
+    );
+}
+
+/// Hover-cursor preview. Routes through the shared preview helper at the
+/// dab's effective radius.
+pub fn render_cursor_preview(
+    ctx: &EvalContext,
+    gpu: &mut BrushGpuContext,
+) -> Vec<(String, ScalarValue)> {
+    let radius = effective_radius(ctx);
+    let _ = crate::brush::wgsl::render_compiled_cursor_preview(gpu, radius);
+    vec![]
+}
+
+/// Assemble the terminal's `compile_wgsl` output: the variant body +
+/// decls, plus the shared `copy_origin` dab field and the `@group(3)`
+/// mirror bindings. The variant must not set `terminal_bindings`.
+pub fn compile_wgsl<T: ReadMirrorTerminal>(
+    term: &T,
+    cctx: &CompileWgslCtx,
+) -> Result<NodeWgsl, String> {
+    let copy_origin_field = cctx.dab_field_name("copy_origin");
+    let mut wgsl = term.compile_body(cctx, &copy_origin_field)?;
+
+    debug_assert!(
+        wgsl.terminal_bindings.is_empty(),
+        "read-mirror variant must not set terminal_bindings — the wrapper owns @group(3)",
+    );
+
+    // Shared per-dab `copy_origin` field. The terminal's `evaluate_gpu`
+    // inserts the value into `dab_batch.slot_outputs`; the packer reads
+    // it through the standard `pack_dab_record` path.
+    let key = copy_origin_field.clone();
+    wgsl.dab_fields.push(DabField {
+        name: copy_origin_field,
+        ty: WgslType::Vec2,
+        pack: Arc::new(move |outputs, bytes| {
+            let v = outputs.get(&key).map(|s| s.as_vec2()).unwrap_or([0.0; 2]);
+            bytes.extend_from_slice(bytemuck::bytes_of(&v));
+        }),
+    });
+
+    wgsl.terminal_bindings = SCRATCH_MIRROR_BINDINGS.to_string();
+
+    Ok(wgsl)
+}
+
+// ── Per-brush pipeline build helper ─────────────────────────────────────
+
+fn ensure_per_brush_pipeline(
+    gpu: &BrushGpuContext,
+    pipe: &ReadMirrorPipeline,
+    compiled: &CompiledBrush,
+    label: &str,
+) {
+    if pipe.cache.borrow().contains_key(&compiled.topology_hash) {
+        return;
+    }
+    let ctx = BuildContext {
+        device: gpu.device,
+        queue: gpu.queue,
+        uniform_bgl: gpu.pipelines.uniform_bind_group_layout(),
+        selection_bgl: gpu.pipelines.selection_bind_group_layout(),
+        canvas_copy_bgl: gpu.pipelines.canvas_copy_bind_group_layout(),
+        canvas_copy_sampler: gpu.pipelines.canvas_copy_sampler(),
+        min_uniform_align: gpu.device.limits().min_uniform_buffer_offset_alignment,
+        texture_registry: gpu.pipelines.texture_registry(),
+    };
+    pipe.ensure_pipeline(&ctx, compiled, label);
+}

--- a/crates/darkly/tests/blur.rs
+++ b/crates/darkly/tests/blur.rs
@@ -1,0 +1,233 @@
+//! Tests for the compiled `blur` terminal.
+//!
+//! Blur reads a golden-angle disc of the scratch read mirror around each
+//! dab, averages the taps, and writes the softened pixel back. Two
+//! behaviors are load-bearing:
+//!
+//! 1. **Neighborhood averaging** — a dab straddling a hard black/white
+//!    edge produces an intermediate gray at the edge, while pixels
+//!    outside the dab footprint stay untouched.
+//! 2. **Dwell-compounding** — because each dab reads the *cumulative*
+//!    scratch through the per-dab read-mirror barrier (the same barrier
+//!    smudge/liquify rely on), a second overlapping pass softens further
+//!    than one. If the flush were ever collapsed into a single instanced
+//!    draw, the second dab would re-read the pre-stroke and the
+//!    compounding would vanish.
+
+use std::sync::{Arc, OnceLock};
+
+use darkly::brush::compile_graph;
+use darkly::brush::eval::BrushGraphRunner;
+use darkly::brush::gpu_context::{BrushGpuContext, BrushPerfCounters, DabBatch, StrokeResources};
+use darkly::brush::paint_info::PaintInformation;
+use darkly::brush::pipeline::BrushPipelines;
+use darkly::brush::stroke_buffer::StrokeBuffer;
+use darkly::gpu::test_utils::{create_test_texture, readback_texture, test_device};
+
+const CANVAS: u32 = 128;
+
+/// Column at which the pre-stroke flips from white (left) to black
+/// (right). Pixels with `x < EDGE_X` are white; the rest are black.
+const EDGE_X: u32 = 64;
+
+fn shared_device() -> (Arc<wgpu::Device>, Arc<wgpu::Queue>) {
+    static HANDLES: OnceLock<(Arc<wgpu::Device>, Arc<wgpu::Queue>)> = OnceLock::new();
+    HANDLES
+        .get_or_init(|| {
+            let (d, q) = test_device();
+            (Arc::new(d), Arc::new(q))
+        })
+        .clone()
+}
+
+/// Pre-stroke canvas: a hard vertical edge — opaque white in `x < EDGE_X`,
+/// opaque black elsewhere. Gives the blur a sharp boundary to soften.
+fn hard_edge_canvas() -> Vec<u8> {
+    let mut out = vec![0u8; (CANVAS * CANVAS * 4) as usize];
+    for y in 0..CANVAS {
+        for x in 0..CANVAS {
+            let idx = ((y * CANVAS + x) * 4) as usize;
+            let v = if x < EDGE_X { 255 } else { 0 };
+            out[idx] = v;
+            out[idx + 1] = v;
+            out[idx + 2] = v;
+            out[idx + 3] = 255;
+        }
+    }
+    out
+}
+
+fn pixel(rgba: &[u8], x: u32, y: u32) -> [u8; 4] {
+    let idx = ((y * CANVAS + x) * 4) as usize;
+    [rgba[idx], rgba[idx + 1], rgba[idx + 2], rgba[idx + 3]]
+}
+
+/// Render `dabs` blur touches (one position each) over the hard-edge
+/// canvas at the given size / strength / opacity, returning the
+/// committed layer pixels. All dabs run in one phase: `execute_gpu`
+/// queues each, then one `flush_dabs` drives the per-dab render-pass loop.
+fn render_blur_dabs(size: f32, strength: f32, opacity: f32, dabs: &[[f32; 2]]) -> Vec<u8> {
+    let brush = darkly::brush::builtin_brushes::all()
+        .into_iter()
+        .find(|b| b.metadata.name == "Blur")
+        .unwrap();
+
+    let mut graph = brush.metadata.graph.clone();
+    let term_id = darkly::brush::find_terminal(&graph).expect("Blur brush has a terminal");
+    graph.set_port_default(term_id, "size", size).unwrap();
+    graph
+        .set_port_default(term_id, "strength", strength)
+        .unwrap();
+    graph.set_port_default(term_id, "opacity", opacity).unwrap();
+
+    let (device, queue) = shared_device();
+    let (layer_texture, layer_view) =
+        create_test_texture(&device, &queue, CANVAS, CANVAS, &hard_edge_canvas());
+    let pipelines = BrushPipelines::new(
+        &device,
+        &queue,
+        &darkly::gpu::selection::selection_mask_bgl(&device),
+    );
+    let mut stroke_buffer = StrokeBuffer::new(&device, CANVAS, CANVAS, &pipelines);
+
+    let pre_stroke = darkly::gpu::paint_target::GpuPaintTarget::from_canvas_texture(
+        &layer_texture,
+        &layer_view,
+        wgpu::TextureFormat::Rgba8Unorm,
+        darkly::coord::CanvasRect::from_xywh(0, 0, CANVAS, CANVAS),
+    );
+    let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("blur-test-pre-stroke"),
+    });
+    stroke_buffer.save_pre_stroke(&device, &mut enc, &pipelines, &pre_stroke);
+    queue.submit([enc.finish()]);
+
+    let mut runner: BrushGraphRunner = compile_graph(&graph).expect("brush compiles");
+    macro_rules! make_ctx {
+        ($label:expr) => {{
+            let (scratch, pre_stroke_tex, pre_stroke_bg) = stroke_buffer.parts_for_brush_ctx();
+            BrushGpuContext {
+                encoder: device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some($label),
+                }),
+                device: &device,
+                queue: &queue,
+                pipelines: &pipelines,
+                selection_bind_group: pipelines.default_selection_bind_group(),
+                canvas_width: CANVAS,
+                canvas_height: CANVAS,
+                canvas_origin: [0, 0],
+                blend_mode: 0,
+                view_rotation: 0.0,
+                perf: BrushPerfCounters::default(),
+                stroke: Some(StrokeResources {
+                    scratch,
+                    paint_target: darkly::gpu::paint_target::GpuPaintTarget::from_canvas_texture(
+                        &layer_texture,
+                        &layer_view,
+                        wgpu::TextureFormat::Rgba8Unorm,
+                        darkly::coord::CanvasRect::from_xywh(0, 0, CANVAS, CANVAS),
+                    ),
+                    pre_stroke_texture: pre_stroke_tex,
+                    pre_stroke_bind_group: pre_stroke_bg,
+                }),
+                preview: None,
+                dab_batch: DabBatch::default(),
+            }
+        }};
+    }
+
+    {
+        let mut ctx = make_ctx!("blur-test-begin");
+        runner.begin_stroke(&mut ctx);
+        queue.submit([ctx.encoder.finish()]);
+    }
+    {
+        let mut ctx = make_ctx!("blur-test-flush");
+        for (i, pos) in dabs.iter().enumerate() {
+            let info = PaintInformation {
+                pos: *pos,
+                pressure: 1.0,
+                distance: 10.0,
+                index: i as u32,
+                ..Default::default()
+            };
+            runner.seed_sensors(&info, [1.0, 1.0, 1.0, 1.0], 0xC0FFEE, i as u32);
+            runner.execute_cpu();
+            runner.execute_gpu(&mut ctx);
+        }
+        runner.flush_dabs(&mut ctx);
+        runner.commit(&mut ctx);
+        queue.submit([ctx.encoder.finish()]);
+    }
+
+    readback_texture(
+        &device,
+        &queue,
+        &layer_texture,
+        wgpu::TextureFormat::Rgba8Unorm,
+        CANVAS,
+        CANVAS,
+    )
+}
+
+/// A single blur dab straddling the hard edge averages white and black
+/// into an intermediate gray at the edge, and leaves pixels well outside
+/// the dab footprint untouched.
+#[test]
+fn blur_dab_softens_hard_edge_to_gray() {
+    // Radius ≈ 0.15 * 256 ≈ 38 px — wide enough that the kernel at the
+    // edge spans both the white and black halves.
+    let rgba = render_blur_dabs(0.15, 1.0, 1.0, &[[EDGE_X as f32, 64.0]]);
+
+    let centre = pixel(&rgba, EDGE_X, 64);
+    assert!(
+        centre[0] > 30 && centre[0] < 225,
+        "a blur dab straddling a hard black/white edge should leave an \
+         intermediate gray at the edge; got {centre:?}"
+    );
+
+    // Far inside the white half and the black half, outside the dab
+    // footprint — must be untouched.
+    let far_white = pixel(&rgba, 8, 8);
+    let far_black = pixel(&rgba, CANVAS - 8, CANVAS - 8);
+    assert_eq!(
+        far_white,
+        [255, 255, 255, 255],
+        "white pixel outside the dab footprint must be untouched"
+    );
+    assert_eq!(
+        far_black,
+        [0, 0, 0, 255],
+        "black pixel outside the dab footprint must be untouched"
+    );
+}
+
+/// **Dwell-compounding test.** With `opacity < 1`, each pass blends only
+/// a fraction of the blurred result, so a second overlapping dab — which
+/// reads the *cumulative* scratch through the per-dab read-mirror barrier
+/// — pushes the edge centre further toward gray than one pass does.
+///
+/// Working barrier: pass 2 reads pass 1's grayer writeback and softens
+/// further, so the (initially black) edge centre rises more.
+///
+/// Broken barrier (e.g. all dabs collapsed to one instanced draw): pass 2
+/// would re-read the pre-stroke black and land at the same value as pass 1.
+#[test]
+fn blur_second_pass_compounds() {
+    let centre = [EDGE_X as f32, 64.0];
+    // opacity 0.5 → each pass blends 50% of the blurred neighborhood, so
+    // the compounding is visible. The edge centre starts black (0) and
+    // rises toward the ~mid-gray neighborhood average with each pass.
+    let one_pass = render_blur_dabs(0.15, 1.0, 0.5, &[centre]);
+    let two_pass = render_blur_dabs(0.15, 1.0, 0.5, &[centre, centre]);
+
+    let v1 = pixel(&one_pass, EDGE_X, 64)[0];
+    let v2 = pixel(&two_pass, EDGE_X, 64)[0];
+    assert!(
+        v2 > v1 + 8,
+        "a second overlapping blur pass must compound (read the first \
+         pass's writeback through the per-dab barrier and soften further): \
+         one pass left {v1}, two passes left {v2}"
+    );
+}


### PR DESCRIPTION
https://github.com/user-attachments/assets/118648ed-cde6-42ec-8d93-e635171fd63a

---

## Blur brush + read-mirror terminal extraction

Adds **Blur** to the brush roster and, as a prerequisite, factors the shared per-dab read-mirror machinery out of `smudge` and `liquify` so blur slots in as a thin third variant instead of a third copy.

### Shared infrastructure — `brush/read_mirror_terminal.rs`

`smudge.rs` (701 lines) and `liquify.rs` (788 lines) were ~80% identical (liquify's own header said *"Same overall outline as smudge"* — a CLAUDE.md stop-sign). The common mechanics now live in one module:

- **`ReadMirrorPipeline`** — the generic per-brush pipeline cache (REPLACE blend, `@group(3)` scratch read mirror), registered under three ids (`"smudge"`, `"liquify"`, `"blur"`) via `read_mirror_pipeline_reg(id)`.
- **`ReadMirrorDabMeta { position, write_half, read_half }`** — unifies the two former per-dab meta structs.
- **`ReadMirrorTerminal` trait** — the only per-variant surface: `read_half` (read half-extent + early-out), optional `pack_extra` (extra per-dab slots), and the variant WGSL (`compile_body` / `compile_cursor_preview_body`).
- **Free helpers** — `evaluate_gpu` / `flush_dabs` / `commit` / `compile_wgsl` / `render_cursor_preview` / `effective_radius`, which the variants' `BrushNodeEvaluator` impls delegate to.

`compile_wgsl` appends the shared `copy_origin` dab field and owns `terminal_bindings`; variants never declare the `@group(3)` layout themselves.

### smudge / liquify refactor

Each terminal shrinks to `register()` + an `impl ReadMirrorTerminal` (its early-out math and WGSL, moved verbatim) + thin `BrushNodeEvaluator` delegations.

**Behavior change (liquify):** liquify previously passed its `radius + displacement` half as *both* the write and read extent. The refactor sets `write_half = bbox_radius`, tightening the per-dab damage rect liquify records (the warp only writes within the disc). A strict improvement; the pixel-level liquify/preview/probe tests are unaffected.

**Bug fix (all three terminals):** the per-dab read-mirror origin cache (`Scratch::read_origin_cache`) treated a second dab sharing an origin as a no-op, so it never re-copied the prior dab's writeback into the mirror. The flush loop now resets that cache per dab. This is what enables blur's same-spot dwell-compounding and closes a latent per-dab-barrier gap for any same-origin smudge/liquify pair.

### Blur node — `brush/nodes/blur.rs` + `brushes/blur.yaml`

- Single **Strength** control scales the kernel radius: `blur_px = strength × radius`. A 24-tap golden-angle disc averages the scratch read mirror around each dab (technique adapted from the `lens_blur` veil; credited per the Credit Principle), with every tap UV clamped inside the mirror bounds. Output: `mix(original, blurred, mask × selection × opacity)`.
- **Deliberately dwell-compounding** (rides the per-dab serialized path so overlapping/scrubbed dabs progressively re-blur, like Photoshop/Krita) and **deliberately size-variant** (bigger brush blurs more — the opposite of liquify's size-invariant push). Both intents are documented in the node header so a future reader won't "optimize" the per-dab flush into a single instanced pass.
- Built-in `blur.yaml` (`pen_input → shape → blur`, `category: Effects`) is auto-embedded and auto-discovered — no WASM/frontend/protocol changes.

### Tests

- `tests/blur.rs`: a blur dab straddling a hard black/white edge produces intermediate gray while pixels outside the footprint stay untouched; a second overlapping pass compounds (the regression guard for the read-mirror cache fix).
- Existing pixel-level smudge/liquify/preview/probe suites pass unchanged; the builtin-brush smoke + pixel-preservation tests now cover Blur.

### Files

- **New:** `brush/read_mirror_terminal.rs`, `brush/nodes/blur.rs`, `brushes/blur.yaml`, `tests/blur.rs`.
- **Edit:** `brush/mod.rs` (module registration), `brush/nodes/smudge.rs`, `brush/nodes/liquify.rs`, `brush/read_mirror_terminal.rs` flush-loop cache reset, `brush/pipeline.rs` (doc example), `README.md` (Blur → shipped).
