### PR TITLE
Curves Layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ For a feature to count, it must be:
 -     [ ] Brightness / Contrast
 -     [ ] Hue / Saturation / Lightness
 -     [ ] Levels
--     [ ] Curves
+-     [x] Curves
 -     [x] Invert colors
 -     [ ] Desaturate
 - [ ] Clipping mask

--- a/crates/darkly/shaders/filters/curves.wgsl
+++ b/crates/darkly/shaders/filters/curves.wgsl
@@ -1,14 +1,32 @@
-// Per-channel tone-curve adjustment via a precomputed 256×1 RGBA8 LUT.
+// Per-channel tone-curve adjustment — Krita's "Color Adjustment Curves" model
+// (plugins/filters/colorsfilters, KisMultiChannelFilter). Channels, in order:
 //
-// The LUT is baked on the CPU (`gpu/filters/curves.rs`) so each texel already
-// folds the per-channel curve and the composite "value" curve together —
-// `lut.rgb[i] = value(channel(i))`, `lut.a[i] = alpha(i)` (the value curve is
-// not applied to alpha; per GIMP `gimp_curve_map_pixels`). The shader is then a
-// single `textureLoad` per channel at the integer index `round(c*255)` — no
-// sampler, no branching, so identity curves are exactly identity.
+//   RGB (composite), Red, Green, Blue, Alpha, Hue, Saturation, Lightness
+//
+// The curves are baked on the CPU (`gpu/filters/curves.rs`) into a 256×2 RGBA8
+// LUT read at integer index `round(c*255)` (no sampler):
+//   row 0 (.rgba) — per-component color curves. `.rgb[i] = rgb(channel(i))`
+//                   (the per-channel curve first, then the composite "RGB"
+//                   curve on top, per Krita's transform order); `.a[i] = alpha(i)`,
+//                   with the composite curve NOT applied to alpha.
+//   row 1 (.rgb)  — `.r = hue(i)`, `.g = saturation(i)`, `.b = lightness(i)`.
+//
+// The color-component stage is bit-exact for identity curves (LUT[i]==i), so it
+// always runs. The Hue/Saturation (HSV) and Lightness (CIELAB L*) stages need a
+// color-space round trip that is only ~identity in float, so each is gated by a
+// `_active` flag (set when its curve is non-identity) — exactly as Krita skips
+// null transforms — keeping an all-identity Curves layer a byte-for-byte no-op.
 
 @group(0) @binding(0) var t_src: texture_2d<f32>;
 @group(0) @binding(1) var t_lut: texture_2d<f32>;
+
+struct Flags {
+    hsv_active: u32,
+    lightness_active: u32,
+    _pad0: u32,
+    _pad1: u32,
+};
+@group(0) @binding(2) var<uniform> flags: Flags;
 
 struct VsOut { @builtin(position) pos: vec4f };
 
@@ -25,15 +43,137 @@ fn lut_index(c: f32) -> i32 {
     return i32(round(clamp(c, 0.0, 1.0) * 255.0));
 }
 
+// --- HSV (matches Krita KoColorConversions RGBToHSV / HSVToRGB) --------------
+
+const EPS: f32 = 1e-6;
+
+// Returns h in [0,360) (0 when achromatic), s and v in [0,1].
+fn rgb_to_hsv(c: vec3f) -> vec3f {
+    let mx = max(c.r, max(c.g, c.b));
+    let mn = min(c.r, min(c.g, c.b));
+    let v = mx;
+    var s = 0.0;
+    if (mx > EPS) { s = (mx - mn) / mx; }
+    var h = 0.0;
+    if (s >= EPS) {
+        let delta = mx - mn;
+        if (c.r == mx) {
+            h = (c.g - c.b) / delta;
+        } else if (c.g == mx) {
+            h = 2.0 + (c.b - c.r) / delta;
+        } else {
+            h = 4.0 + (c.r - c.g) / delta;
+        }
+        h *= 60.0;
+        if (h < 0.0) { h += 360.0; }
+    }
+    return vec3f(h, s, v);
+}
+
+fn hsv_to_rgb(hsv: vec3f) -> vec3f {
+    let s = hsv.y;
+    let v = hsv.z;
+    if (s < EPS) { return vec3f(v, v, v); }
+    var h = hsv.x;
+    if (h > 360.0 - EPS) { h -= 360.0; }
+    h /= 60.0;
+    let i = i32(floor(h));
+    let f = h - f32(i);
+    let p = v * (1.0 - s);
+    let q = v * (1.0 - s * f);
+    let t = v * (1.0 - s * (1.0 - f));
+    switch (i) {
+        case 0: { return vec3f(v, t, p); }
+        case 1: { return vec3f(q, v, p); }
+        case 2: { return vec3f(p, v, t); }
+        case 3: { return vec3f(p, q, v); }
+        case 4: { return vec3f(t, p, v); }
+        default: { return vec3f(v, p, q); }
+    }
+}
+
+// --- CIELAB (sRGB / D65) — Krita's "Lightness L*a*b*" channel ----------------
+
+fn srgb_to_linear(c: f32) -> f32 {
+    if (c <= 0.04045) { return c / 12.92; }
+    return pow((c + 0.055) / 1.055, 2.4);
+}
+fn linear_to_srgb(c: f32) -> f32 {
+    if (c <= 0.0031308) { return c * 12.92; }
+    return 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+const XN: f32 = 0.95047;
+const YN: f32 = 1.0;
+const ZN: f32 = 1.08883;
+
+fn lab_f(t: f32) -> f32 {
+    if (t > 0.008856) { return pow(t, 1.0 / 3.0); }
+    return 7.787 * t + 16.0 / 116.0;
+}
+fn lab_finv(f: f32) -> f32 {
+    let f3 = f * f * f;
+    if (f3 > 0.008856) { return f3; }
+    return (f - 16.0 / 116.0) / 7.787;
+}
+
+// Returns L in [0,100], a and b in their usual CIELAB ranges.
+fn rgb_to_lab(c: vec3f) -> vec3f {
+    let r = srgb_to_linear(c.r);
+    let g = srgb_to_linear(c.g);
+    let b = srgb_to_linear(c.b);
+    let x = (0.4124564 * r + 0.3575761 * g + 0.1804375 * b) / XN;
+    let y = (0.2126729 * r + 0.7151522 * g + 0.0721750 * b) / YN;
+    let z = (0.0193339 * r + 0.1191920 * g + 0.9503041 * b) / ZN;
+    let fx = lab_f(x);
+    let fy = lab_f(y);
+    let fz = lab_f(z);
+    return vec3f(116.0 * fy - 16.0, 500.0 * (fx - fy), 200.0 * (fy - fz));
+}
+
+fn lab_to_rgb(lab: vec3f) -> vec3f {
+    let fy = (lab.x + 16.0) / 116.0;
+    let fx = fy + lab.y / 500.0;
+    let fz = fy - lab.z / 200.0;
+    let x = XN * lab_finv(fx);
+    let y = YN * lab_finv(fy);
+    let z = ZN * lab_finv(fz);
+    let r = 3.2404542 * x - 1.5371385 * y - 0.4985314 * z;
+    let g = -0.9692660 * x + 1.8760108 * y + 0.0415560 * z;
+    let b = 0.0556434 * x - 0.2040259 * y + 1.0572252 * z;
+    return vec3f(
+        clamp(linear_to_srgb(r), 0.0, 1.0),
+        clamp(linear_to_srgb(g), 0.0, 1.0),
+        clamp(linear_to_srgb(b), 0.0, 1.0),
+    );
+}
+
 @fragment
 fn fs_curves(in: VsOut) -> @location(0) vec4f {
     let p = vec2i(floor(in.pos.xy));
-    let src = textureLoad(t_src, p, 0);
-    // Each channel indexes the LUT at its own stored value and reads its own
-    // baked component.
-    let r = textureLoad(t_lut, vec2i(lut_index(src.r), 0), 0).r;
-    let g = textureLoad(t_lut, vec2i(lut_index(src.g), 0), 0).g;
-    let b = textureLoad(t_lut, vec2i(lut_index(src.b), 0), 0).b;
-    let a = textureLoad(t_lut, vec2i(lut_index(src.a), 0), 0).a;
-    return vec4f(r, g, b, a);
+    var c = textureLoad(t_src, p, 0);
+
+    // Per-component color curves (composite∘channel baked in row 0).
+    c.r = textureLoad(t_lut, vec2i(lut_index(c.r), 0), 0).r;
+    c.g = textureLoad(t_lut, vec2i(lut_index(c.g), 0), 0).g;
+    c.b = textureLoad(t_lut, vec2i(lut_index(c.b), 0), 0).b;
+    c.a = textureLoad(t_lut, vec2i(lut_index(c.a), 0), 0).a;
+
+    // Hue + Saturation, in HSV. Non-relative (Krita perchannel): the curve
+    // replaces the channel value. Both curves ride one HSV round trip.
+    if (flags.hsv_active != 0u) {
+        var hsv = rgb_to_hsv(c.rgb);
+        hsv.x = textureLoad(t_lut, vec2i(lut_index(hsv.x / 360.0), 1), 0).r * 360.0;
+        hsv.y = textureLoad(t_lut, vec2i(lut_index(hsv.y), 1), 0).g;
+        c = vec4f(hsv_to_rgb(hsv), c.a);
+    }
+
+    // Lightness, on CIELAB L* (normalized to [0,1] for the LUT).
+    if (flags.lightness_active != 0u) {
+        var lab = rgb_to_lab(c.rgb);
+        lab.x = textureLoad(t_lut, vec2i(lut_index(lab.x / 100.0), 1), 0).b * 100.0;
+        c = vec4f(lab_to_rgb(lab), c.a);
+    }
+
+    return c;
 }

--- a/crates/darkly/shaders/filters/curves.wgsl
+++ b/crates/darkly/shaders/filters/curves.wgsl
@@ -1,0 +1,39 @@
+// Per-channel tone-curve adjustment via a precomputed 256×1 RGBA8 LUT.
+//
+// The LUT is baked on the CPU (`gpu/filters/curves.rs`) so each texel already
+// folds the per-channel curve and the composite "value" curve together —
+// `lut.rgb[i] = value(channel(i))`, `lut.a[i] = alpha(i)` (the value curve is
+// not applied to alpha; per GIMP `gimp_curve_map_pixels`). The shader is then a
+// single `textureLoad` per channel at the integer index `round(c*255)` — no
+// sampler, no branching, so identity curves are exactly identity.
+
+@group(0) @binding(0) var t_src: texture_2d<f32>;
+@group(0) @binding(1) var t_lut: texture_2d<f32>;
+
+struct VsOut { @builtin(position) pos: vec4f };
+
+@vertex
+fn vs_main(@builtin(vertex_index) idx: u32) -> VsOut {
+    // Fullscreen triangle.
+    let uv = vec2f(f32((idx << 1u) & 2u), f32(idx & 2u));
+    var out: VsOut;
+    out.pos = vec4f(uv * 2.0 - 1.0, 0.0, 1.0);
+    return out;
+}
+
+fn lut_index(c: f32) -> i32 {
+    return i32(round(clamp(c, 0.0, 1.0) * 255.0));
+}
+
+@fragment
+fn fs_curves(in: VsOut) -> @location(0) vec4f {
+    let p = vec2i(floor(in.pos.xy));
+    let src = textureLoad(t_src, p, 0);
+    // Each channel indexes the LUT at its own stored value and reads its own
+    // baked component.
+    let r = textureLoad(t_lut, vec2i(lut_index(src.r), 0), 0).r;
+    let g = textureLoad(t_lut, vec2i(lut_index(src.g), 0), 0).g;
+    let b = textureLoad(t_lut, vec2i(lut_index(src.b), 0), 0).b;
+    let a = textureLoad(t_lut, vec2i(lut_index(src.a), 0), 0).a;
+    return vec4f(r, g, b, a);
+}

--- a/crates/darkly/src/document/layer_kinds/filter.rs
+++ b/crates/darkly/src/document/layer_kinds/filter.rs
@@ -149,6 +149,38 @@ mod tests {
         assert!(f_after.params.is_empty());
     }
 
+    /// A parametric filter (curves) round-trips its full param vector — the
+    /// five per-channel curves are the whole document state, exactly like a
+    /// void's params. Regression against dropping/reordering the curves on save.
+    #[test]
+    fn curves_body_round_trips_with_params() {
+        use crate::gpu::params::ParamValue;
+
+        let mut doc = Document::new(64, 64);
+        let params = vec![
+            ParamValue::Curve(vec![[0.0, 0.0], [0.5, 0.7], [1.0, 1.0]]),
+            ParamValue::Curve(vec![[0.0, 0.1], [1.0, 0.9]]),
+            ParamValue::Curve(vec![[0.0, 0.0], [1.0, 1.0]]),
+            ParamValue::Curve(vec![[0.0, 0.0], [1.0, 0.5]]),
+            ParamValue::Curve(vec![[0.0, 0.0], [1.0, 1.0]]),
+        ];
+        let id = doc.add_filter_layer("curves".to_string(), "Curves", params.clone(), None);
+
+        let reg = register();
+        let node = doc.find_node(id).expect("filter exists");
+        let serialized = (reg.serialize)(node);
+        let restored = (reg.deserialize)(&serialized.body, id).expect("deserialize must succeed");
+        let f_after = match &restored {
+            LayerNode::Layer(Layer::Filter(f)) => f,
+            _ => panic!("deserialize must yield a Filter layer"),
+        };
+        assert_eq!(f_after.pipeline, "curves");
+        assert_eq!(
+            f_after.params, params,
+            "all five curve params must survive the round-trip in order"
+        );
+    }
+
     /// A corrupt blend_mode in the saved body must surface as
     /// `CorruptManifest`, not a silent fallback — the same contract every
     /// other layer kind holds.

--- a/crates/darkly/src/document/layer_kinds/filter.rs
+++ b/crates/darkly/src/document/layer_kinds/filter.rs
@@ -150,19 +150,24 @@ mod tests {
     }
 
     /// A parametric filter (curves) round-trips its full param vector — the
-    /// five per-channel curves are the whole document state, exactly like a
+    /// eight per-channel curves are the whole document state, exactly like a
     /// void's params. Regression against dropping/reordering the curves on save.
     #[test]
     fn curves_body_round_trips_with_params() {
         use crate::gpu::params::ParamValue;
 
         let mut doc = Document::new(64, 64);
+        // One entry per Krita channel: RGB, R, G, B, A, Hue, Saturation,
+        // Lightness — a mix of identity and non-identity curves.
         let params = vec![
             ParamValue::Curve(vec![[0.0, 0.0], [0.5, 0.7], [1.0, 1.0]]),
             ParamValue::Curve(vec![[0.0, 0.1], [1.0, 0.9]]),
             ParamValue::Curve(vec![[0.0, 0.0], [1.0, 1.0]]),
             ParamValue::Curve(vec![[0.0, 0.0], [1.0, 0.5]]),
             ParamValue::Curve(vec![[0.0, 0.0], [1.0, 1.0]]),
+            ParamValue::Curve(vec![[0.0, 0.0], [0.5, 0.4], [1.0, 1.0]]),
+            ParamValue::Curve(vec![[0.0, 0.2], [1.0, 0.8]]),
+            ParamValue::Curve(vec![[0.0, 0.0], [1.0, 0.9]]),
         ];
         let id = doc.add_filter_layer("curves".to_string(), "Curves", params.clone(), None);
 
@@ -177,7 +182,7 @@ mod tests {
         assert_eq!(f_after.pipeline, "curves");
         assert_eq!(
             f_after.params, params,
-            "all five curve params must survive the round-trip in order"
+            "all eight curve params must survive the round-trip in order"
         );
     }
 

--- a/crates/darkly/src/document/mod.rs
+++ b/crates/darkly/src/document/mod.rs
@@ -727,6 +727,33 @@ impl Document {
         }
     }
 
+    /// Iterate every filter layer in the tree, regardless of visibility or
+    /// nesting depth. The compositor uses this to build/refresh each parametric
+    /// filter's GPU resources (curves LUT) in the pre-compose ensure phase.
+    /// Same shape as [`Self::all_void_layers`].
+    pub fn all_filter_layers(&self) -> Vec<&crate::layer::FilterLayer> {
+        let mut out = Vec::new();
+        self.collect_filter_layers(self.root, &mut out);
+        out
+    }
+
+    fn collect_filter_layers<'a>(
+        &'a self,
+        group_id: LayerId,
+        out: &mut Vec<&'a crate::layer::FilterLayer>,
+    ) {
+        let Some(LayerNode::Group(g)) = self.find_node(group_id) else {
+            return;
+        };
+        for &child_id in &g.children {
+            match self.find_node(child_id) {
+                Some(LayerNode::Layer(Layer::Filter(f))) => out.push(f),
+                Some(LayerNode::Group(_)) => self.collect_filter_layers(child_id, out),
+                _ => {}
+            }
+        }
+    }
+
     /// Add a new empty group; positioning follows the same rules as
     /// [`Document::add_raster_layer`].
     pub fn add_group(&mut self, anchor: Option<LayerId>) -> LayerId {

--- a/crates/darkly/src/engine/filters/apply.rs
+++ b/crates/darkly/src/engine/filters/apply.rs
@@ -12,24 +12,29 @@
 use super::super::rendering::commit_undo_region;
 use super::super::{DarklyEngine, PendingFilter};
 use crate::coord::WindowRect;
-use crate::engine::types::VeilTypeInfo;
+use crate::engine::types::{ParamInfo, VeilTypeInfo};
 use crate::layer::LayerId;
 use crate::undo::GpuRegionAction;
 
 impl DarklyEngine {
-    /// All registered filter types (id + display name), as the same
-    /// `VeilTypeInfo` shape veils/voids use — filters carry no params, so
-    /// the list is empty there. Drives the frontend's dynamic Colors-menu
-    /// action registration.
+    /// All registered filter types (id + display name + param schema), as the
+    /// same `VeilTypeInfo` shape veils/voids use. Parameter-free filters (invert)
+    /// carry an empty `params`; parametric ones (curves) carry their schema.
+    /// Drives both the frontend's dynamic Colors-menu action registration and
+    /// the filter-layer properties panel.
     pub fn filter_types(&self) -> Vec<VeilTypeInfo> {
-        self.compositor
-            .filter_pipeline_registry()
+        let registry = self.compositor.filter_pipeline_registry();
+        registry
             .types()
             .into_iter()
             .map(|(type_id, display_name)| VeilTypeInfo {
                 type_id,
                 display_name,
-                params: Vec::new(),
+                params: registry
+                    .params(type_id)
+                    .iter()
+                    .map(|d| ParamInfo::from_def(d, None))
+                    .collect(),
             })
             .collect()
     }
@@ -43,6 +48,18 @@ impl DarklyEngine {
             return false;
         }
         if !self.compositor.filter_pipeline_registry().has(filter_type) {
+            return false;
+        }
+        // Parametric filters (curves, …) are non-destructive-only: the
+        // one-click destructive path has no UI to author their params, so it
+        // would bake an identity no-op. Keep them out of it — they're used
+        // exclusively as filter *layers*.
+        if !self
+            .compositor
+            .filter_pipeline_registry()
+            .params(filter_type)
+            .is_empty()
+        {
             return false;
         }
         self.auto_commit_floating();
@@ -145,7 +162,7 @@ impl DarklyEngine {
                 node_id,
                 region,
                 mask_view.as_ref(),
-                &pipeline,
+                pipeline.as_ref(),
             );
         });
 

--- a/crates/darkly/src/engine/layers.rs
+++ b/crates/darkly/src/engine/layers.rs
@@ -270,6 +270,51 @@ impl DarklyEngine {
         ));
     }
 
+    /// Resolve a layer id to its filter `pipeline` id, if the layer is a filter.
+    /// Lets the protocol handler fetch the filter's param schema without
+    /// importing the layer enum.
+    pub fn filter_layer_pipeline(&self, layer_id: LayerId) -> Option<String> {
+        match self.doc.find_node(layer_id) {
+            Some(LayerNode::Layer(Layer::Filter(f))) => Some(f.pipeline.clone()),
+            _ => None,
+        }
+    }
+
+    /// Parameter schema for a filter type (empty for parameter-free filters).
+    /// Backs the protocol handler's JSON→`ParamValue` conversion.
+    pub fn filter_param_defs(&self, type_id: &str) -> &'static [crate::gpu::params::ParamDef] {
+        self.compositor.filter_pipeline_registry().params(type_id)
+    }
+
+    /// Replace a filter layer's parameter values. Coalesces with prior
+    /// `FilterParams` edits on the same layer so a curve drag is one undo step —
+    /// the exact analog of [`Self::update_void_params`]. The compositor rebuilds
+    /// any param-derived GPU resources (the curves LUT) lazily on the next
+    /// `sync_projection_states`, keyed by the param fingerprint.
+    pub fn update_filter_params(
+        &mut self,
+        layer_id: LayerId,
+        new_params: Vec<crate::gpu::params::ParamValue>,
+    ) {
+        if !self.doc.is_node_editable(layer_id) {
+            return;
+        }
+        let old_params = match self.doc.find_node(layer_id) {
+            Some(LayerNode::Layer(Layer::Filter(f))) => f.params.clone(),
+            _ => return,
+        };
+        if let Some(LayerNode::Layer(Layer::Filter(f))) = self.doc.find_node_mut(layer_id) {
+            f.params = new_params.clone();
+        }
+        self.compositor.mark_dirty();
+
+        self.coalesce_property_undo(PropertyAction::new(
+            layer_id,
+            Property::FilterParams(old_params),
+            Property::FilterParams(new_params),
+        ));
+    }
+
     /// Set a void layer's user transform (the void *consuming* the generic
     /// transform gizmo's output). Mirrors [`Self::update_void_params`]:
     /// reads the layer's CURRENT transform as the undo `old_value` before

--- a/crates/darkly/src/engine/protocol/handlers/layers.rs
+++ b/crates/darkly/src/engine/protocol/handlers/layers.rs
@@ -85,14 +85,36 @@ pub fn registrations() -> Vec<RequestRegistration> {
                 }
                 let r: Req = decode(payload)?;
                 let anchor = (r.anchor >= 0).then(|| LayerId::from_ffi(r.anchor as u64));
-                // Filters carry no params today (invert is parameter-free), so
-                // the schema is empty; `params_from_json` yields an empty vec.
-                let pv = params_from_json(&r.params, &[]);
+                // Convert against the filter's schema so a curves layer created
+                // with `{}` gets five identity curves; invert's empty schema
+                // yields an empty vec.
+                let defs: &'static [ParamDef] = engine.filter_param_defs(&r.pipeline);
+                let pv = params_from_json(&r.params, defs);
                 let value = match engine.add_filter_layer(&r.pipeline, pv, anchor) {
                     Some(id) => json!({ "id": id.to_ffi() }),
                     None => json!({ "id": -1 }),
                 };
                 Ok(Response::json(value))
+            },
+        },
+        RequestRegistration {
+            kind: "update_filter_params",
+            handle: |engine, payload, _b| {
+                #[derive(Deserialize)]
+                struct Req {
+                    id: u64,
+                    params: serde_json::Value,
+                }
+                let r: Req = decode(payload)?;
+                let id = LayerId::from_ffi(r.id);
+                let pipeline = match engine.filter_layer_pipeline(id) {
+                    Some(p) => p,
+                    None => return Ok(Response::empty()),
+                };
+                let defs = engine.filter_param_defs(&pipeline);
+                let pv = params_from_json(&r.params, defs);
+                engine.update_filter_params(id, pv);
+                Ok(Response::empty())
             },
         },
         RequestRegistration {

--- a/crates/darkly/src/engine/types.rs
+++ b/crates/darkly/src/engine/types.rs
@@ -119,6 +119,11 @@ pub enum LayerInfo {
         /// Stable filter `type_id` (e.g. `"invert"`) — UI resolves to a
         /// display label via `filter_types()`.
         pipeline: String,
+        /// Param schema + current values, in the order the filter's `ParamDef`
+        /// slice declares them. Empty for parameter-free filters (invert);
+        /// carries the five tone curves for `curves`. Same shape the void panel
+        /// uses.
+        params: Vec<ParamInfo>,
     },
     #[serde(rename_all = "camelCase")]
     Group {
@@ -422,6 +427,7 @@ pub struct ClipboardExport {
 pub(crate) fn node_to_layer_info(
     doc: &crate::document::Document,
     void_registry: &crate::gpu::void::VoidRegistry,
+    filter_registry: &crate::gpu::filter::FilterPipelineRegistry,
     node_id: crate::layer::LayerId,
 ) -> Option<LayerInfo> {
     use crate::layer::{Layer, LayerNode};
@@ -484,26 +490,35 @@ pub(crate) fn node_to_layer_info(
                     params,
                 }
             }
-            Layer::Filter(f) => LayerInfo::Filter {
-                id: f.id.to_ffi() as f64,
-                name: f.common.name.clone(),
-                visible: f.common.visible,
-                locked: f.common.locked,
-                editable,
-                can_have_mask: kind.can_have_mask,
-                can_rename: kind.can_rename,
-                has_thumbnail: kind.has_thumbnail,
-                icon: kind.icon,
-                kind_name: kind.display_name,
-                opacity: f.blend.opacity,
-                blend_mode: f.blend.blend_mode.type_id,
-                modifiers: f
-                    .filters
+            Layer::Filter(f) => {
+                let param_defs = filter_registry.params(&f.pipeline);
+                let params = param_defs
                     .iter()
-                    .filter_map(|mid| doc.find_filter(*mid).map(|m| modifier_to_info(doc, m)))
-                    .collect(),
-                pipeline: f.pipeline.clone(),
-            },
+                    .enumerate()
+                    .map(|(j, def)| ParamInfo::from_def(def, f.params.get(j)))
+                    .collect();
+                LayerInfo::Filter {
+                    id: f.id.to_ffi() as f64,
+                    name: f.common.name.clone(),
+                    visible: f.common.visible,
+                    locked: f.common.locked,
+                    editable,
+                    can_have_mask: kind.can_have_mask,
+                    can_rename: kind.can_rename,
+                    has_thumbnail: kind.has_thumbnail,
+                    icon: kind.icon,
+                    kind_name: kind.display_name,
+                    opacity: f.blend.opacity,
+                    blend_mode: f.blend.blend_mode.type_id,
+                    modifiers: f
+                        .filters
+                        .iter()
+                        .filter_map(|mid| doc.find_filter(*mid).map(|m| modifier_to_info(doc, m)))
+                        .collect(),
+                    pipeline: f.pipeline.clone(),
+                    params,
+                }
+            }
         },
         LayerNode::Group(g) => LayerInfo::Group {
             id: g.id.to_ffi() as f64,
@@ -529,7 +544,7 @@ pub(crate) fn node_to_layer_info(
                 .children
                 .iter()
                 .rev()
-                .filter_map(|cid| node_to_layer_info(doc, void_registry, *cid))
+                .filter_map(|cid| node_to_layer_info(doc, void_registry, filter_registry, *cid))
                 .collect(),
         },
     };

--- a/crates/darkly/src/engine/veils.rs
+++ b/crates/darkly/src/engine/veils.rs
@@ -204,7 +204,14 @@ impl DarklyEngine {
             .children_of(self.doc.root_id())
             .iter()
             .rev()
-            .filter_map(|id| node_to_layer_info(&self.doc, self.compositor.void_registry(), *id))
+            .filter_map(|id| {
+                node_to_layer_info(
+                    &self.doc,
+                    self.compositor.void_registry(),
+                    self.compositor.filter_pipeline_registry(),
+                    *id,
+                )
+            })
             .collect()
     }
 

--- a/crates/darkly/src/gpu/compositor.rs
+++ b/crates/darkly/src/gpu/compositor.rs
@@ -635,6 +635,15 @@ pub struct Compositor {
     /// resource, exactly like `void_registry`'s pipelines.
     filter_pipeline_registry: crate::gpu::filter::FilterPipelineRegistry,
 
+    /// Per-filter-layer GPU state for *parametric* filters (curves, …). The
+    /// stored `Vec<ParamValue>` is the change-detection fingerprint — when a
+    /// layer's params differ from it, the effect rebuilds its resources (the
+    /// LUT) into the paired [`EffectCache`] during the pre-compose ensure phase
+    /// (`sync_projection_states`). Compose then merely binds the cache. Entries
+    /// for removed filter layers are pruned there too. Parameter-free filters
+    /// (invert) never populate this — their `ensure` is a no-op.
+    filter_caches: HashMap<LayerId, (Vec<ParamValue>, crate::gpu::effect::EffectCache)>,
+
     // --- Floating Content Transform ---
     pub(super) transform_pass: crate::gpu::transform::TransformPass,
 
@@ -1128,6 +1137,7 @@ impl Compositor {
             veil_chain,
             void_registry: VoidRegistry::new(),
             filter_pipeline_registry: crate::gpu::filter::FilterPipelineRegistry::new(),
+            filter_caches: HashMap::new(),
             transform_pass,
             rescale_pass,
             ortho_pass,
@@ -1511,8 +1521,12 @@ impl Compositor {
         node_id: LayerId,
         region: CanvasRect,
         mask_view: Option<&wgpu::TextureView>,
-        pipeline: &crate::gpu::effect::MaskedFilterPipeline,
+        pipeline: &dyn crate::gpu::filter::FilterEffect,
     ) {
+        // The destructive path serves only parameter-free filters (parametric
+        // ones are excluded upstream in `apply_filter`), so a throwaway empty
+        // cache is all the effect's `render` needs — invert ignores it.
+        let cache = crate::gpu::effect::EffectCache::empty();
         let ran = run_filter_region(
             &self.node_textures,
             device,
@@ -1522,7 +1536,7 @@ impl Compositor {
             region,
             mask_view,
             |dev, _q, enc, src, mask, out, _w, _h, fmt| {
-                pipeline.render(dev, enc, src, mask, out, fmt)
+                pipeline.render(dev, enc, src, mask, out, fmt, &cache)
             },
         );
         if ran {
@@ -3462,6 +3476,38 @@ impl Compositor {
             let pms = &self.mask_snapshot_state[&host_id];
             queue.write_buffer(&pms.uniform_buf, 0, bytemuck::bytes_of(&lu));
         }
+
+        // Build/refresh parametric-filter GPU resources (the curves LUT). This
+        // is the one place with both `device` and `queue`; the compose walk that
+        // follows only *binds* the cache. Walk every filter layer — the loops
+        // above (`layer_cache.keys()`, `masked_in_place_hosts()`) miss an
+        // unmasked filter layer. Rebuild only when the param fingerprint changes,
+        // and prune caches for filter layers that no longer exist.
+        let filters: Vec<(LayerId, String, Vec<ParamValue>)> = doc
+            .all_filter_layers()
+            .iter()
+            .map(|f| (f.id, f.pipeline.clone(), f.params.clone()))
+            .collect();
+        let live: HashSet<LayerId> = filters.iter().map(|(id, ..)| *id).collect();
+        self.filter_caches.retain(|id, _| live.contains(id));
+        for (id, pipeline_id, params) in filters {
+            let unchanged = self
+                .filter_caches
+                .get(&id)
+                .is_some_and(|(stored, _)| *stored == params);
+            if unchanged {
+                continue;
+            }
+            let Some(effect) = self.filter_pipeline_registry.pipeline(&pipeline_id, device) else {
+                continue;
+            };
+            let entry = self
+                .filter_caches
+                .entry(id)
+                .or_insert_with(|| (Vec::new(), crate::gpu::effect::EffectCache::empty()));
+            effect.ensure(device, queue, &params, &mut entry.1);
+            entry.0 = params;
+        }
     }
 
     /// De-fused leaf-mask compose: host content → projection, mask modulates
@@ -3842,6 +3888,18 @@ impl Compositor {
 
         {
             let gs = &self.group_state[&parent_group];
+            // The LUT (for parametric filters) is built in `sync_projection_states`
+            // before this walk, keyed by `filter.id`. Parameter-free filters have
+            // an empty cache; an absent entry (should not happen post-sync) falls
+            // back to a transient empty one.
+            let empty;
+            let cache = match self.filter_caches.get(&filter.id) {
+                Some((_, c)) => c,
+                None => {
+                    empty = crate::gpu::effect::EffectCache::empty();
+                    &empty
+                }
+            };
             pipeline.render(
                 device,
                 encoder,
@@ -3849,6 +3907,7 @@ impl Compositor {
                 None,
                 &gs.accum.views[dst],
                 wgpu::TextureFormat::Rgba8Unorm,
+                cache,
             );
         }
 

--- a/crates/darkly/src/gpu/effect.rs
+++ b/crates/darkly/src/gpu/effect.rs
@@ -11,6 +11,8 @@ impl std::fmt::Debug for EffectPipeline {
     }
 }
 
+use super::filter::FilterEffect;
+
 /// Cached GPU objects for an effect instance.
 /// Created once at instance creation, never in the render loop.
 /// Used by both filters (layer-level) and veils (viewport-level).
@@ -27,6 +29,21 @@ pub struct EffectCache {
     /// Veils that render at a lower internal resolution use this for the
     /// upscale blit back to viewport size.
     pub aux_pipelines: Vec<wgpu::RenderPipeline>,
+}
+
+impl EffectCache {
+    /// An empty cache holding no resources. The starting state a `FilterEffect`
+    /// fills in `ensure`, and the throwaway a parameter-free filter's
+    /// `render` reads from on the destructive region path.
+    pub fn empty() -> Self {
+        EffectCache {
+            uniform_bufs: Vec::new(),
+            bind_groups: Vec::new(),
+            aux_textures: Vec::new(),
+            aux_views: Vec::new(),
+            aux_pipelines: Vec::new(),
+        }
+    }
 }
 
 /// Build a render pipeline from a passthrough blit shader.
@@ -343,6 +360,34 @@ impl MaskedFilterPipeline {
         pass.set_pipeline(pipeline);
         pass.set_bind_group(0, &bind_group, &[]);
         pass.draw(0..3, 0..1);
+    }
+}
+
+/// A `MaskedFilterPipeline` is a parameter-free [`FilterEffect`]: `ensure` has
+/// nothing to build, and `render` delegates straight to the inherent method,
+/// ignoring the cache. This is all invert (and any future parameter-free
+/// filter) needs to slot into the filter registry.
+impl FilterEffect for MaskedFilterPipeline {
+    fn ensure(
+        &self,
+        _device: &wgpu::Device,
+        _queue: &wgpu::Queue,
+        _params: &[super::params::ParamValue],
+        _cache: &mut EffectCache,
+    ) {
+    }
+
+    fn render(
+        &self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        src: &wgpu::TextureView,
+        mask: Option<&wgpu::TextureView>,
+        out: &wgpu::TextureView,
+        format: wgpu::TextureFormat,
+        _cache: &EffectCache,
+    ) {
+        MaskedFilterPipeline::render(self, device, encoder, src, mask, out, format);
     }
 }
 

--- a/crates/darkly/src/gpu/filter.rs
+++ b/crates/darkly/src/gpu/filter.rs
@@ -1,41 +1,87 @@
-//! Destructive color-filter registry.
+//! Non-destructive filter-layer registry.
 //!
-//! An "filter" applies a `MaskedFilterPipeline` to a node's pixels in
-//! place (`1 - color` for invert, more to come), respecting an active
-//! selection and working on both raster layers (RGBA8) and masks (R8). It is
-//! the destructive cousin of a veil: a veil is ephemeral viewport post-process
-//! state, an filter bakes into the document and is undoable.
+//! A "filter" is a layer-tree adjustment node: it transforms the composite of
+//! everything below it (`1 - color` for invert, a per-channel tone map for
+//! curves). Each filter owns a [`FilterEffect`] — its render pipeline plus any
+//! parameter-derived GPU resources (a curves LUT, say), held in a reused
+//! [`EffectCache`](super::effect::EffectCache). Parameter-free filters like
+//! invert are a trivial wrapper over the shared
+//! [`MaskedFilterPipeline`](super::effect::MaskedFilterPipeline).
 //!
-//! Mirrors [`VeilRegistry`](super::veil::VeilRegistry)'s *registry shape* —
-//! auto-discovered from `gpu/filters/*.rs` (each exports `pub fn register()
-//! -> FilterPipelineRegistration`), with lazy per-type pipeline caching — but the
-//! cached GPU object is the shared [`MaskedFilterPipeline`](super::effect::MaskedFilterPipeline),
-//! not a bespoke pass. New filters slot in by dropping a file in the
-//! directory; nothing here is edited.
+//! Auto-discovered from `gpu/filters/*.rs` (each exports `pub fn register() ->
+//! FilterPipelineRegistration`), with lazy per-type effect caching. New filters
+//! slot in by dropping a file in the directory; nothing here is edited.
+//!
+//! `FilterEffect` is deliberately distinct from [`Veil`](super::veil::Veil):
+//! veils are fullscreen viewport post-process passes over ping-pong buffers
+//! driven by `VeilChain`; filters run over a group accumulator at a fixed tree
+//! position. The two share the [`EffectCache`](super::effect::EffectCache) and
+//! the [`ParamDef`]/[`ParamValue`](super::params::ParamValue) schema — where the
+//! real reuse lives — not the invocation contract.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use super::effect::MaskedFilterPipeline;
+use super::effect::EffectCache;
+use super::params::{ParamDef, ParamValue};
 
-/// What each filter module returns from its `register()` function. Unlike
-/// a veil, an filter has no parameters and its pipeline holds every target
-/// format, so `create_pipeline` needs only the device.
+/// A filter's GPU realization: a render pipeline plus optional param-derived
+/// resources built into an [`EffectCache`]. One instance is shared (Arc'd)
+/// across every filter layer of the same type — the per-layer state (the built
+/// LUT, the change-detection fingerprint) lives in the compositor's cache map,
+/// not on the effect.
+pub trait FilterEffect: Send + Sync {
+    /// Build or refresh any parameter-derived GPU resources (e.g. a curves LUT)
+    /// into `cache`. Called from the compositor's pre-compose ensure phase
+    /// whenever a layer's params change — never in the render loop. A genuine
+    /// no-op for parameter-free filters, so a transient empty `EffectCache`
+    /// satisfies the destructive path.
+    fn ensure(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        params: &[ParamValue],
+        cache: &mut EffectCache,
+    );
+
+    /// Run the filter over `src`, writing the result to `out` (same dims). With
+    /// `mask` present, only mask-selected texels take the filtered value;
+    /// elsewhere the original passes through. `format` selects the RGBA8 (layer)
+    /// or R8 (mask) pipeline. `cache` holds the resources built by [`ensure`].
+    ///
+    /// [`ensure`]: FilterEffect::ensure
+    fn render(
+        &self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        src: &wgpu::TextureView,
+        mask: Option<&wgpu::TextureView>,
+        out: &wgpu::TextureView,
+        format: wgpu::TextureFormat,
+        cache: &EffectCache,
+    );
+}
+
+/// What each filter module returns from its `register()` function. `params`
+/// declares the filter's schema (empty for parameter-free filters); the
+/// `create_pipeline` factory builds the shared [`FilterEffect`].
 pub struct FilterPipelineRegistration {
     pub type_id: &'static str,
     pub display_name: &'static str,
-    pub create_pipeline: fn(&wgpu::Device) -> MaskedFilterPipeline,
+    pub params: &'static [ParamDef],
+    pub create_pipeline: fn(&wgpu::Device) -> Arc<dyn FilterEffect>,
 }
 
-/// Auto-discovered filter registry with lazy pipeline caching.
+/// Auto-discovered filter registry with lazy effect caching.
 pub struct FilterPipelineRegistry {
     entries: HashMap<&'static str, RegistryEntry>,
 }
 
 struct RegistryEntry {
     display_name: &'static str,
-    create_pipeline: fn(&wgpu::Device) -> MaskedFilterPipeline,
-    cached_pipeline: Option<Arc<MaskedFilterPipeline>>,
+    params: &'static [ParamDef],
+    create_pipeline: fn(&wgpu::Device) -> Arc<dyn FilterEffect>,
+    cached_pipeline: Option<Arc<dyn FilterEffect>>,
 }
 
 impl Default for FilterPipelineRegistry {
@@ -52,6 +98,7 @@ impl FilterPipelineRegistry {
                 reg.type_id,
                 RegistryEntry {
                     display_name: reg.display_name,
+                    params: reg.params,
                     create_pipeline: reg.create_pipeline,
                     cached_pipeline: None,
                 },
@@ -72,12 +119,19 @@ impl FilterPipelineRegistry {
         types
     }
 
+    /// Parameter schema for a filter type, or an empty slice for an unknown
+    /// type (or a parameter-free filter). Drives both the `filter_types()`
+    /// protocol emission and JSON→`ParamValue` conversion when a layer is added.
+    pub fn params(&self, type_id: &str) -> &'static [ParamDef] {
+        self.entries.get(type_id).map(|e| e.params).unwrap_or(&[])
+    }
+
     /// True when this registry knows the given `type_id`.
     pub fn has(&self, type_id: &str) -> bool {
         self.entries.contains_key(type_id)
     }
 
-    /// Human-friendly display name for an filter type, falling back to the
+    /// Human-friendly display name for a filter type, falling back to the
     /// empty string when the type is unknown.
     pub fn display_name(&self, type_id: &str) -> &'static str {
         self.entries
@@ -86,19 +140,19 @@ impl FilterPipelineRegistry {
             .unwrap_or("")
     }
 
-    /// Get or create the shared pipeline for an filter type. Returns `None`
+    /// Get or create the shared effect for a filter type. Returns `None`
     /// for an unknown type rather than panicking — the caller (a protocol
     /// request carrying an arbitrary string) decides how to fail.
     pub fn pipeline(
         &mut self,
         type_id: &str,
         device: &wgpu::Device,
-    ) -> Option<Arc<MaskedFilterPipeline>> {
+    ) -> Option<Arc<dyn FilterEffect>> {
         let entry = self.entries.get_mut(type_id)?;
         Some(
             entry
                 .cached_pipeline
-                .get_or_insert_with(|| Arc::new((entry.create_pipeline)(device)))
+                .get_or_insert_with(|| (entry.create_pipeline)(device))
                 .clone(),
         )
     }

--- a/crates/darkly/src/gpu/filters/curves.rs
+++ b/crates/darkly/src/gpu/filters/curves.rs
@@ -1,17 +1,35 @@
-//! Curves filter — per-channel tone mapping via a baked 256×1 RGBA8 LUT.
+//! Curves filter — per-channel tone mapping, modeled on Krita's "Color
+//! Adjustment Curves" (`plugins/filters/colorsfilters`, `KisMultiChannelFilter`).
 //!
-//! The first *parametric* filter. The user edits five independent curves — red,
-//! green, blue, a composite "value", and alpha — on a 2D control-point editor;
-//! each is a [`ParamValue::Curve`]. `ensure` evaluates them (through the shared
-//! [`CurveLut`](crate::brush::curve_math::CurveLut) natural-cubic-spline, the
-//! same Krita algorithm the brush curve node uses) into a lookup texture that
-//! the fragment shader (`shaders/filters/curves.wgsl`) reads once per channel.
+//! For an RGBA image Krita 5.1+ exposes eight virtual channels, in this order
+//! (`kis_multichannel_utils.cpp:59-64`, `virtual_channel_info.cpp`):
 //!
-//! Fold order follows GIMP's `gimp_curve_map_pixels`
-//! (`gimp/app/core/gimpcurve-map.c:169-179`): the per-channel curve is applied
-//! first, then the composite "value" curve on top — `dest = value(channel(src))`
-//! — and the value curve is *not* applied to alpha. We bake exactly that into
-//! the LUT so the shader stays a single `textureLoad` per channel.
+//!   RGB (composite), Red, Green, Blue, Alpha, Hue, Saturation, Lightness
+//!
+//! Each is an independent curve edited on a 2D control-point editor (a
+//! [`ParamValue::Curve`]), evaluated through the shared
+//! [`CurveLut`](crate::brush::curve_math::CurveLut) natural-cubic spline (the
+//! same Krita algorithm the brush curve node uses).
+//!
+//! Transform semantics, matching Krita:
+//! - **RGB / Red / Green / Blue / Alpha** — per-component curves. Krita applies
+//!   the per-channel curve first, then the composite "RGB" curve on top
+//!   (`kis_multichannel_utils.cpp:256-263`, `colorTransform` then
+//!   `allColorsTransform`), and the composite curve is *not* applied to alpha
+//!   (`:241`). Both fold into row 0 of the LUT: `rgb[i] = rgb(channel(i))`,
+//!   `a[i] = alpha(i)`.
+//! - **Hue / Saturation** — HSV curves (`hsv_curve_adjustment`, non-relative:
+//!   the curve replaces the channel value; `kis_hsv_adjustment.cpp:765-771`).
+//!   The shader does one RGB→HSV→RGB round trip.
+//! - **Lightness** — a curve on CIELAB L* (Krita's
+//!   `createBrightnessContrastAdjustment` builds an L*a*b* device link on the L
+//!   channel, `LcmsColorSpace.h:301`). The shader does an sRGB→Lab→sRGB round
+//!   trip.
+//!
+//! The three 1D remap curves for Hue/Saturation/Lightness live in row 1 of the
+//! LUT; the color-space conversions happen per pixel in `curves.wgsl`. The HSV
+//! and Lab stages are gated by `_active` flags so an all-identity layer is a
+//! byte-for-byte no-op (Krita likewise skips null transforms).
 
 use std::sync::Arc;
 
@@ -23,13 +41,21 @@ use crate::gpu::params::{ParamDef, ParamValue};
 /// Identity curve — a straight line through the two endpoints.
 const IDENTITY: &[[f32; 2]] = &[[0.0, 0.0], [1.0, 1.0]];
 
-/// Number of LUT entries (one per 8-bit input value).
+/// Number of LUT entries per row (one per 8-bit input value).
 const LUT_LEN: usize = 256;
+/// The LUT is two rows: row 0 = per-component color curves, row 1 = HSL curves.
+const LUT_ROWS: usize = 2;
+/// Total LUT byte length (`256 × 2 × RGBA8`).
+const LUT_BYTES: usize = LUT_LEN * LUT_ROWS * 4;
 
-/// Parameter schema. Order is load-bearing: [`build_lut`] indexes these
-/// positionally, and the shader reads the baked components in the same order.
-/// `value` is the composite curve applied on top of every color channel.
+/// Parameter schema — Krita's channel order for an RGBA image. Load-bearing:
+/// [`build_lut`] indexes these positionally and the shader reads baked
+/// components in the same order.
 pub const PARAMS: &[ParamDef] = &[
+    ParamDef::Curve {
+        name: "rgb",
+        default: IDENTITY,
+    },
     ParamDef::Curve {
         name: "red",
         default: IDENTITY,
@@ -43,21 +69,32 @@ pub const PARAMS: &[ParamDef] = &[
         default: IDENTITY,
     },
     ParamDef::Curve {
-        name: "value",
+        name: "alpha",
         default: IDENTITY,
     },
     ParamDef::Curve {
-        name: "alpha",
+        name: "hue",
+        default: IDENTITY,
+    },
+    ParamDef::Curve {
+        name: "saturation",
+        default: IDENTITY,
+    },
+    ParamDef::Curve {
+        name: "lightness",
         default: IDENTITY,
     },
 ];
 
 /// Positional indices into [`PARAMS`] / a filter layer's param vector.
-const RED: usize = 0;
-const GREEN: usize = 1;
-const BLUE: usize = 2;
-const VALUE: usize = 3;
+const RGB: usize = 0;
+const RED: usize = 1;
+const GREEN: usize = 2;
+const BLUE: usize = 3;
 const ALPHA: usize = 4;
+const HUE: usize = 5;
+const SATURATION: usize = 6;
+const LIGHTNESS: usize = 7;
 
 /// Read a curve param's control points by index, falling back to identity when
 /// the param is missing or malformed (fewer than two points).
@@ -72,25 +109,65 @@ fn to_u8(v: f32) -> u8 {
     (v.clamp(0.0, 1.0) * 255.0 + 0.5) as u8
 }
 
-/// Bake the five curves into a 256×1 RGBA8 LUT (`256 * 4` bytes, row-major).
-/// `lut.rgb[i] = value(channel(i/255))`, `lut.a[i] = alpha(i/255)` — the value
-/// curve rides on top of each color channel but never on alpha.
-fn build_lut(params: &[ParamValue]) -> [u8; LUT_LEN * 4] {
+/// A baked curves LUT plus the stage-gating flags the shader reads.
+struct Baked {
+    /// 256×2 RGBA8, row-major. Row 0 = `[rgb∘red, rgb∘green, rgb∘blue, alpha]`;
+    /// row 1 = `[hue, saturation, lightness, 0]`.
+    lut: [u8; LUT_BYTES],
+    /// Whether the Hue or Saturation curve is non-identity (gates the HSV pass).
+    hsv_active: bool,
+    /// Whether the Lightness curve is non-identity (gates the Lab pass).
+    lightness_active: bool,
+}
+
+/// Evaluate `curve` across the 256 input steps into a u8 ramp.
+fn ramp(curve: &CurveLut) -> [u8; LUT_LEN] {
+    let mut out = [0u8; LUT_LEN];
+    for (i, slot) in out.iter_mut().enumerate() {
+        *slot = to_u8(curve.evaluate(i as f32 / (LUT_LEN - 1) as f32));
+    }
+    out
+}
+
+/// True when a u8 ramp maps every input to itself (an identity curve, up to
+/// 8-bit rounding).
+fn is_identity(ramp: &[u8; LUT_LEN]) -> bool {
+    ramp.iter().enumerate().all(|(i, &v)| v as usize == i)
+}
+
+/// Bake the eight curves into the LUT + gate flags (see [`Baked`]).
+fn build_lut(params: &[ParamValue]) -> Baked {
+    let rgb = CurveLut::from_points(&curve_points(params, RGB));
     let red = CurveLut::from_points(&curve_points(params, RED));
     let green = CurveLut::from_points(&curve_points(params, GREEN));
     let blue = CurveLut::from_points(&curve_points(params, BLUE));
-    let value = CurveLut::from_points(&curve_points(params, VALUE));
     let alpha = CurveLut::from_points(&curve_points(params, ALPHA));
+    let hue = ramp(&CurveLut::from_points(&curve_points(params, HUE)));
+    let sat = ramp(&CurveLut::from_points(&curve_points(params, SATURATION)));
+    let light = ramp(&CurveLut::from_points(&curve_points(params, LIGHTNESS)));
 
-    let mut lut = [0u8; LUT_LEN * 4];
+    let mut lut = [0u8; LUT_BYTES];
+    let row1 = LUT_LEN * 4;
     for i in 0..LUT_LEN {
         let t = i as f32 / (LUT_LEN - 1) as f32;
-        lut[i * 4] = to_u8(value.evaluate(red.evaluate(t)));
-        lut[i * 4 + 1] = to_u8(value.evaluate(green.evaluate(t)));
-        lut[i * 4 + 2] = to_u8(value.evaluate(blue.evaluate(t)));
+        // Row 0: per-channel curve first, then the composite RGB curve on top;
+        // the composite curve is not applied to alpha.
+        lut[i * 4] = to_u8(rgb.evaluate(red.evaluate(t)));
+        lut[i * 4 + 1] = to_u8(rgb.evaluate(green.evaluate(t)));
+        lut[i * 4 + 2] = to_u8(rgb.evaluate(blue.evaluate(t)));
         lut[i * 4 + 3] = to_u8(alpha.evaluate(t));
+        // Row 1: the raw HSL remap curves.
+        lut[row1 + i * 4] = hue[i];
+        lut[row1 + i * 4 + 1] = sat[i];
+        lut[row1 + i * 4 + 2] = light[i];
+        lut[row1 + i * 4 + 3] = 0;
     }
-    lut
+
+    Baked {
+        lut,
+        hsv_active: !is_identity(&hue) || !is_identity(&sat),
+        lightness_active: !is_identity(&light),
+    }
 }
 
 /// A `textureLoad` source binding (no sampler / hardware filtering).
@@ -108,8 +185,8 @@ fn load_tex_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
 }
 
 /// GPU realization of the curves filter: one plain-RGBA pipeline that binds
-/// `[src texture, lut texture]` (both `textureLoad`, no sampler). The per-layer
-/// LUT texture lives in the compositor's [`EffectCache`], built by [`ensure`].
+/// `[src texture, lut texture, gate uniform]`. The per-layer LUT texture and
+/// uniform live in the compositor's [`EffectCache`], built by [`ensure`].
 ///
 /// [`ensure`]: FilterEffect::ensure
 pub struct CurvesFilter {
@@ -121,7 +198,20 @@ impl CurvesFilter {
     fn new(device: &wgpu::Device) -> Self {
         let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: Some("filter-curves-bgl"),
-            entries: &[load_tex_entry(0), load_tex_entry(1)],
+            entries: &[
+                load_tex_entry(0),
+                load_tex_entry(1),
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
         });
         let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("filter-curves-layout"),
@@ -183,13 +273,13 @@ impl FilterEffect for CurvesFilter {
         params: &[ParamValue],
         cache: &mut EffectCache,
     ) {
-        // Allocate the LUT texture once; subsequent param edits reuse it.
+        // Allocate the LUT texture + gate uniform once; param edits reuse them.
         if cache.aux_textures.is_empty() {
             let tex = device.create_texture(&wgpu::TextureDescriptor {
                 label: Some("filter-curves-lut"),
                 size: wgpu::Extent3d {
                     width: LUT_LEN as u32,
-                    height: 1,
+                    height: LUT_ROWS as u32,
                     depth_or_array_layers: 1,
                 },
                 mip_level_count: 1,
@@ -203,8 +293,18 @@ impl FilterEffect for CurvesFilter {
             cache.aux_textures.push(tex);
             cache.aux_views.push(view);
         }
+        if cache.uniform_bufs.is_empty() {
+            cache
+                .uniform_bufs
+                .push(device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("filter-curves-flags"),
+                    size: 16,
+                    usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                    mapped_at_creation: false,
+                }));
+        }
 
-        let lut = build_lut(params);
+        let baked = build_lut(params);
         queue.write_texture(
             wgpu::TexelCopyTextureInfo {
                 texture: &cache.aux_textures[0],
@@ -212,18 +312,25 @@ impl FilterEffect for CurvesFilter {
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,
             },
-            &lut,
+            &baked.lut,
             wgpu::TexelCopyBufferLayout {
                 offset: 0,
                 bytes_per_row: Some((LUT_LEN * 4) as u32),
-                rows_per_image: Some(1),
+                rows_per_image: Some(LUT_ROWS as u32),
             },
             wgpu::Extent3d {
                 width: LUT_LEN as u32,
-                height: 1,
+                height: LUT_ROWS as u32,
                 depth_or_array_layers: 1,
             },
         );
+        let flags = [
+            baked.hsv_active as u32,
+            baked.lightness_active as u32,
+            0u32,
+            0u32,
+        ];
+        queue.write_buffer(&cache.uniform_bufs[0], 0, bytemuck::cast_slice(&flags));
     }
 
     fn render(
@@ -237,9 +344,10 @@ impl FilterEffect for CurvesFilter {
         cache: &EffectCache,
     ) {
         // The compose path always runs `ensure` first (pre-compose sync phase),
-        // so the LUT view is present. Guard defensively rather than panic in the
-        // render loop.
-        let Some(lut_view) = cache.aux_views.first() else {
+        // so the LUT view + uniform are present. Guard defensively rather than
+        // panic in the render loop.
+        let (Some(lut_view), Some(uniform)) = (cache.aux_views.first(), cache.uniform_bufs.first())
+        else {
             return;
         };
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -253,6 +361,10 @@ impl FilterEffect for CurvesFilter {
                 wgpu::BindGroupEntry {
                     binding: 1,
                     resource: wgpu::BindingResource::TextureView(lut_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: uniform.as_entire_binding(),
                 },
             ],
         });
@@ -295,73 +407,113 @@ pub fn register() -> FilterPipelineRegistration {
 mod tests {
     use super::*;
 
-    /// Identity curves ⇒ identity LUT: every entry maps its input value back to
-    /// itself (`lut.c[i] == i`), so a pixel is bit-unchanged. This is the
-    /// invariant the `textureLoad(round(v*255))` index convention relies on.
+    fn curve(points: &[[f32; 2]]) -> ParamValue {
+        ParamValue::Curve(points.to_vec())
+    }
+
+    /// Row 0, component `c` (0=r,1=g,2=b,3=a) at input index `i`.
+    fn row0(lut: &[u8; LUT_BYTES], i: usize, c: usize) -> u8 {
+        lut[i * 4 + c]
+    }
+    /// Row 1, component `c` (0=hue,1=sat,2=lightness) at input index `i`.
+    fn row1(lut: &[u8; LUT_BYTES], i: usize, c: usize) -> u8 {
+        lut[LUT_LEN * 4 + i * 4 + c]
+    }
+
+    /// Identity curves ⇒ identity LUT on every channel (both rows), and neither
+    /// gated stage is active. This is the invariant the `textureLoad(round(v*255))`
+    /// index convention relies on for a bit-exact no-op.
     #[test]
     fn identity_curves_yield_identity_lut() {
         let params: Vec<ParamValue> = PARAMS.iter().map(|d| d.default_value()).collect();
-        let lut = build_lut(&params);
+        let baked = build_lut(&params);
         for i in 0..LUT_LEN {
             for c in 0..4 {
                 assert_eq!(
-                    lut[i * 4 + c] as usize,
+                    row0(&baked.lut, i, c) as usize,
                     i,
-                    "identity LUT entry {i} channel {c}"
+                    "row0 entry {i} chan {c}"
+                );
+            }
+            for c in 0..3 {
+                assert_eq!(
+                    row1(&baked.lut, i, c) as usize,
+                    i,
+                    "row1 entry {i} chan {c}"
                 );
             }
         }
-    }
-
-    /// Fold order matches GIMP: the color channels are `value(channel(i))` — the
-    /// per-channel curve first, then the composite value curve on top. Both
-    /// curves are two-point (exact linear in `CurveLut`) so the arithmetic is
-    /// unambiguous and no spline overshoot muddies the assertions.
-    #[test]
-    fn value_curve_composes_over_channel_curve() {
-        // red(t) = 0.5·t (halve); value(x) = min(2·x, 1) (double, clamped).
-        // Correct fold: value(red(t)) = min(t, 1) = t → identity.
-        // Wrong fold red(value(t)) = 0.5·min(2t,1) would map the top to 0.5.
-        let half = vec![[0.0, 0.0], [1.0, 0.5]];
-        let double = vec![[0.0, 0.0], [0.5, 1.0]];
-        let params = vec![
-            ParamValue::Curve(half), // red
-            ParamValue::Curve(IDENTITY.to_vec()),
-            ParamValue::Curve(IDENTITY.to_vec()),
-            ParamValue::Curve(double), // value
-            ParamValue::Curve(IDENTITY.to_vec()),
-        ];
-        let lut = build_lut(&params);
-        // value(red(1.0)) = min(2·0.5, 1) = 1.0 → 255. The wrong order gives 128.
-        assert_eq!(lut[255 * 4], 255, "value(red(255)) must map back to 255");
-        // Midpoint: value(red(0.5)) = min(2·0.25, 1) = 0.5 → ~128.
-        let mid = lut[128 * 4];
         assert!(
-            (mid as i32 - 128).abs() <= 2,
-            "value(red(0.5)) ≈ 0.5, got {mid}"
+            !baked.hsv_active,
+            "identity HSL curves must not arm the HSV pass"
+        );
+        assert!(
+            !baked.lightness_active,
+            "identity lightness must not arm the Lab pass"
         );
     }
 
-    /// The value curve is applied to R/G/B but never to alpha (GIMP line 178):
-    /// with an identity alpha curve and a non-identity value curve, the alpha
-    /// column stays identity.
+    /// Fold order matches Krita: the color channels are `rgb(channel(i))` — the
+    /// per-channel curve first, then the composite "RGB" curve on top. Both
+    /// curves are two-point (exact linear in `CurveLut`) so the arithmetic is
+    /// unambiguous.
     #[test]
-    fn value_curve_never_touches_alpha() {
-        let double = vec![[0.0, 0.0], [0.5, 1.0], [1.0, 1.0]];
-        let params = vec![
-            ParamValue::Curve(IDENTITY.to_vec()),
-            ParamValue::Curve(IDENTITY.to_vec()),
-            ParamValue::Curve(IDENTITY.to_vec()),
-            ParamValue::Curve(double), // value curve is aggressive
-            ParamValue::Curve(IDENTITY.to_vec()), // alpha identity
-        ];
-        let lut = build_lut(&params);
+    fn composite_curve_composes_over_channel_curve() {
+        // red(t) = 0.5·t (halve); rgb(x) = min(2·x, 1) (double, clamped).
+        // Correct fold rgb(red(t)) = min(t, 1) = t → identity.
+        // Wrong fold red(rgb(t)) = 0.5·min(2t,1) would map the top to 0.5.
+        let mut params: Vec<ParamValue> = PARAMS.iter().map(|d| d.default_value()).collect();
+        params[RGB] = curve(&[[0.0, 0.0], [0.5, 1.0]]); // composite doubles
+        params[RED] = curve(&[[0.0, 0.0], [1.0, 0.5]]); // red halves
+        let baked = build_lut(&params);
+        // rgb(red(1.0)) = min(2·0.5, 1) = 1.0 → 255. Wrong order gives 128.
+        assert_eq!(
+            row0(&baked.lut, 255, 0),
+            255,
+            "rgb(red(255)) must map to 255"
+        );
+        // Midpoint: rgb(red(0.5)) = min(2·0.25, 1) = 0.5 → ~128.
+        assert!(
+            (row0(&baked.lut, 128, 0) as i32 - 128).abs() <= 2,
+            "rgb(red(0.5)) ≈ 0.5, got {}",
+            row0(&baked.lut, 128, 0)
+        );
+    }
+
+    /// The composite "RGB" curve is applied to R/G/B but never to alpha (Krita
+    /// `:241`): with a non-identity composite curve and identity alpha, the
+    /// alpha column stays identity.
+    #[test]
+    fn composite_curve_never_touches_alpha() {
+        let mut params: Vec<ParamValue> = PARAMS.iter().map(|d| d.default_value()).collect();
+        params[RGB] = curve(&[[0.0, 0.0], [0.5, 1.0]]); // aggressive composite
+        let baked = build_lut(&params);
         for i in 0..LUT_LEN {
             assert_eq!(
-                lut[i * 4 + 3] as usize,
+                row0(&baked.lut, i, 3) as usize,
                 i,
-                "alpha must stay identity regardless of the value curve, entry {i}"
+                "alpha must stay identity regardless of the composite curve, entry {i}"
             );
         }
+    }
+
+    /// A non-identity Hue or Saturation curve arms the HSV pass; a non-identity
+    /// Lightness curve arms the Lab pass — independently.
+    #[test]
+    fn hsl_curves_arm_their_stages() {
+        let mut p = PARAMS.iter().map(|d| d.default_value()).collect::<Vec<_>>();
+        p[SATURATION] = curve(&[[0.0, 0.0], [1.0, 0.5]]);
+        let baked = build_lut(&p);
+        assert!(baked.hsv_active, "a saturation curve must arm the HSV pass");
+        assert!(!baked.lightness_active);
+
+        let mut p = PARAMS.iter().map(|d| d.default_value()).collect::<Vec<_>>();
+        p[LIGHTNESS] = curve(&[[0.0, 0.0], [1.0, 0.5]]);
+        let baked = build_lut(&p);
+        assert!(
+            baked.lightness_active,
+            "a lightness curve must arm the Lab pass"
+        );
+        assert!(!baked.hsv_active);
     }
 }

--- a/crates/darkly/src/gpu/filters/curves.rs
+++ b/crates/darkly/src/gpu/filters/curves.rs
@@ -1,0 +1,367 @@
+//! Curves filter — per-channel tone mapping via a baked 256×1 RGBA8 LUT.
+//!
+//! The first *parametric* filter. The user edits five independent curves — red,
+//! green, blue, a composite "value", and alpha — on a 2D control-point editor;
+//! each is a [`ParamValue::Curve`]. `ensure` evaluates them (through the shared
+//! [`CurveLut`](crate::brush::curve_math::CurveLut) natural-cubic-spline, the
+//! same Krita algorithm the brush curve node uses) into a lookup texture that
+//! the fragment shader (`shaders/filters/curves.wgsl`) reads once per channel.
+//!
+//! Fold order follows GIMP's `gimp_curve_map_pixels`
+//! (`gimp/app/core/gimpcurve-map.c:169-179`): the per-channel curve is applied
+//! first, then the composite "value" curve on top — `dest = value(channel(src))`
+//! — and the value curve is *not* applied to alpha. We bake exactly that into
+//! the LUT so the shader stays a single `textureLoad` per channel.
+
+use std::sync::Arc;
+
+use crate::brush::curve_math::CurveLut;
+use crate::gpu::effect::EffectCache;
+use crate::gpu::filter::{FilterEffect, FilterPipelineRegistration};
+use crate::gpu::params::{ParamDef, ParamValue};
+
+/// Identity curve — a straight line through the two endpoints.
+const IDENTITY: &[[f32; 2]] = &[[0.0, 0.0], [1.0, 1.0]];
+
+/// Number of LUT entries (one per 8-bit input value).
+const LUT_LEN: usize = 256;
+
+/// Parameter schema. Order is load-bearing: [`build_lut`] indexes these
+/// positionally, and the shader reads the baked components in the same order.
+/// `value` is the composite curve applied on top of every color channel.
+pub const PARAMS: &[ParamDef] = &[
+    ParamDef::Curve {
+        name: "red",
+        default: IDENTITY,
+    },
+    ParamDef::Curve {
+        name: "green",
+        default: IDENTITY,
+    },
+    ParamDef::Curve {
+        name: "blue",
+        default: IDENTITY,
+    },
+    ParamDef::Curve {
+        name: "value",
+        default: IDENTITY,
+    },
+    ParamDef::Curve {
+        name: "alpha",
+        default: IDENTITY,
+    },
+];
+
+/// Positional indices into [`PARAMS`] / a filter layer's param vector.
+const RED: usize = 0;
+const GREEN: usize = 1;
+const BLUE: usize = 2;
+const VALUE: usize = 3;
+const ALPHA: usize = 4;
+
+/// Read a curve param's control points by index, falling back to identity when
+/// the param is missing or malformed (fewer than two points).
+fn curve_points(params: &[ParamValue], idx: usize) -> Vec<[f32; 2]> {
+    match params.get(idx) {
+        Some(ParamValue::Curve(pts)) if pts.len() >= 2 => pts.clone(),
+        _ => IDENTITY.to_vec(),
+    }
+}
+
+fn to_u8(v: f32) -> u8 {
+    (v.clamp(0.0, 1.0) * 255.0 + 0.5) as u8
+}
+
+/// Bake the five curves into a 256×1 RGBA8 LUT (`256 * 4` bytes, row-major).
+/// `lut.rgb[i] = value(channel(i/255))`, `lut.a[i] = alpha(i/255)` — the value
+/// curve rides on top of each color channel but never on alpha.
+fn build_lut(params: &[ParamValue]) -> [u8; LUT_LEN * 4] {
+    let red = CurveLut::from_points(&curve_points(params, RED));
+    let green = CurveLut::from_points(&curve_points(params, GREEN));
+    let blue = CurveLut::from_points(&curve_points(params, BLUE));
+    let value = CurveLut::from_points(&curve_points(params, VALUE));
+    let alpha = CurveLut::from_points(&curve_points(params, ALPHA));
+
+    let mut lut = [0u8; LUT_LEN * 4];
+    for i in 0..LUT_LEN {
+        let t = i as f32 / (LUT_LEN - 1) as f32;
+        lut[i * 4] = to_u8(value.evaluate(red.evaluate(t)));
+        lut[i * 4 + 1] = to_u8(value.evaluate(green.evaluate(t)));
+        lut[i * 4 + 2] = to_u8(value.evaluate(blue.evaluate(t)));
+        lut[i * 4 + 3] = to_u8(alpha.evaluate(t));
+    }
+    lut
+}
+
+/// A `textureLoad` source binding (no sampler / hardware filtering).
+fn load_tex_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::FRAGMENT,
+        ty: wgpu::BindingType::Texture {
+            sample_type: wgpu::TextureSampleType::Float { filterable: false },
+            view_dimension: wgpu::TextureViewDimension::D2,
+            multisampled: false,
+        },
+        count: None,
+    }
+}
+
+/// GPU realization of the curves filter: one plain-RGBA pipeline that binds
+/// `[src texture, lut texture]` (both `textureLoad`, no sampler). The per-layer
+/// LUT texture lives in the compositor's [`EffectCache`], built by [`ensure`].
+///
+/// [`ensure`]: FilterEffect::ensure
+pub struct CurvesFilter {
+    pipeline: wgpu::RenderPipeline,
+    bgl: wgpu::BindGroupLayout,
+}
+
+impl CurvesFilter {
+    fn new(device: &wgpu::Device) -> Self {
+        let bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("filter-curves-bgl"),
+            entries: &[load_tex_entry(0), load_tex_entry(1)],
+        });
+        let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("filter-curves-layout"),
+            bind_group_layouts: &[Some(&bgl)],
+            immediate_size: 0,
+        });
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("filter-curves-shader"),
+            source: wgpu::ShaderSource::Wgsl(
+                include_str!("../../../shaders/filters/curves.wgsl").into(),
+            ),
+        });
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("filter-curves"),
+            layout: Some(&layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_curves"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    // Curves only serves the filter-*layer* compose path, which
+                    // is RGBA8-only (the destructive/R8 path excludes parametric
+                    // filters at the engine layer).
+                    format: wgpu::TextureFormat::Rgba8Unorm,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview_mask: None,
+            cache: None,
+        });
+        CurvesFilter { pipeline, bgl }
+    }
+}
+
+impl std::fmt::Debug for CurvesFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CurvesFilter").finish_non_exhaustive()
+    }
+}
+
+impl FilterEffect for CurvesFilter {
+    fn ensure(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        params: &[ParamValue],
+        cache: &mut EffectCache,
+    ) {
+        // Allocate the LUT texture once; subsequent param edits reuse it.
+        if cache.aux_textures.is_empty() {
+            let tex = device.create_texture(&wgpu::TextureDescriptor {
+                label: Some("filter-curves-lut"),
+                size: wgpu::Extent3d {
+                    width: LUT_LEN as u32,
+                    height: 1,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::Rgba8Unorm,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+                view_formats: &[],
+            });
+            let view = tex.create_view(&wgpu::TextureViewDescriptor::default());
+            cache.aux_textures.push(tex);
+            cache.aux_views.push(view);
+        }
+
+        let lut = build_lut(params);
+        queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &cache.aux_textures[0],
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &lut,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some((LUT_LEN * 4) as u32),
+                rows_per_image: Some(1),
+            },
+            wgpu::Extent3d {
+                width: LUT_LEN as u32,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+        );
+    }
+
+    fn render(
+        &self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        src: &wgpu::TextureView,
+        _mask: Option<&wgpu::TextureView>,
+        out: &wgpu::TextureView,
+        _format: wgpu::TextureFormat,
+        cache: &EffectCache,
+    ) {
+        // The compose path always runs `ensure` first (pre-compose sync phase),
+        // so the LUT view is present. Guard defensively rather than panic in the
+        // render loop.
+        let Some(lut_view) = cache.aux_views.first() else {
+            return;
+        };
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("filter-curves-bg"),
+            layout: &self.bgl,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(src),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(lut_view),
+                },
+            ],
+        });
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("filter-curves-pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: out,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                    store: wgpu::StoreOp::Store,
+                },
+                depth_slice: None,
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.draw(0..3, 0..1);
+    }
+}
+
+fn create_pipeline(device: &wgpu::Device) -> Arc<dyn FilterEffect> {
+    Arc::new(CurvesFilter::new(device))
+}
+
+pub fn register() -> FilterPipelineRegistration {
+    FilterPipelineRegistration {
+        type_id: "curves",
+        display_name: "Curves",
+        params: PARAMS,
+        create_pipeline,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Identity curves ⇒ identity LUT: every entry maps its input value back to
+    /// itself (`lut.c[i] == i`), so a pixel is bit-unchanged. This is the
+    /// invariant the `textureLoad(round(v*255))` index convention relies on.
+    #[test]
+    fn identity_curves_yield_identity_lut() {
+        let params: Vec<ParamValue> = PARAMS.iter().map(|d| d.default_value()).collect();
+        let lut = build_lut(&params);
+        for i in 0..LUT_LEN {
+            for c in 0..4 {
+                assert_eq!(
+                    lut[i * 4 + c] as usize,
+                    i,
+                    "identity LUT entry {i} channel {c}"
+                );
+            }
+        }
+    }
+
+    /// Fold order matches GIMP: the color channels are `value(channel(i))` — the
+    /// per-channel curve first, then the composite value curve on top. Both
+    /// curves are two-point (exact linear in `CurveLut`) so the arithmetic is
+    /// unambiguous and no spline overshoot muddies the assertions.
+    #[test]
+    fn value_curve_composes_over_channel_curve() {
+        // red(t) = 0.5·t (halve); value(x) = min(2·x, 1) (double, clamped).
+        // Correct fold: value(red(t)) = min(t, 1) = t → identity.
+        // Wrong fold red(value(t)) = 0.5·min(2t,1) would map the top to 0.5.
+        let half = vec![[0.0, 0.0], [1.0, 0.5]];
+        let double = vec![[0.0, 0.0], [0.5, 1.0]];
+        let params = vec![
+            ParamValue::Curve(half), // red
+            ParamValue::Curve(IDENTITY.to_vec()),
+            ParamValue::Curve(IDENTITY.to_vec()),
+            ParamValue::Curve(double), // value
+            ParamValue::Curve(IDENTITY.to_vec()),
+        ];
+        let lut = build_lut(&params);
+        // value(red(1.0)) = min(2·0.5, 1) = 1.0 → 255. The wrong order gives 128.
+        assert_eq!(lut[255 * 4], 255, "value(red(255)) must map back to 255");
+        // Midpoint: value(red(0.5)) = min(2·0.25, 1) = 0.5 → ~128.
+        let mid = lut[128 * 4];
+        assert!(
+            (mid as i32 - 128).abs() <= 2,
+            "value(red(0.5)) ≈ 0.5, got {mid}"
+        );
+    }
+
+    /// The value curve is applied to R/G/B but never to alpha (GIMP line 178):
+    /// with an identity alpha curve and a non-identity value curve, the alpha
+    /// column stays identity.
+    #[test]
+    fn value_curve_never_touches_alpha() {
+        let double = vec![[0.0, 0.0], [0.5, 1.0], [1.0, 1.0]];
+        let params = vec![
+            ParamValue::Curve(IDENTITY.to_vec()),
+            ParamValue::Curve(IDENTITY.to_vec()),
+            ParamValue::Curve(IDENTITY.to_vec()),
+            ParamValue::Curve(double), // value curve is aggressive
+            ParamValue::Curve(IDENTITY.to_vec()), // alpha identity
+        ];
+        let lut = build_lut(&params);
+        for i in 0..LUT_LEN {
+            assert_eq!(
+                lut[i * 4 + 3] as usize,
+                i,
+                "alpha must stay identity regardless of the value curve, entry {i}"
+            );
+        }
+    }
+}

--- a/crates/darkly/src/gpu/filters/invert.rs
+++ b/crates/darkly/src/gpu/filters/invert.rs
@@ -6,8 +6,10 @@
 //! and `Compositor::filter_node_region` supplies the region plumbing. This
 //! file is everything specific to invert.
 
+use std::sync::Arc;
+
 use crate::gpu::effect::MaskedFilterPipeline;
-use crate::gpu::filter::FilterPipelineRegistration;
+use crate::gpu::filter::{FilterEffect, FilterPipelineRegistration};
 
 /// Prepend the shared color atom to the invert shader so `fs_invert` /
 /// `fs_invert_masked` can call `invert_color` — the same `include_str!`
@@ -18,20 +20,21 @@ fn shader_source() -> String {
     format!("{color}\n{invert}")
 }
 
-fn create_pipeline(device: &wgpu::Device) -> MaskedFilterPipeline {
-    MaskedFilterPipeline::new(
+fn create_pipeline(device: &wgpu::Device) -> Arc<dyn FilterEffect> {
+    Arc::new(MaskedFilterPipeline::new(
         device,
         "filter-invert",
         &shader_source(),
         "fs_invert",
         "fs_invert_masked",
-    )
+    ))
 }
 
 pub fn register() -> FilterPipelineRegistration {
     FilterPipelineRegistration {
         type_id: "invert",
         display_name: "Invert Colors",
+        params: &[],
         create_pipeline,
     }
 }

--- a/crates/darkly/src/gpu/filters/mod.rs
+++ b/crates/darkly/src/gpu/filters/mod.rs
@@ -2,6 +2,7 @@
 // To add a new module, create a .rs file in this directory
 // that exports `pub fn register() -> crate::gpu::filter::FilterPipelineRegistration`.
 
+pub mod curves;
 pub mod invert;
 
 use crate::gpu::filter::FilterPipelineRegistration;
@@ -9,6 +10,7 @@ use crate::gpu::filter::FilterPipelineRegistration;
 #[rustfmt::skip]
 pub fn registrations() -> Vec<FilterPipelineRegistration> {
     vec![
+        curves::register(),
         invert::register(),
     ]
 }

--- a/crates/darkly/src/undo/property.rs
+++ b/crates/darkly/src/undo/property.rs
@@ -23,6 +23,11 @@ pub enum Property {
     /// (multiple `VoidParams` edits in a row) into one undo step, matching
     /// how opacity behaves.
     VoidParams(Vec<ParamValue>),
+    /// Full parameter vector of a filter layer (the five curves of a `curves`
+    /// layer, say). Direct analog of `VoidParams`: replaces in bulk, coalesces a
+    /// curve drag into one undo step. The compositor rebuilds the derived LUT
+    /// from the restored params on the next `sync_projection_states`.
+    FilterParams(Vec<ParamValue>),
     /// A void layer's user transform (gizmo-edited pan / scale / rotate).
     /// Coalesces on `same_kind` so a whole gizmo drag is one undo step,
     /// exactly like `VoidParams`. The GPU re-sync happens in
@@ -60,6 +65,11 @@ impl Property {
             Property::VoidParams(values) => {
                 if let LayerNode::Layer(Layer::Void(v)) = node {
                     v.params = values.clone();
+                }
+            }
+            Property::FilterParams(values) => {
+                if let LayerNode::Layer(Layer::Filter(f)) = node {
+                    f.params = values.clone();
                 }
             }
             Property::Transform(t) => {

--- a/crates/darkly/tests/filters.rs
+++ b/crates/darkly/tests/filters.rs
@@ -11,9 +11,10 @@
 
 use darkly::coord::{CanvasPoint, CanvasRect};
 use darkly::document::SelectionMode;
-use darkly::engine::types::StrokeOp;
+use darkly::engine::types::{LayerInfo, StrokeOp};
 use darkly::engine::DarklyEngine;
 use darkly::gpu::context::GpuContext;
+use darkly::gpu::params::ParamValue;
 use darkly::gpu::test_utils::*;
 use darkly::layer::LayerId;
 
@@ -692,4 +693,175 @@ fn filter_layer_is_non_destructive() {
         original,
         "deleting the filter must restore the original composite exactly"
     );
+}
+
+// ---- Curves (parametric) filter layer --------------------------------------
+//
+// Curves is the first parametric filter: five per-channel tone curves baked
+// into a GPU LUT. These pin the schema (five identity curves on add), the
+// param-edit + undo path, the destructive-path exclusion, and the two GPU
+// promises (identity ⇒ bit-unchanged; a value curve shifts pixels as baked).
+
+/// An identity curve — a straight diagonal.
+fn identity_curve() -> ParamValue {
+    ParamValue::Curve(vec![[0.0, 0.0], [1.0, 1.0]])
+}
+
+/// The default param vector for a filter type, straight from its schema.
+fn filter_defaults(e: &DarklyEngine, type_id: &str) -> Vec<ParamValue> {
+    e.filter_param_defs(type_id)
+        .iter()
+        .map(|d| d.default_value())
+        .collect()
+}
+
+/// Pull a root filter layer's effective param values (`value`, else `default`)
+/// from the engine's layer-tree query.
+fn filter_layer_params(e: &DarklyEngine, id: LayerId) -> Vec<ParamValue> {
+    let ffi = id.to_ffi() as f64;
+    for node in e.layer_tree() {
+        if let LayerInfo::Filter {
+            id: nid, params, ..
+        } = &node
+        {
+            if *nid == ffi {
+                return params
+                    .iter()
+                    .map(|p| p.value.clone().unwrap_or_else(|| p.default.clone()))
+                    .collect();
+            }
+        }
+    }
+    panic!("filter layer {ffi} not found in layer tree");
+}
+
+#[test]
+fn add_curves_layer_yields_five_identity_curves() {
+    let mut e = test_engine(8, 8);
+    let params = filter_defaults(&e, "curves");
+    let id = e
+        .add_filter_layer("curves", params, None)
+        .expect("curves is a registered filter type");
+
+    let got = filter_layer_params(&e, id);
+    assert_eq!(got.len(), 5, "curves exposes red/green/blue/value/alpha");
+    for (i, p) in got.iter().enumerate() {
+        assert_eq!(
+            p,
+            &identity_curve(),
+            "default curve param {i} must be identity"
+        );
+    }
+}
+
+#[test]
+fn update_filter_params_mutates_and_undo_restores() {
+    let mut e = test_engine(8, 8);
+    let id = e
+        .add_filter_layer("curves", filter_defaults(&e, "curves"), None)
+        .unwrap();
+
+    // Edit the value curve (index 3) to a non-identity darkening ramp.
+    let edited = {
+        let mut p = filter_defaults(&e, "curves");
+        p[3] = ParamValue::Curve(vec![[0.0, 0.0], [1.0, 0.5]]);
+        p
+    };
+    e.update_filter_params(id, edited.clone());
+    assert_eq!(
+        filter_layer_params(&e, id),
+        edited,
+        "update_filter_params must set the new curves"
+    );
+
+    e.undo();
+    let restored = filter_layer_params(&e, id);
+    for (i, p) in restored.iter().enumerate() {
+        assert_eq!(
+            p,
+            &identity_curve(),
+            "undo must restore curve {i} to identity"
+        );
+    }
+}
+
+#[test]
+fn apply_filter_excludes_parametric_curves() {
+    let (w, h) = (4u32, 4u32);
+    let mut e = test_engine(w, h);
+    let layer = e.paste_image(w, h, &distinct_rgba(w, h), 0, 0, None);
+    let before = e.test_readback_layer(layer);
+
+    assert!(
+        !e.apply_filter(layer, "curves"),
+        "a parametric filter must be excluded from the destructive one-click path"
+    );
+    assert_eq!(
+        e.test_readback_layer(layer),
+        before,
+        "the excluded destructive curves call must not touch pixels"
+    );
+}
+
+/// Identity curves ⇒ the composite is bit-unchanged. Validates the
+/// `textureLoad(round(v*255))` index convention: LUT[i] == i, so every byte
+/// maps to itself.
+#[test]
+fn curves_identity_leaves_composite_unchanged() {
+    let (cw, ch) = (16u32, 16u32);
+    let mut engine = test_engine(cw, ch);
+
+    let base = engine.add_raster_layer(None);
+    fill_layer(&mut engine, base, 200, 64, 128);
+    engine.test_flush_readbacks();
+    engine.render(0.0);
+    let before = engine.test_readback_canvas();
+
+    engine
+        .add_filter_layer("curves", filter_defaults(&engine, "curves"), None)
+        .unwrap();
+    engine.test_flush_readbacks();
+    engine.render(0.0);
+
+    assert_eq!(
+        engine.test_readback_canvas(),
+        before,
+        "an identity curves layer must not change any pixel"
+    );
+}
+
+/// A non-identity value curve shifts pixels as baked: `value(x) = x/2` halves
+/// every color channel while leaving alpha untouched (the value curve is not
+/// applied to alpha).
+#[test]
+fn curves_value_curve_shifts_pixels() {
+    let (cw, ch) = (16u32, 16u32);
+    let mut engine = test_engine(cw, ch);
+
+    let base = engine.add_raster_layer(None);
+    fill_layer(&mut engine, base, 255, 0, 0); // opaque red
+    engine.test_flush_readbacks();
+    engine.render(0.0);
+
+    // Value curve halves the input; red/green/blue identity, alpha identity.
+    let params = vec![
+        identity_curve(),
+        identity_curve(),
+        identity_curve(),
+        ParamValue::Curve(vec![[0.0, 0.0], [1.0, 0.5]]),
+        identity_curve(),
+    ];
+    engine.add_filter_layer("curves", params, None).unwrap();
+    engine.test_flush_readbacks();
+    engine.render(0.0);
+
+    let p = px(&engine.test_readback_canvas(), cw, cw / 2, ch / 2);
+    // value(red(1.0)) = value(1.0) = 0.5 → ~128; g/b stay 0; alpha stays 255.
+    assert!(
+        (p[0] as i32 - 128).abs() <= 2,
+        "value curve should halve red to ~128, got {p:?}"
+    );
+    assert_eq!(p[1], 0, "green stays 0");
+    assert_eq!(p[2], 0, "blue stays 0");
+    assert_eq!(p[3], 255, "alpha untouched by the value curve");
 }

--- a/crates/darkly/tests/filters.rs
+++ b/crates/darkly/tests/filters.rs
@@ -697,10 +697,17 @@ fn filter_layer_is_non_destructive() {
 
 // ---- Curves (parametric) filter layer --------------------------------------
 //
-// Curves is the first parametric filter: five per-channel tone curves baked
-// into a GPU LUT. These pin the schema (five identity curves on add), the
-// param-edit + undo path, the destructive-path exclusion, and the two GPU
-// promises (identity ⇒ bit-unchanged; a value curve shifts pixels as baked).
+// Curves is the first parametric filter: Krita's eight "Color Adjustment
+// Curves" channels (RGB, Red, Green, Blue, Alpha, Hue, Saturation, Lightness)
+// baked into a GPU LUT. These pin the schema (eight identity curves on add),
+// the param-edit + undo path, the destructive-path exclusion, and the GPU
+// promises (identity ⇒ bit-unchanged; a composite curve shifts pixels as baked;
+// a hue curve rotates hue).
+
+/// Positional channel indices into a curves layer's param vector (Krita order).
+const CH_RGB: usize = 0;
+const CH_HUE: usize = 5;
+const CH_LIGHTNESS: usize = 7;
 
 /// An identity curve — a straight diagonal.
 fn identity_curve() -> ParamValue {
@@ -736,7 +743,7 @@ fn filter_layer_params(e: &DarklyEngine, id: LayerId) -> Vec<ParamValue> {
 }
 
 #[test]
-fn add_curves_layer_yields_five_identity_curves() {
+fn add_curves_layer_yields_eight_identity_curves() {
     let mut e = test_engine(8, 8);
     let params = filter_defaults(&e, "curves");
     let id = e
@@ -744,7 +751,11 @@ fn add_curves_layer_yields_five_identity_curves() {
         .expect("curves is a registered filter type");
 
     let got = filter_layer_params(&e, id);
-    assert_eq!(got.len(), 5, "curves exposes red/green/blue/value/alpha");
+    assert_eq!(
+        got.len(),
+        8,
+        "curves exposes RGB/Red/Green/Blue/Alpha/Hue/Saturation/Lightness"
+    );
     for (i, p) in got.iter().enumerate() {
         assert_eq!(
             p,
@@ -761,10 +772,10 @@ fn update_filter_params_mutates_and_undo_restores() {
         .add_filter_layer("curves", filter_defaults(&e, "curves"), None)
         .unwrap();
 
-    // Edit the value curve (index 3) to a non-identity darkening ramp.
+    // Edit the composite RGB curve to a non-identity darkening ramp.
     let edited = {
         let mut p = filter_defaults(&e, "curves");
-        p[3] = ParamValue::Curve(vec![[0.0, 0.0], [1.0, 0.5]]);
+        p[CH_RGB] = ParamValue::Curve(vec![[0.0, 0.0], [1.0, 0.5]]);
         p
     };
     e.update_filter_params(id, edited.clone());
@@ -830,11 +841,11 @@ fn curves_identity_leaves_composite_unchanged() {
     );
 }
 
-/// A non-identity value curve shifts pixels as baked: `value(x) = x/2` halves
-/// every color channel while leaving alpha untouched (the value curve is not
-/// applied to alpha).
+/// A non-identity composite RGB curve shifts pixels as baked: `rgb(x) = x/2`
+/// halves every color channel while leaving alpha untouched (the composite curve
+/// is not applied to alpha).
 #[test]
-fn curves_value_curve_shifts_pixels() {
+fn curves_composite_curve_shifts_pixels() {
     let (cw, ch) = (16u32, 16u32);
     let mut engine = test_engine(cw, ch);
 
@@ -843,25 +854,81 @@ fn curves_value_curve_shifts_pixels() {
     engine.test_flush_readbacks();
     engine.render(0.0);
 
-    // Value curve halves the input; red/green/blue identity, alpha identity.
-    let params = vec![
-        identity_curve(),
-        identity_curve(),
-        identity_curve(),
-        ParamValue::Curve(vec![[0.0, 0.0], [1.0, 0.5]]),
-        identity_curve(),
-    ];
+    // Composite RGB curve halves the input; all other channels identity.
+    let mut params = vec![identity_curve(); 8];
+    params[CH_RGB] = ParamValue::Curve(vec![[0.0, 0.0], [1.0, 0.5]]);
     engine.add_filter_layer("curves", params, None).unwrap();
     engine.test_flush_readbacks();
     engine.render(0.0);
 
     let p = px(&engine.test_readback_canvas(), cw, cw / 2, ch / 2);
-    // value(red(1.0)) = value(1.0) = 0.5 → ~128; g/b stay 0; alpha stays 255.
+    // rgb(1.0) = 0.5 → ~128; g/b stay 0; alpha stays 255.
     assert!(
         (p[0] as i32 - 128).abs() <= 2,
-        "value curve should halve red to ~128, got {p:?}"
+        "composite curve should halve red to ~128, got {p:?}"
     );
     assert_eq!(p[1], 0, "green stays 0");
     assert_eq!(p[2], 0, "blue stays 0");
-    assert_eq!(p[3], 255, "alpha untouched by the value curve");
+    assert_eq!(p[3], 255, "alpha untouched by the composite curve");
+}
+
+/// A Hue curve rotates hue in HSV space (Krita's `hsv_curve_adjustment`,
+/// non-relative): mapping input hue `2/3` (pure blue, 240°) to output `1/3`
+/// (120°, green) turns an opaque blue layer green, with saturation/value intact.
+/// This exercises the RGB→HSV→RGB path and the shader's `hsv_active` gate.
+#[test]
+fn curves_hue_curve_rotates_hue() {
+    let (cw, ch) = (16u32, 16u32);
+    let mut engine = test_engine(cw, ch);
+
+    let base = engine.add_raster_layer(None);
+    fill_layer(&mut engine, base, 0, 0, 255); // opaque blue (hue 240° = 2/3)
+    engine.test_flush_readbacks();
+    engine.render(0.0);
+
+    // Hue curve maps normalized hue 2/3 → 1/3 (240° → 120°, green). A ramp with
+    // an interior control point pinned so hue(2/3) = 1/3.
+    let mut params = vec![identity_curve(); 8];
+    params[CH_HUE] = ParamValue::Curve(vec![[0.0, 0.0], [2.0 / 3.0, 1.0 / 3.0], [1.0, 1.0]]);
+    engine.add_filter_layer("curves", params, None).unwrap();
+    engine.test_flush_readbacks();
+    engine.render(0.0);
+
+    let p = px(&engine.test_readback_canvas(), cw, cw / 2, ch / 2);
+    // Pure blue rotated to ~120° at full saturation/value is pure green.
+    assert!(
+        p[1] > 200 && p[0] < 60 && p[2] < 60,
+        "hue curve should rotate blue → green, got {p:?}"
+    );
+    assert_eq!(p[3], 255, "alpha untouched by the hue curve");
+}
+
+/// A Lightness curve darkens on CIELAB L* (Krita's "Lightness L*a*b*"): halving
+/// L on a neutral gray yields a darker — but still neutral — gray. Exercises the
+/// sRGB→Lab→sRGB round trip and the `lightness_active` gate.
+#[test]
+fn curves_lightness_curve_darkens_neutral() {
+    let (cw, ch) = (16u32, 16u32);
+    let mut engine = test_engine(cw, ch);
+
+    let base = engine.add_raster_layer(None);
+    fill_layer(&mut engine, base, 128, 128, 128); // neutral mid gray
+    engine.test_flush_readbacks();
+    engine.render(0.0);
+
+    // Lightness curve halves L*; every other channel identity.
+    let mut params = vec![identity_curve(); 8];
+    params[CH_LIGHTNESS] = ParamValue::Curve(vec![[0.0, 0.0], [1.0, 0.5]]);
+    engine.add_filter_layer("curves", params, None).unwrap();
+    engine.test_flush_readbacks();
+    engine.render(0.0);
+
+    let p = px(&engine.test_readback_canvas(), cw, cw / 2, ch / 2);
+    // Darker than the input gray, and still neutral (channels stay together).
+    assert!(p[0] < 120, "halving L* must darken the gray, got {p:?}");
+    assert!(
+        (p[0] as i32 - p[1] as i32).abs() <= 3 && (p[1] as i32 - p[2] as i32).abs() <= 3,
+        "lightness on L* must keep the gray neutral, got {p:?}"
+    );
+    assert_eq!(p[3], 255, "alpha untouched by the lightness curve");
 }

--- a/frontend/src/engine/protocol_gen.ts
+++ b/frontend/src/engine/protocol_gen.ts
@@ -155,6 +155,7 @@ export type RequestKind =
     | 'stroke_to'
     | 'tool_types'
     | 'undo'
+    | 'update_filter_params'
     | 'update_floating_matrix'
     | 'update_veil'
     | 'update_void_params'
@@ -319,6 +320,7 @@ export const REQUEST_KINDS: readonly RequestKind[] = [
     'stroke_to',
     'tool_types',
     'undo',
+    'update_filter_params',
     'update_floating_matrix',
     'update_veil',
     'update_void_params',

--- a/frontend/src/state/app.svelte.ts
+++ b/frontend/src/state/app.svelte.ts
@@ -147,7 +147,7 @@ export class DarklyInstance {
      *  at startup. Drives the dynamic, auto-discovered Colors-menu actions in
      *  `registerActions` — a new filter in the Rust core surfaces a menu
      *  entry with zero frontend edits. */
-    filterTypes = $state<Array<{ type: string; displayName: string }>>([]);
+    filterTypes = $state<Array<{ type: string; displayName: string; params?: unknown[] }>>([]);
 
     toolDisplayName(id: string): string {
         return this.toolDisplayNames[id] ?? id;
@@ -166,6 +166,11 @@ export class DarklyInstance {
     }
     layerKindDisplayName(id: string): string {
         return this.layerKindDisplayNames[id] ?? id;
+    }
+    /** Display label for a filter `type_id` (e.g. `"curves"` → `"Curves"`),
+     *  resolved from the `filterTypes` registry list. */
+    filterDisplayName(id: string): string {
+        return this.filterTypes.find((f) => f.type === id)?.displayName ?? id;
     }
 
     /** Populate every registry-backed display-name map from the Rust core in

--- a/frontend/src/ui/filters/FilterProperties.svelte
+++ b/frontend/src/ui/filters/FilterProperties.svelte
@@ -1,0 +1,219 @@
+<script lang="ts">
+    import { setContext } from 'svelte';
+    import { app } from '../../state/app.svelte';
+    import CurveEditor from '../CurveEditor.svelte';
+    import { createGraphCoords } from '../brush_builder/coords';
+    import type { NodeCanvasContext } from '../brush_builder/NodeCanvas.svelte';
+    import { partitionFilterParams, type FilterParam, type CurvePoints } from './filterParams';
+
+    let { node }: {
+        node: { id: number; pipeline: string; params: FilterParam[] };
+    } = $props();
+
+    // `CurveEditor` reads pointer coordinates through the `node-canvas` context
+    // (it normally lives inside the brush graph). This panel is neither zoomed
+    // nor panned, so a trivial identity coord system suffices — only
+    // `clientToElementLocal` is exercised; the port register hooks are no-ops.
+    let rootEl: HTMLDivElement;
+    const coords = createGraphCoords({ nodeLayerEl: () => rootEl, zoom: () => 1 });
+    setContext<NodeCanvasContext>('node-canvas', {
+        register() {},
+        unregister() {},
+        coords,
+    });
+
+    const filterLabel = $derived(app.filterDisplayName(node.pipeline));
+
+    const partition = $derived(partitionFilterParams(node.params ?? []));
+    const curves = $derived(partition.curves);
+    const scalars = $derived(partition.scalars);
+
+    // The channel currently shown in the curve editor. Kept valid as the param
+    // set changes (layer swap, load) — defaults to the first curve.
+    let selectedChannel = $state<string | null>(null);
+    $effect(() => {
+        if (curves.length === 0) {
+            selectedChannel = null;
+        } else if (!curves.some((c) => c.name === selectedChannel)) {
+            selectedChannel = curves[0].name;
+        }
+    });
+    const selectedCurve = $derived(curves.find((c) => c.name === selectedChannel) ?? null);
+
+    // Post the whole `{name: value}` param map. `refresh` re-pulls the layer
+    // tree (skipped mid curve-drag so the live edit isn't churned; the editor
+    // holds its own drag state either way).
+    function pushParams(refresh: boolean) {
+        if (!app.engine) return;
+        const params: Record<string, number | boolean | CurvePoints> = {};
+        for (const p of node.params) {
+            params[p.name] = (p.value ?? p.default) as number | boolean | CurvePoints;
+        }
+        app.engine.post('update_filter_params', { id: node.id, params });
+        if (refresh) app.refreshLayerTree();
+        app.requestFrame();
+    }
+
+    function onSliderInput(param: FilterParam, e: Event) {
+        const target = e.target as HTMLInputElement;
+        param.value = param.kind === 'int' ? parseInt(target.value, 10) : parseFloat(target.value);
+        pushParams(true);
+    }
+    function onBoolChange(param: FilterParam, e: Event) {
+        param.value = (e.target as HTMLInputElement).checked;
+        pushParams(true);
+    }
+    function onCurveInput(pts: CurvePoints) {
+        if (!selectedCurve) return;
+        selectedCurve.value = pts;
+        pushParams(false);
+    }
+    function onCurveChange(pts: CurvePoints) {
+        if (!selectedCurve) return;
+        selectedCurve.value = pts;
+        pushParams(true);
+    }
+</script>
+
+<div class="filter-props" bind:this={rootEl}>
+    <div class="header">
+        <span class="type-label">{filterLabel}</span>
+    </div>
+
+    {#if curves.length > 0}
+        {#if curves.length > 1}
+            <div class="row">
+                <span class="label">Channel</span>
+                <select class="channel-select" bind:value={selectedChannel}>
+                    {#each curves as c (c.name)}
+                        <option value={c.name}>{c.name}</option>
+                    {/each}
+                </select>
+            </div>
+        {/if}
+        {#if selectedCurve}
+            <!-- Remount the editor on channel switch so its drag/selection
+                 state resets to the newly-shown curve. -->
+            {#key selectedChannel}
+                <CurveEditor
+                    points={(selectedCurve.value ?? selectedCurve.default) as CurvePoints}
+                    oninput={onCurveInput}
+                    onchange={onCurveChange}
+                />
+            {/key}
+        {/if}
+    {/if}
+
+    {#each scalars as param (param.name)}
+        <div class="row">
+            <span class="label">{param.name}</span>
+            {#if param.kind === 'float' || param.kind === 'int'}
+                <input
+                    type="range"
+                    class="slider"
+                    min={param.min}
+                    max={param.max}
+                    step={param.kind === 'int' ? 1 : (((param.max as number) - (param.min as number)) / 100)}
+                    value={(param.value ?? param.default) as number}
+                    oninput={(e) => onSliderInput(param, e)}
+                />
+                <span class="value">
+                    {param.kind === 'int'
+                        ? (param.value ?? param.default)
+                        : ((param.value ?? param.default) as number).toFixed(2)}
+                </span>
+            {:else if param.kind === 'bool'}
+                <input
+                    type="checkbox"
+                    class="checkbox"
+                    checked={(param.value ?? param.default) as boolean}
+                    onchange={(e) => onBoolChange(param, e)}
+                />
+            {/if}
+        </div>
+    {/each}
+
+    {#if node.params.length === 0}
+        <div class="empty">No parameters</div>
+    {/if}
+</div>
+
+<style>
+    .filter-props {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        padding-bottom: 4px;
+        border-bottom: 1px solid var(--bg-hover);
+        margin-bottom: 2px;
+    }
+
+    .type-label {
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        color: var(--text-muted);
+    }
+
+    .row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        min-height: 22px;
+    }
+
+    .label {
+        font-size: 11px;
+        color: var(--text-muted);
+        min-width: 56px;
+        text-transform: capitalize;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .channel-select {
+        flex: 1;
+        min-width: 0;
+        background: var(--bg);
+        color: var(--text);
+        border: 1px solid var(--bg-hover);
+        border-radius: var(--radius-sm);
+        font-size: 11px;
+        padding: 2px 4px;
+        text-transform: capitalize;
+    }
+
+    .slider {
+        flex: 1;
+        height: 4px;
+        min-width: 0;
+    }
+
+    .value {
+        font-size: 11px;
+        color: var(--text-muted);
+        min-width: 36px;
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .checkbox {
+        accent-color: var(--accent);
+    }
+
+    .empty {
+        font-size: 12px;
+        color: var(--text-dim);
+        text-align: center;
+        padding: 4px 0;
+    }
+</style>

--- a/frontend/src/ui/filters/FilterProperties.svelte
+++ b/frontend/src/ui/filters/FilterProperties.svelte
@@ -4,7 +4,13 @@
     import CurveEditor from '../CurveEditor.svelte';
     import { createGraphCoords } from '../brush_builder/coords';
     import type { NodeCanvasContext } from '../brush_builder/NodeCanvas.svelte';
-    import { partitionFilterParams, type FilterParam, type CurvePoints } from './filterParams';
+    import { partitionFilterParams, channelLabel, type FilterParam, type CurvePoints } from './filterParams';
+
+    /** The identity curve — a straight diagonal from (0,0) to (1,1). */
+    const IDENTITY_CURVE: CurvePoints = [
+        [0, 0],
+        [1, 1],
+    ];
 
     let { node }: {
         node: { id: number; pipeline: string; params: FilterParam[] };
@@ -73,6 +79,13 @@
         selectedCurve.value = pts;
         pushParams(true);
     }
+
+    // Reset the currently-shown channel's curve back to the identity diagonal.
+    function resetSelectedCurve() {
+        if (!selectedCurve) return;
+        selectedCurve.value = IDENTITY_CURVE.map((p) => [...p] as [number, number]);
+        pushParams(true);
+    }
 </script>
 
 <div class="filter-props" bind:this={rootEl}>
@@ -86,7 +99,7 @@
                 <span class="label">Channel</span>
                 <select class="channel-select" bind:value={selectedChannel}>
                     {#each curves as c (c.name)}
-                        <option value={c.name}>{c.name}</option>
+                        <option value={c.name}>{channelLabel(c.name)}</option>
                     {/each}
                 </select>
             </div>
@@ -101,6 +114,13 @@
                     onchange={onCurveChange}
                 />
             {/key}
+            <button
+                class="reset-btn"
+                onclick={resetSelectedCurve}
+                title="Reset {channelLabel(selectedCurve.name)} curve"
+            >
+                Reset
+            </button>
         {/if}
     {/if}
 
@@ -163,6 +183,21 @@
         color: var(--text-muted);
     }
 
+    .reset-btn {
+        align-self: center;
+        padding: 3px 12px;
+        background: var(--bg-hover);
+        border: 1px solid transparent;
+        border-radius: var(--radius-sm);
+        color: var(--text-muted);
+        cursor: pointer;
+        font-size: 11px;
+    }
+    .reset-btn:hover {
+        border-color: var(--accent);
+        color: var(--text);
+    }
+
     .row {
         display: flex;
         align-items: center;
@@ -189,7 +224,6 @@
         border-radius: var(--radius-sm);
         font-size: 11px;
         padding: 2px 4px;
-        text-transform: capitalize;
     }
 
     .slider {

--- a/frontend/src/ui/filters/__tests__/filterParams.test.ts
+++ b/frontend/src/ui/filters/__tests__/filterParams.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { partitionFilterParams, type FilterParam } from '../filterParams';
+
+const curve = (name: string): FilterParam => ({
+    kind: 'curve',
+    name,
+    default: [
+        [0, 0],
+        [1, 1],
+    ],
+});
+const scalar = (name: string): FilterParam => ({ kind: 'float', name, default: 0 });
+
+describe('partitionFilterParams', () => {
+    it("groups the curves layer's five channels under the selector", () => {
+        const params = ['red', 'green', 'blue', 'value', 'alpha'].map(curve);
+        const { curves, scalars } = partitionFilterParams(params);
+        expect(curves.map((c) => c.name)).toEqual(['red', 'green', 'blue', 'value', 'alpha']);
+        expect(scalars).toHaveLength(0);
+    });
+
+    it('separates curves from scalars while preserving order', () => {
+        const params = [scalar('amount'), curve('red'), scalar('mix'), curve('blue')];
+        const { curves, scalars } = partitionFilterParams(params);
+        expect(curves.map((c) => c.name)).toEqual(['red', 'blue']);
+        expect(scalars.map((s) => s.name)).toEqual(['amount', 'mix']);
+    });
+
+    it('handles a parameter-free filter (invert)', () => {
+        const { curves, scalars } = partitionFilterParams([]);
+        expect(curves).toHaveLength(0);
+        expect(scalars).toHaveLength(0);
+    });
+});

--- a/frontend/src/ui/filters/__tests__/filterParams.test.ts
+++ b/frontend/src/ui/filters/__tests__/filterParams.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { partitionFilterParams, type FilterParam } from '../filterParams';
+import { partitionFilterParams, channelLabel, type FilterParam } from '../filterParams';
 
 const curve = (name: string): FilterParam => ({
     kind: 'curve',
@@ -12,10 +12,11 @@ const curve = (name: string): FilterParam => ({
 const scalar = (name: string): FilterParam => ({ kind: 'float', name, default: 0 });
 
 describe('partitionFilterParams', () => {
-    it("groups the curves layer's five channels under the selector", () => {
-        const params = ['red', 'green', 'blue', 'value', 'alpha'].map(curve);
+    it("groups the curves layer's eight Krita channels under the selector", () => {
+        const names = ['rgb', 'red', 'green', 'blue', 'alpha', 'hue', 'saturation', 'lightness'];
+        const params = names.map(curve);
         const { curves, scalars } = partitionFilterParams(params);
-        expect(curves.map((c) => c.name)).toEqual(['red', 'green', 'blue', 'value', 'alpha']);
+        expect(curves.map((c) => c.name)).toEqual(names);
         expect(scalars).toHaveLength(0);
     });
 
@@ -30,5 +31,17 @@ describe('partitionFilterParams', () => {
         const { curves, scalars } = partitionFilterParams([]);
         expect(curves).toHaveLength(0);
         expect(scalars).toHaveLength(0);
+    });
+});
+
+describe('channelLabel', () => {
+    it('renders the RGB composite acronym uppercase, not title-cased', () => {
+        expect(channelLabel('rgb')).toBe('RGB');
+    });
+
+    it('title-cases the ordinary channels', () => {
+        expect(channelLabel('red')).toBe('Red');
+        expect(channelLabel('saturation')).toBe('Saturation');
+        expect(channelLabel('lightness')).toBe('Lightness');
     });
 });

--- a/frontend/src/ui/filters/filterParams.ts
+++ b/frontend/src/ui/filters/filterParams.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure helpers for the filter-layer properties panel.
+ *
+ * A filter's params (the `ParamInfo[]` emitted by the Rust `filter_types()` /
+ * layer-tree query) mix scalar controls (sliders, checkboxes) with tone curves.
+ * The panel renders every curve param through one shared channel selector +
+ * `<CurveEditor>`; the scalars render as their own rows. This module owns the
+ * split so the component stays declarative and the grouping is unit-testable.
+ */
+
+export type CurvePoints = [number, number][];
+
+/** One entry of a filter's `params` array — a `ParamInfo` view. */
+export interface FilterParam {
+    kind: string;
+    name: string;
+    min?: number;
+    max?: number;
+    default: number | boolean | CurvePoints;
+    value?: number | boolean | CurvePoints;
+}
+
+/**
+ * Partition a filter's params into its curve params — each a channel that gets
+ * its own entry in the channel selector — and its scalar params, preserving
+ * declaration order within each group. A filter with N curve params (curves
+ * exposes red/green/blue/value/alpha) surfaces one selector with N options and
+ * a single curve editor bound to the chosen channel.
+ */
+export function partitionFilterParams(params: FilterParam[]): {
+    curves: FilterParam[];
+    scalars: FilterParam[];
+} {
+    const curves: FilterParam[] = [];
+    const scalars: FilterParam[] = [];
+    for (const p of params) {
+        (p.kind === 'curve' ? curves : scalars).push(p);
+    }
+    return { curves, scalars };
+}

--- a/frontend/src/ui/filters/filterParams.ts
+++ b/frontend/src/ui/filters/filterParams.ts
@@ -24,8 +24,8 @@ export interface FilterParam {
  * Partition a filter's params into its curve params — each a channel that gets
  * its own entry in the channel selector — and its scalar params, preserving
  * declaration order within each group. A filter with N curve params (curves
- * exposes red/green/blue/value/alpha) surfaces one selector with N options and
- * a single curve editor bound to the chosen channel.
+ * exposes rgb/red/green/blue/alpha/hue/saturation/lightness) surfaces one
+ * selector with N options and a single curve editor bound to the chosen channel.
  */
 export function partitionFilterParams(params: FilterParam[]): {
     curves: FilterParam[];
@@ -37,4 +37,17 @@ export function partitionFilterParams(params: FilterParam[]): {
         (p.kind === 'curve' ? curves : scalars).push(p);
     }
     return { curves, scalars };
+}
+
+/** Channel ids that must render fully uppercase, not title-cased. */
+const ACRONYM_CHANNELS = new Set(['rgb', 'rgba', 'cmyk', 'xyz', 'ycbcr']);
+
+/**
+ * Display label for a param name. Channel ids are lowercase stable ids
+ * (`"rgb"`, `"saturation"`); acronyms render uppercase (`"rgb"` → `"RGB"`),
+ * everything else title-cased (`"saturation"` → `"Saturation"`).
+ */
+export function channelLabel(name: string): string {
+    if (ACRONYM_CHANNELS.has(name)) return name.toUpperCase();
+    return name.charAt(0).toUpperCase() + name.slice(1);
 }

--- a/frontend/src/ui/properties/PropertiesPanel.svelte
+++ b/frontend/src/ui/properties/PropertiesPanel.svelte
@@ -4,6 +4,7 @@
     import GroupProperties from './GroupProperties.svelte';
     import VeilProperties from '../veils/VeilProperties.svelte';
     import VoidProperties from '../voids/VoidProperties.svelte';
+    import FilterProperties from '../filters/FilterProperties.svelte';
 
     function findNode(nodes: any[], id: number): any | null {
         for (const n of nodes) {
@@ -47,6 +48,8 @@
                 <GroupProperties group={activeLayer} />
             {:else if activeLayer.type === 'void'}
                 <VoidProperties node={activeLayer} />
+            {:else if activeLayer.type === 'filter'}
+                <FilterProperties node={activeLayer} />
             {/if}
         {:else}
             <div class="empty">No selection</div>


### PR DESCRIPTION
<img width="500" alt="image" src="https://github.com/user-attachments/assets/10252373-ad13-4040-b635-1a0b3f15cec0" />

---

## Curves adjustment (filter) layer

Adds **Curves**, Darkly's first *parametric* filter layer. For an RGBA image it exposes eight independent tone curves, in order: **RGB (composite), Red, Green, Blue, Alpha, Hue, Saturation, Lightness**. Each is edited on a 2D control-point editor; all persist together on one non-destructive layer.

### GPU filter substrate → `FilterEffect` trait
The filter registry previously cached a bare, parameter-free `MaskedFilterPipeline`. It now yields `Arc<dyn FilterEffect>`, so each filter owns its pipeline plus any param-derived GPU resources (held in the reused `EffectCache`). `invert` becomes a trivial no-op-param wrapper over `MaskedFilterPipeline`; `curves` slots in with its LUT + gate uniform. A new parametric filter now adds one file and touches no shared dispatch.

### Curves filter
- **RGB / Red / Green / Blue / Alpha** — per-component curves. The per-channel curve is applied first, then the composite "RGB" curve on top; the composite curve is *not* applied to alpha. Both fold into LUT row 0: `rgb[i] = rgb(channel(i))`, `a[i] = alpha(i)`.
- **Hue / Saturation** — HSV curves; the curve replaces the channel value, via one RGB→HSV→RGB round trip.
- **Lightness** — a curve on CIELAB L\*, via an sRGB→Lab→sRGB round trip.

The Hue/Saturation/Lightness remap curves live in LUT row 1 (256×2 RGBA8 total); the color-space conversions run per pixel in `curves.wgsl`. The color-component stage is bit-exact for identity (`LUT[i] == i`) so it always runs; the HSV and Lab stages are gated by `_active` flags (armed only for non-identity curves), so an all-identity Curves layer is a byte-for-byte no-op.

### Compositor wiring
A per-layer `filter_caches` map (keyed by `LayerId`, with a `Vec<ParamValue>` change-detection fingerprint) builds/refreshes the LUT + gate uniform in the pre-compose `sync_projection_states` phase — the one place with both `device` and `queue` — over a new `Document::all_filter_layers()` walk, and prunes entries for removed layers. The compose walk (`compose_filter_arm`) merely binds the cache; the destructive `filter_node_region` path routes through `FilterEffect::render` with a transient empty cache.

### Engine / undo / protocol
- `update_filter_params` (+ a new `update_filter_params` protocol handler, regenerated into `protocol_gen.ts`) with `Property::FilterParams` coalesced undo — a curve drag is one undo step.
- Schema-aware `add_filter_layer`: a curves layer created with `{}` gets eight identity curves.
- `filter_types()` and `LayerInfo::Filter` now carry the param schema + values.
- `apply_filter` excludes any filter with a non-empty param schema, keeping parametric filters out of the destructive one-click Colors menu.

### Frontend
New `FilterProperties.svelte` renders scalar params generically and groups a filter's curve params under one channel `<select>` + `<CurveEditor>`, so all eight channels surface automatically. A **Reset** button below the editor resets the selected channel to identity through the same undoable path. Composite acronym channels render uppercase (`rgb` → "RGB") via a small `channelLabel` helper. The curve/scalar split (`partitionFilterParams`) and the label helper are pure and unit-tested.

### Tests
- Rust unit (identity LUT on both rows, composite∘channel fold order, composite-not-on-alpha, HSL gate flags), document round-trip (all eight curves).
- Engine (eight identity curves on add, param-edit + undo restore, destructive-path exclusion).
- GPU (identity ⇒ bit-unchanged; composite curve halves color; Hue curve rotates blue→green; Lightness curve darkens a neutral gray on L\*).
- Frontend vitest for `partitionFilterParams` and `channelLabel`.
- README "Features & Roadmap" Curves entry flipped to `[x]`.

All gates pass: `cargo fmt`, clippy (workspace + wasm), `cargo test` (full darkly suite), `tsc --noEmit`, and vitest (301 passed).
