### PR TITLE
Frontend Bugfixes + Tool Session

### DIFF
--- a/frontend/src/actions/clipboard.ts
+++ b/frontend/src/actions/clipboard.ts
@@ -4,6 +4,7 @@ import { config } from '../config/store.svelte';
 import { brushGraph } from '../state/brush_graph.svelte';
 import { copyToSystemClipboard, readImageFromClipboard, readLayerFromClipboard } from '../clipboard';
 import { toolRegistry, type ToolContext } from '../tools/registry';
+import { beginToolSession } from '../tools/tool_session';
 import { screenToCanvas } from '../canvas/coordinates';
 
 /** Switch to the transform tool after a paste so the freshly-floated layer is
@@ -16,8 +17,13 @@ function enterTransformTool() {
     app.activeToolId = 'transform';
     if (wasTransform && app.engine && app.canvasEl) {
         const canvasEl = app.canvasEl;
+        // The CanvasView tool-change effect no-ops on a same-tool switch, so it
+        // won't begin a fresh session for us. Begin one here so transform's
+        // onActivate → activate() runs against a live session and picks up the
+        // just-pasted floating (see tool_session.ts).
+        const engine = beginToolSession(app.engine);
         const ctx: ToolContext = {
-            engine: app.engine,
+            engine,
             canvasEl,
             screenToCanvas: (sx: number, sy: number) => screenToCanvas(sx, sy, canvasEl),
         };

--- a/frontend/src/canvas/CanvasView.svelte
+++ b/frontend/src/canvas/CanvasView.svelte
@@ -6,6 +6,7 @@
     import { nav } from './navigation.svelte';
     import { toolRegistry } from '../tools/registry';
     import type { ToolContext } from '../tools/registry';
+    import { beginToolSession, toolEngine, runHook } from '../tools/tool_session';
     import { screenToCanvas } from './coordinates';
     import { toast } from '../state/toast.svelte';
     import { theme } from '../state/theme.svelte';
@@ -161,9 +162,14 @@
 
 
     function getToolContext(): ToolContext | null {
-        if (!inst.engine) return null;
+        // Tool code reaches the engine only through the live tool session, never
+        // `inst.engine` directly — so a request that resolves after the session
+        // dies (tool switch, layer change, tab swap) rejects instead of touching
+        // stale state. See `tools/tool_session.ts`.
+        const engine = toolEngine();
+        if (!engine) return null;
         return {
-            engine: inst.engine,
+            engine,
             canvasEl: canvas,
             screenToCanvas(sx: number, sy: number) {
                 return screenToCanvas(sx, sy, canvas);
@@ -194,7 +200,7 @@
                 const ctx = getToolContext();
                 if (ctx) {
                     const tool = toolRegistry.get(inst.activeToolId);
-                    tool?.onPointerUp(ctx, e);
+                    void runHook(tool?.onPointerUp(ctx, e));
                 }
                 return;
             }
@@ -219,7 +225,7 @@
         canvas.setPointerCapture(e.pointerId);
 
         if (!ctx) return;
-        tool?.onPointerDown(ctx, e, pos.x, pos.y);
+        void runHook(tool?.onPointerDown(ctx, e, pos.x, pos.y));
         // Mark a tool interaction in flight so autosave doesn't snapshot
         // mid-stroke. Released in onPointerUp / onPointerCancel (pointer
         // capture guarantees one of them fires on this element).
@@ -271,7 +277,7 @@
         // that needs `pollPick` to commit on the next frame.
         if (!isColorPickerModifierActive()) {
             const tool = toolRegistry.get(inst.activeToolId);
-            tool?.onPointerMove(ctx, e, pos.x, pos.y);
+            void runHook(tool?.onPointerMove(ctx, e, pos.x, pos.y));
         }
         inst.requestFrame();
     }
@@ -295,7 +301,7 @@
         const ctx = getToolContext();
         if (!ctx) return;
         const tool = toolRegistry.get(inst.activeToolId);
-        tool?.onPointerUp(ctx, e);
+        void runHook(tool?.onPointerUp(ctx, e));
         inst.requestFrame();
     }
 
@@ -316,7 +322,7 @@
         const ctx = getToolContext();
         if (!ctx) return;
         const tool = toolRegistry.get(inst.activeToolId);
-        tool?.onPointerUp(ctx, e);
+        void runHook(tool?.onPointerUp(ctx, e));
         inst.requestFrame();
     }
 
@@ -324,7 +330,7 @@
         const ctx = getToolContext();
         if (!ctx) return;
         const tool = toolRegistry.get(inst.activeToolId);
-        tool?.onPointerLeave?.(ctx);
+        void runHook(tool?.onPointerLeave?.(ctx));
         inst.requestFrame();
     }
 
@@ -356,35 +362,49 @@
         if (nav.spaceHeld || MODIFIER_KEYS.has(e.key)) return;
         const tool = toolRegistry.get(inst.activeToolId);
         if (tool?.onKeyDown?.(e)) return;
-        tool?.dismissOverlay?.();
+        void runHook(tool?.dismissOverlay?.());
         inst.requestFrame();
     }
 
-    // Call onDeactivate/onActivate when the active tool changes.
+    // Call onDeactivate/onActivate when the active tool changes. This is one of
+    // the ~3 sites that own the tool session's lifecycle (see tool_session.ts):
+    // the outgoing tool is deactivated through its still-alive session, then a
+    // fresh session is begun for the incoming tool. `inst.engine` is read
+    // directly so the effect re-runs once the engine finishes async init.
     let prevToolId = '';
     $effect(() => {
         const id = inst.activeToolId;
-        if (id !== prevToolId) {
-            const ctx = getToolContext();
-            if (ctx) {
-                // Reset before deactivate so a tool's onDeactivate can still
-                // override; whatever the new tool's onActivate sets wins.
-                inst.toolCursor = null;
-                toolRegistry.get(prevToolId)?.onDeactivate?.(ctx);
-                toolRegistry.get(id)?.onActivate?.(ctx);
-                prevToolId = id;
-            }
-        }
+        const engine = inst.engine;
+        if (id === prevToolId || !engine) return;
+        // Reset before deactivate so a tool's onDeactivate can still override;
+        // whatever the new tool's onActivate sets wins.
+        inst.toolCursor = null;
+        // Deactivate through the outgoing session (its synchronous commit/detach
+        // posts must land on the session that's still alive).
+        const prevCtx = getToolContext();
+        if (prevCtx) toolRegistry.get(prevToolId)?.onDeactivate?.(prevCtx);
+        // Begin a fresh session for the incoming tool, killing the old one — any
+        // op parked on an await from the previous tool now rejects on resume.
+        beginToolSession(engine);
+        const nextCtx = getToolContext();
+        if (nextCtx) toolRegistry.get(id)?.onActivate?.(nextCtx);
+        prevToolId = id;
     });
 
-    // Dismiss tool overlay when the active layer changes.
+    // Dismiss tool overlay when the active layer changes. Rebinding the session
+    // first kills the outgoing one, so an op parked on an await from before the
+    // change rejects instead of resuming against the new layer; dismissOverlay
+    // then runs on the fresh (alive) session and can still finalize in-flight
+    // work (e.g. commit a floating being moved). This is what makes wrong-layer
+    // resumption unrepresentable too.
     let prevLayerId: number | null = null;
     $effect(() => {
         const id = inst.activeLayerId;
         if (id !== prevLayerId) {
             prevLayerId = id;
+            if (inst.engine) beginToolSession(inst.engine);
             const tool = toolRegistry.get(inst.activeToolId);
-            tool?.dismissOverlay?.();
+            void runHook(tool?.dismissOverlay?.());
         }
     });
 

--- a/frontend/src/canvas/gpu_overlay.ts
+++ b/frontend/src/canvas/gpu_overlay.ts
@@ -25,7 +25,7 @@ import {
     FLAG_CANVAS_SPACE, prim,
     type GpuPrim,
 } from '../tools/selection_helpers';
-import type { Engine } from '../engine/protocol';
+import type { EngineRequests } from '../engine/protocol';
 import { app } from '../state/app.svelte';
 
 // ---------------------------------------------------------------------------
@@ -140,7 +140,7 @@ export class OverlayBuilder {
     }
 
     /** Convert to GPU primitives and push to the overlay system. */
-    push(engine: Engine): void {
+    push(engine: EngineRequests): void {
         const dpr = window.devicePixelRatio || 1;
         const prims: GpuPrim[] = [];
 
@@ -178,7 +178,7 @@ export class OverlayBuilder {
     }
 
     /** Clear the GPU overlay. */
-    clear(engine: Engine): void {
+    clear(engine: EngineRequests): void {
         engine.post('clear_overlay');
         app.requestFrame();
     }

--- a/frontend/src/engine/protocol.ts
+++ b/frontend/src/engine/protocol.ts
@@ -18,6 +18,17 @@ export function reportEngineError(e: unknown): void {
     console.error('[engine] request failed:', err?.kind ?? 'error', err?.message ?? e);
 }
 
+/** The request surface of the engine: `send` (awaited) and `post`
+ *  (fire-and-forget). Both {@link Engine} and the tool-session wrapper
+ *  `SessionEngine` (`tools/tool_session.ts`) satisfy this shape. Helpers that
+ *  only issue requests should accept this rather than the concrete `Engine`, so
+ *  a session-scoped caller can hand in its cancellation-aware wrapper without a
+ *  type mismatch. */
+export interface EngineRequests {
+    send<T = any>(kind: RequestKind, payload?: object, bytes?: Uint8Array): Promise<T>;
+    post(kind: RequestKind, payload?: object, bytes?: Uint8Array): void;
+}
+
 interface Pending {
     resolve: (value: any) => void;
     reject: (reason: EngineError) => void;

--- a/frontend/src/state/app.svelte.ts
+++ b/frontend/src/state/app.svelte.ts
@@ -3,6 +3,7 @@ import type { SaveBundle } from '../storage/saveDocument';
 import { compute_view_matrices } from '../../wasm/pkg/darkly_wasm';
 import { toolRegistry } from '../tools/registry';
 import { pollPick } from '../tools/color_pick_sync';
+import { beginToolSession, killToolSession, runHook } from '../tools/tool_session';
 import { tickColorPickerCursor } from '../tools/colorpicker_cursor';
 import { MediaStreamSource, describeMediaError, type CaptureKind } from '../lib/mediaStreamSource';
 
@@ -969,8 +970,10 @@ export class DarklyInstance {
             // changes) and document bools.
             if (frame.state) this.engineState = frame.state;
 
-            // Per-frame tool hook — async state sync (e.g. GPU readback completion).
-            toolRegistry.get(this.activeToolId)?.onFrame?.();
+            // Per-frame tool hook — async state sync (e.g. GPU readback
+            // completion). Wrapped so a hook whose engine op was cancelled by a
+            // session change mid-await settles cleanly (see tool_session.ts).
+            void runHook(toolRegistry.get(this.activeToolId)?.onFrame?.());
 
             // Global color-pick poll — drives both the color-picker tool and
             // the modifier-held `sampleColor` chord. Runs regardless of active
@@ -1050,6 +1053,17 @@ let activeInstance = $state<DarklyInstance | null>(null);
  *  `app.<x>` (because the proxy's getter reads the `$state` `activeInstance`,
  *  threading the dependency through). */
 export function setActiveInstance(inst: DarklyInstance | null) {
+    // Rebind the tool session to the newly-focused instance. This kills the
+    // outgoing session (any tool op parked on an await now rejects on resume
+    // instead of landing on the wrong tab) and starts a fresh one over the new
+    // tab's engine — necessary because every tab's `<CanvasView>` stays mounted
+    // across a focus switch, so the tool/layer effects that normally begin a
+    // session don't re-fire. When the new instance has no engine yet (the
+    // single-instance boot call, before `initEditor` sets it), leave the session
+    // severed; the tool effect begins it once the engine is ready.
+    // See tool_session.ts.
+    if (inst?.engine) beginToolSession(inst.engine);
+    else killToolSession();
     activeInstance = inst;
 }
 

--- a/frontend/src/tools/__tests__/tool_session.test.ts
+++ b/frontend/src/tools/__tests__/tool_session.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+    SessionEngine,
+    ToolSessionCancelled,
+    beginToolSession,
+    killToolSession,
+    toolEngine,
+    runHook,
+} from '../tool_session';
+
+/** A deferred promise so a `send` can be parked, then resolved after a kill. */
+function deferred<T>() {
+    let resolve!: (v: T) => void;
+    let reject!: (e: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+    killToolSession();
+});
+
+describe('SessionEngine.send', () => {
+    it('resolves normally while the session is alive', async () => {
+        const inner = { send: vi.fn(() => Promise.resolve({ value: 7 })), post: vi.fn() };
+        const session = new SessionEngine(inner as never);
+        await expect(session.send('has_floating')).resolves.toEqual({ value: 7 });
+        expect(inner.send).toHaveBeenCalledWith('has_floating', undefined, undefined);
+    });
+
+    it('rejects an in-flight send with ToolSessionCancelled once killed', async () => {
+        const gate = deferred<{ value: boolean }>();
+        const inner = { send: vi.fn(() => gate.promise), post: vi.fn() };
+        const session = new SessionEngine(inner as never);
+
+        const p = session.send('has_floating');
+        // The world changes while the request is parked.
+        session.kill();
+        gate.resolve({ value: true });
+
+        await expect(p).rejects.toBeInstanceOf(ToolSessionCancelled);
+    });
+
+    it('drops a post issued after kill', () => {
+        const inner = { send: vi.fn(), post: vi.fn() };
+        const session = new SessionEngine(inner as never);
+
+        session.post('clear_overlay');
+        expect(inner.post).toHaveBeenCalledTimes(1);
+
+        session.kill();
+        session.post('clear_overlay');
+        // Still 1 — the post-kill call was dropped.
+        expect(inner.post).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('session registry', () => {
+    it('beginToolSession installs the live session and kills the prior one', async () => {
+        const inner = { send: vi.fn(() => Promise.resolve('ok')), post: vi.fn() };
+
+        const first = beginToolSession(inner as never);
+        expect(toolEngine()).toBe(first);
+
+        const parked = first.send('has_floating'); // in flight on the first session
+        const second = beginToolSession(inner as never);
+        expect(toolEngine()).toBe(second);
+
+        // Beginning the second session killed the first, so its parked op rejects.
+        await expect(parked).rejects.toBeInstanceOf(ToolSessionCancelled);
+        // The new session is alive.
+        await expect(second.send('has_floating')).resolves.toBe('ok');
+    });
+
+    it('killToolSession leaves no live session', () => {
+        beginToolSession({ send: vi.fn(), post: vi.fn() } as never);
+        killToolSession();
+        expect(toolEngine()).toBeNull();
+    });
+});
+
+describe('runHook', () => {
+    it('swallows ToolSessionCancelled', async () => {
+        await expect(runHook(Promise.reject(new ToolSessionCancelled()))).resolves.toBeUndefined();
+    });
+
+    it('re-throws any other error', async () => {
+        const boom = new Error('boom');
+        await expect(runHook(Promise.reject(boom))).rejects.toBe(boom);
+    });
+
+    it('passes through a resolved (or sync) hook', async () => {
+        await expect(runHook(undefined)).resolves.toBeUndefined();
+        await expect(runHook(Promise.resolve(42))).resolves.toBeUndefined();
+    });
+});

--- a/frontend/src/tools/__tests__/transform_binding_cancel.test.ts
+++ b/frontend/src/tools/__tests__/transform_binding_cancel.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // The void binding captures the pre-edit transform — INCLUDING its mode — on
 // first read, so cancelling reverts faithfully. Engine transport is mocked.
@@ -9,7 +9,15 @@ const { fakeApp } = vi.hoisted(() => {
 vi.mock('../../state/app.svelte', () => ({ app: fakeApp }));
 
 import { voidTransformBinding } from '../transform_bindings';
+import { beginToolSession } from '../tool_session';
 import type { Mat3 } from '../transform_projective';
+
+// The bindings reach the engine through the live tool session; establish one
+// over the fake engine so `toolEngine()` resolves (its send/post delegate to
+// the fake's spies).
+beforeEach(() => {
+    beginToolSession(fakeApp.engine as never);
+});
 
 describe('voidTransformBinding cancel preserves the original mode', () => {
     it('reverts a void that was already perspective to mode 1, not affine', async () => {

--- a/frontend/src/tools/__tests__/transform_dismiss.test.ts
+++ b/frontend/src/tools/__tests__/transform_dismiss.test.ts
@@ -2,15 +2,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Minimal stand-ins for the Svelte-runic state proxy and the gizmo, so the
 // race in `dismissOverlay` can be driven without the Svelte/GPU runtime.
-const { engine, fakeApp, gizmo, TransformGizmoMock } = vi.hoisted(() => {
+const { engine, fakeApp, gizmo, TransformGizmoMock, resolveHasFloating } = vi.hoisted(() => {
+    let resolve: (v: { value: boolean }) => void = () => {};
     const engine = {
+        // has_floating is deferred so dismissOverlay parks on its await, giving
+        // the test a window to tear the tool down before it resolves.
         send: vi.fn((kind: string) => {
-            if (kind === 'has_floating') return Promise.resolve({ value: true });
-            // A target layer that does NOT match activeLayerId, so dismissOverlay
-            // falls through to the commit at the end (the crash site).
+            if (kind === 'has_floating') return new Promise<{ value: boolean }>((r) => (resolve = r));
+            // A target layer that does NOT match activeLayerId, so a resumed
+            // dismissOverlay would fall through to the commit at the end.
             if (kind === 'floating_target_layer') return Promise.resolve({ id: 999 });
             return Promise.resolve({});
         }),
+        post: vi.fn(),
     };
     const fakeApp = {
         engine,
@@ -21,7 +25,7 @@ const { engine, fakeApp, gizmo, TransformGizmoMock } = vi.hoisted(() => {
     const TransformGizmoMock = vi.fn(function () {
         return gizmo;
     });
-    return { engine, fakeApp, gizmo, TransformGizmoMock };
+    return { engine, fakeApp, gizmo, TransformGizmoMock, resolveHasFloating: () => resolve({ value: true }) };
 });
 vi.mock('../../state/app.svelte', () => ({ app: fakeApp }));
 vi.mock('../transform_gizmo', () => ({ TransformGizmo: TransformGizmoMock }));
@@ -31,6 +35,7 @@ vi.mock('../transform_bindings', () => ({
 }));
 
 import { transformTool } from '../transform.svelte';
+import { beginToolSession, killToolSession, runHook, ToolSessionCancelled } from '../tool_session';
 
 const ctx = { canvasEl: {} } as never;
 
@@ -42,28 +47,38 @@ beforeEach(() => {
     gizmo.commit.mockClear();
     engine.send.mockClear();
     fakeApp.activeLayerId = 1;
+    beginToolSession(engine as never);
 });
 
 /**
- * Regression: `dismissOverlay` is async and awaits two engine round-trips. A
- * tool switch / layer change can run `onDeactivate` (which commits and nulls
- * the gizmo) before those awaits resolve. The resumed `dismissOverlay` must not
- * dereference the now-null gizmo, nor commit a second time.
+ * Regression: `dismissOverlay` is async and awaits engine round-trips. A tool
+ * switch / layer change tears the tool down (onDeactivate commits + nulls the
+ * gizmo) AND kills the tool session in the same synchronous moment. The parked
+ * dismissOverlay must then reject via the dead session — unwinding before it can
+ * dereference the now-null gizmo or commit a second time — and that rejection is
+ * a `ToolSessionCancelled` that the dispatcher's `runHook` swallows.
  */
-describe('transform dismissOverlay race with onDeactivate', () => {
-    it('does not throw or double-commit when deactivated mid-await', async () => {
+describe('transform dismissOverlay race with session teardown', () => {
+    it('rejects with ToolSessionCancelled instead of double-committing', async () => {
         transformTool.onActivate?.(ctx);
 
-        // Start the dismissal; its awaits are still pending at this point.
+        // Start the dismissal; it parks on the deferred has_floating.
         const pending = transformTool.dismissOverlay!() as unknown as Promise<void>;
 
-        // Tool gets torn down before the awaits resolve.
+        // Tool torn down before the await resolves: onDeactivate commits once and
+        // nulls the gizmo; the session dies alongside it.
         transformTool.onDeactivate?.(ctx);
+        killToolSession();
         expect(gizmo.commit).toHaveBeenCalledTimes(1); // onDeactivate's own commit
 
-        // Resuming dismissOverlay must be a no-op, not a TypeError.
-        await expect(pending).resolves.toBeUndefined();
+        // The deferred read now resolves — but on a dead session, so the resumed
+        // dismissOverlay rejects rather than reaching its final commit.
+        resolveHasFloating();
+        await expect(pending).rejects.toBeInstanceOf(ToolSessionCancelled);
         await flush();
         expect(gizmo.commit).toHaveBeenCalledTimes(1); // no double-commit
+
+        // Wrapped by the dispatcher's runHook, that same rejection settles cleanly.
+        await expect(runHook(Promise.reject(new ToolSessionCancelled()))).resolves.toBeUndefined();
     });
 });

--- a/frontend/src/tools/__tests__/transform_entry_mode.test.ts
+++ b/frontend/src/tools/__tests__/transform_entry_mode.test.ts
@@ -45,6 +45,7 @@ vi.mock('../../canvas/gpu_overlay', () => ({
 }));
 
 import { transformTool, transformPerspectiveTool, transformActiveMode } from '../transform.svelte';
+import { beginToolSession } from '../tool_session';
 
 const ctx = { canvasEl: {} as HTMLCanvasElement } as never;
 
@@ -57,6 +58,9 @@ async function activate(tool: typeof transformTool) {
 describe('transform cluster entry modes', () => {
     beforeEach(() => {
         fakeApp.engine.post.mockClear();
+        // Tool code reaches the engine through the live session (see
+        // tool_session.ts); begin one over the fake engine.
+        beginToolSession(fakeApp.engine as never);
     });
 
     it('the free transform tool engages in mode 0 (adopts the document default)', async () => {

--- a/frontend/src/tools/__tests__/transform_gizmo_commit_race.test.ts
+++ b/frontend/src/tools/__tests__/transform_gizmo_commit_race.test.ts
@@ -28,6 +28,7 @@ vi.mock('../transform_modes', () => ({
 }));
 
 import { TransformGizmo } from '../transform_gizmo';
+import { beginToolSession } from '../tool_session';
 
 function deferred<T>() {
     let resolve!: (v: T) => void;
@@ -46,6 +47,9 @@ const INFO = {
 beforeEach(() => {
     pushSpy.mockClear();
     engine.post.mockClear();
+    // The gizmo pushes/clears its overlay through the live tool session; begin
+    // one over the fake engine so `toolEngine()` resolves.
+    beginToolSession(engine as never);
 });
 
 /**
@@ -83,7 +87,8 @@ describe('transform gizmo commit during in-flight frame read', () => {
         // ...the user presses Enter mid-read: commit clears the gizmo.
         gizmo.commit();
         expect(gizmo.active).toBe(false);
-        expect(engine.post).toHaveBeenCalledWith('clear_overlay');
+        // Routed through the session wrapper, so trailing payload/bytes ride along.
+        expect(engine.post.mock.calls.some((c) => c[0] === 'clear_overlay')).toBe(true);
 
         // The stale read resolves. The overlay must stay cleared.
         gate.resolve(INFO);

--- a/frontend/src/tools/__tests__/transform_menu.test.ts
+++ b/frontend/src/tools/__tests__/transform_menu.test.ts
@@ -50,6 +50,7 @@ import {
     transformActiveMode,
     setTransformMode,
 } from '../transform.svelte';
+import { beginToolSession } from '../tool_session';
 
 const ctx = { canvasEl: {} as HTMLCanvasElement } as never;
 
@@ -64,6 +65,9 @@ describe('transform right-click mode menu', () => {
     beforeEach(() => {
         fakeApp.transformModeMenu = null;
         fakeApp.engine.post.mockClear();
+        // Tool code reaches the engine through the live session (see
+        // tool_session.ts); begin one over the fake engine.
+        beginToolSession(fakeApp.engine as never);
     });
 
     it('right-click inside the bbox opens the mode menu at the cursor', async () => {

--- a/frontend/src/tools/__tests__/transform_perspective_entry.test.ts
+++ b/frontend/src/tools/__tests__/transform_perspective_entry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Stand-ins for the Svelte state proxy + GPU overlay builder so the gizmo's
 // lifecycle runs without the Svelte/GPU/DOM runtime. The transform-mode
@@ -20,8 +20,16 @@ vi.mock('../../canvas/gpu_overlay', () => ({
 
 import { TransformGizmo } from '../transform_gizmo';
 import { mat3Apply, type Mat3 } from '../transform_projective';
+import { beginToolSession } from '../tool_session';
 
 const IDENTITY_MAT3: Mat3 = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+
+// The gizmo pushes/clears its overlay through the live tool session; establish
+// one over the fake engine so `toolEngine()` resolves and the overlay (and thus
+// the bbox that `isInside` reads) is built.
+beforeEach(() => {
+    beginToolSession(fakeApp.engine as never);
+});
 
 function makeBinding(live = false) {
     return {

--- a/frontend/src/tools/__tests__/transform_session_race.test.ts
+++ b/frontend/src/tools/__tests__/transform_session_race.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Drives the transform tool's async hooks against a mocked engine + gizmo to
+// prove the tool-session mechanism (tool_session.ts) makes "resume into a
+// changed world" unrepresentable: a parked engine read routed through a session
+// that dies mid-await rejects with ToolSessionCancelled, unwinding the hook
+// before it can dereference a nulled gizmo or drive an op on the wrong layer.
+const { engine, fakeApp, gizmo, TransformGizmoMock, deferrals } = vi.hoisted(() => {
+    const deferrals: Record<string, { resolve: (v: unknown) => void }> = {};
+    const engine = {
+        // Each kind may be answered eagerly (Promise.resolve) or parked via a
+        // per-kind deferral the test resolves by name.
+        send: vi.fn((kind: string) => {
+            if (kind === 'layer_transform_capability' && deferrals.cap)
+                return new Promise((r) => (deferrals.cap.resolve = r as never));
+            if (kind === 'has_floating' && deferrals.hf)
+                return new Promise((r) => (deferrals.hf.resolve = r as never));
+            if (kind === 'layer_transform_capability') return Promise.resolve({ value: 'none' });
+            if (kind === 'has_floating') return Promise.resolve({ value: false });
+            return Promise.resolve({});
+        }),
+        post: vi.fn(),
+    };
+    const fakeApp = {
+        engine,
+        activeLayerId: 5 as number | null,
+        requestFrame: vi.fn(),
+        transformModeMenu: null as unknown,
+    };
+    const gizmo = {
+        active: false,
+        commit: vi.fn(),
+        attach: vi.fn(() => Promise.resolve(true)),
+        frame: vi.fn(() => Promise.resolve()),
+    };
+    const TransformGizmoMock = vi.fn(function () {
+        return gizmo;
+    });
+    return { engine, fakeApp, gizmo, TransformGizmoMock, deferrals };
+});
+vi.mock('../../state/app.svelte', () => ({ app: fakeApp }));
+vi.mock('../transform_gizmo', () => ({ TransformGizmo: TransformGizmoMock }));
+vi.mock('../transform_bindings', () => ({
+    floatingTransformBinding: () => ({ kind: 'floating' }),
+    voidTransformBinding: (id: number) => ({ kind: 'void', id }),
+}));
+
+import { transformTool } from '../transform.svelte';
+import {
+    beginToolSession,
+    killToolSession,
+    toolEngine,
+    ToolSessionCancelled,
+} from '../tool_session';
+
+const ctx = { canvasEl: {} } as never;
+
+async function flush() {
+    for (let i = 0; i < 6; i++) await Promise.resolve();
+}
+
+beforeEach(() => {
+    engine.send.mockClear();
+    engine.post.mockClear();
+    gizmo.commit.mockClear();
+    gizmo.attach.mockClear();
+    gizmo.frame.mockClear();
+    gizmo.active = false;
+    fakeApp.activeLayerId = 5;
+    delete deferrals.cap;
+    delete deferrals.hf;
+    killToolSession();
+});
+
+/**
+ * Regression for the reported crash (`Cannot read properties of null (reading
+ * 'frame')` in transform.onFrame): onFrame awaits an engine read, and a tool
+ * switch runs onDeactivate (nulling the gizmo) + kills the session during that
+ * await. The resumed read must reject via the dead session BEFORE the
+ * `await gizmo.frame()` deref — so onFrame rejects with ToolSessionCancelled,
+ * never a TypeError. (has_floating resolves `false`, so absent the session
+ * reject the resumed onFrame would fall straight through to the null deref.)
+ */
+describe('transform onFrame resumes into a torn-down tool', () => {
+    it('rejects with ToolSessionCancelled instead of dereferencing a null gizmo', async () => {
+        deferrals.hf = { resolve: () => {} };
+        beginToolSession(engine as never);
+        // onActivate seeds the module gizmo; its own activate() sees cap 'none'
+        // (eager) and no-ops.
+        transformTool.onActivate?.(ctx);
+        await flush();
+
+        gizmo.active = false;
+        const framePromise = transformTool.onFrame!() as unknown as Promise<void>;
+        await flush(); // parked on the deferred has_floating
+
+        // Tool switch: onDeactivate commits + nulls the gizmo; the session dies.
+        transformTool.onDeactivate?.(ctx);
+        killToolSession();
+
+        deferrals.hf.resolve({ value: false });
+
+        await expect(framePromise).rejects.toBeInstanceOf(ToolSessionCancelled);
+        expect(gizmo.frame).not.toHaveBeenCalled();
+    });
+});
+
+/**
+ * Regression for wrong-layer resumption: activate() captures the active layer
+ * before its first await. If the active layer changes (and the session is
+ * rebegun) while activate is parked, the captured op must NOT proceed against
+ * the stale layer — the old session's next send rejects, so no `begin_transform`
+ * / attach fires.
+ */
+describe('transform activate resumes after an active-layer change', () => {
+    it('does not begin_transform/attach for the layer captured before the change', async () => {
+        deferrals.cap = { resolve: () => {} };
+        deferrals.hf = { resolve: () => {} };
+        beginToolSession(engine as never);
+
+        // activate() (via onActivate) captures layerId = 5, then parks on the
+        // capability read.
+        transformTool.onActivate?.(ctx);
+        await flush();
+
+        // Capability resolves 'destructive' while the session is still alive, so
+        // activate advances to the has_floating read...
+        deferrals.cap.resolve({ value: 'destructive' });
+        await flush();
+
+        // ...the active layer changes and the session is rebegun (as the
+        // CanvasView layer-change effect does), killing the old session.
+        fakeApp.activeLayerId = 6;
+        beginToolSession(engine as never);
+        expect(toolEngine()).not.toBeNull();
+
+        // The parked has_floating read now resolves — but on the dead session, so
+        // activate unwinds without issuing begin_transform or attaching.
+        deferrals.hf.resolve({ value: false });
+        await flush();
+
+        const beganTransform = engine.send.mock.calls.some((c) => c[0] === 'begin_transform');
+        expect(beganTransform).toBe(false);
+        expect(gizmo.attach).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/tools/brush.svelte.ts
+++ b/frontend/src/tools/brush.svelte.ts
@@ -1,5 +1,5 @@
 import type { Tool } from './registry';
-import type { Engine } from '../engine/protocol';
+import type { EngineRequests } from '../engine/protocol';
 import { app } from '../state/app.svelte';
 import { brushGraph } from '../state/brush_graph.svelte';
 import { srgbToLinear } from '../lib/color';
@@ -86,14 +86,19 @@ let lastHover: { cx: number; cy: number; pose: PenPose } | null = null;
  *  when a stroke begins could otherwise land its `set_overlay` *after*
  *  pointerdown's `clear_overlay`, freezing a ghost dab on-canvas for the whole
  *  stroke. Capturing the generation before the await and re-checking after lets
- *  an invalidated hover bail instead of overtaking the clear. */
+ *  an invalidated hover bail instead of overtaking the clear.
+ *
+ *  This is a finer-grained sibling of `tool_session.ts`: that primitive
+ *  invalidates on session boundaries (tool switch, layer change, tab swap);
+ *  `hoverGen` also invalidates on *stroke start* within the same session, a
+ *  boundary a tool session doesn't draw — so it stays. */
 let hoverGen = 0;
 
 /** Refresh the on-canvas brush cursor preview at `(cx, cy)` using the
  *  given pose. Exported so non-brush callers (e.g. the shift+drag size
  *  scrub, which uses `cursorPose` so the circle shows the brush's full
  *  extent) can keep the preview in sync after mutating the graph. */
-export async function pushHoverOverlay(engine: Engine, pose: PenPose, cx: number, cy: number) {
+export async function pushHoverOverlay(engine: EngineRequests, pose: PenPose, cx: number, cy: number) {
     const gen = hoverGen;
     const info = (await engine.send('refresh_brush_cursor_preview', {
         x: cx,
@@ -132,7 +137,7 @@ export async function pushHoverOverlay(engine: Engine, pose: PenPose, cx: number
  *  if the pointer isn't currently hovering the canvas (no cached
  *  pose). Used by hotkey-driven brush-param changes so the on-canvas
  *  preview reflects the new value without requiring pointer motion. */
-export function refreshHoverOverlay(engine: Engine) {
+export function refreshHoverOverlay(engine: EngineRequests) {
     if (!lastHover) return;
     void pushHoverOverlay(engine, lastHover.pose, lastHover.cx, lastHover.cy);
 }

--- a/frontend/src/tools/color_pick_sync.ts
+++ b/frontend/src/tools/color_pick_sync.ts
@@ -1,4 +1,4 @@
-import type { Engine } from '../engine/protocol';
+import type { EngineRequests } from '../engine/protocol';
 import { app } from '../state/app.svelte';
 import { config } from '../config/store.svelte';
 
@@ -19,7 +19,7 @@ let pollInFlight = false;
  *  and current-layer sampling. The Rust side falls back to the merged
  *  composite when the current-layer source can't resolve (group, mask, point
  *  outside layer extent), so this never silently no-ops. */
-export function startPick(engine: Engine, cx: number, cy: number): void {
+export function startPick(engine: EngineRequests, cx: number, cy: number): void {
     const mode = config.get('tools.colorPickerSampleSource');
     const layerId =
         mode === 'currentLayer' && app.activeLayerId != null ? app.activeLayerId : -1;

--- a/frontend/src/tools/colorpicker_cursor.ts
+++ b/frontend/src/tools/colorpicker_cursor.ts
@@ -1,5 +1,6 @@
 import { app, type Color } from '../state/app.svelte';
 import { toolRegistry } from './registry';
+import { toolEngine } from './tool_session';
 import { screenToCanvas } from '../canvas/coordinates';
 import { effectiveMouseClicks } from '../actions/triggers';
 import { parseBinding } from '../actions/hotkey_resolve';
@@ -342,10 +343,11 @@ function disengage(): void {
         // not implementing `restoreHover`.
         const tool = toolRegistry.get(app.activeToolId);
         const canvasEl = app.canvasEl;
-        if (tool?.restoreHover && app.engine && canvasEl && lastCanvas) {
+        const engine = toolEngine();
+        if (tool?.restoreHover && engine && canvasEl && lastCanvas) {
             tool.restoreHover(
                 {
-                    engine: app.engine,
+                    engine,
                     canvasEl,
                     screenToCanvas: (sx, sy) => screenToCanvas(sx, sy, canvasEl),
                 },

--- a/frontend/src/tools/registry.ts
+++ b/frontend/src/tools/registry.ts
@@ -1,8 +1,12 @@
-import type { Engine } from '../engine/protocol';
+import type { SessionEngine } from './tool_session';
 import type { Component } from 'svelte';
 
 export interface ToolContext {
-    engine: Engine;
+    /** The engine bound to the current tool session — not the raw `Engine`. A
+     *  request that resolves after the session dies rejects with
+     *  `ToolSessionCancelled`, so tool code never resumes into a changed world.
+     *  See `tool_session.ts`. */
+    engine: SessionEngine;
     canvasEl: HTMLCanvasElement;
     screenToCanvas: (screenX: number, screenY: number) => { x: number; y: number };
 }

--- a/frontend/src/tools/tool_session.ts
+++ b/frontend/src/tools/tool_session.ts
@@ -1,0 +1,113 @@
+/**
+ * Tool-session-scoped engine access — the primitive that makes "an async tool
+ * op resumes into a changed world" unrepresentable.
+ *
+ * The problem it solves: a tool hook parks on an `await` (an engine round-trip),
+ * and while it's suspended the world changes underneath it — the tool is
+ * switched, the active layer changes, or (multi-tab) the focused instance swaps.
+ * The same synchronous moment that invalidates the session also nulls the
+ * tool's module-level state (its gizmo, its placement). On resume the hook
+ * dereferences state that died with the session, or drives an engine op against
+ * the wrong layer/tab.
+ *
+ * The fix is a capability, not a discipline: a tool reaches the engine only
+ * through the *current* {@link SessionEngine}. A dead session's `send` rejects
+ * with {@link ToolSessionCancelled} the instant its response lands, unwinding
+ * the caller before it can touch state that no longer belongs to it. So:
+ *
+ *   Reaching any line after an `await` proves the session is still alive — which
+ *   proves the module state is still valid. No per-call-site guard is needed;
+ *   the await *is* the check.
+ *
+ * The events that invalidate a session are owned by the dispatcher in ~3 places
+ * (tool change / active-layer change in `CanvasView.svelte`, instance swap in
+ * `setActiveInstance`), never per-tool.
+ *
+ * Residual: cancellation is automatic only for awaits routed through the session
+ * engine. In today's transform tooling *every* await crosses the engine
+ * (directly or via a gizmo/binding), so it's fully covered. A future hook that
+ * awaits a *non*-engine promise (a timer, a `fetch`) would not auto-cancel — it
+ * must re-check `toolEngine()` on resume, or route its wait through the engine.
+ * A finer-grained sibling of this idiom is the brush tool's `hoverGen`, which
+ * invalidates on stroke start too — a tighter boundary than a whole session.
+ */
+import type { Engine, EngineRequests, RequestKind } from '../engine/protocol';
+
+/** Thrown by a dead session's `send` when its response resolves. Swallowed by
+ *  {@link runHook} at the dispatcher's hook call sites — a cancelled op is a
+ *  no-op, not an error. */
+export class ToolSessionCancelled extends Error {
+    constructor() {
+        super('tool session cancelled');
+        this.name = 'ToolSessionCancelled';
+    }
+}
+
+/** A thin, cancellation-aware wrapper over the real {@link Engine}, bound to one
+ *  tool session. Tool code holds no direct `Engine` reference — it goes through
+ *  the live session, so the resource itself enforces safety. */
+export class SessionEngine implements EngineRequests {
+    #inner: Engine;
+    #alive = true;
+
+    constructor(inner: Engine) {
+        this.#inner = inner;
+    }
+
+    /** Sever this session. In-flight `send`s reject on resume; new `post`s drop. */
+    kill(): void {
+        this.#alive = false;
+    }
+
+    /** Awaited request. Resolves normally only if the session is still alive
+     *  when the response lands; otherwise rejects with {@link ToolSessionCancelled},
+     *  unwinding the caller before it can touch state that died with the session.
+     *  This is the one cancellation point — there is no per-call-site guard
+     *  anywhere else. */
+    send<T = any>(kind: RequestKind, payload?: object, bytes?: Uint8Array): Promise<T> {
+        return this.#inner.send<T>(kind, payload, bytes).then((v) => {
+            if (!this.#alive) throw new ToolSessionCancelled();
+            return v;
+        });
+    }
+
+    /** Fire-and-forget request. A dead session drops it — its effect is moot. */
+    post(kind: RequestKind, payload?: object, bytes?: Uint8Array): void {
+        if (this.#alive) this.#inner.post(kind, payload, bytes);
+    }
+}
+
+/** The single live tool session — global, matching today's module-level tool
+ *  state (one gizmo shared across tabs). */
+let current: SessionEngine | null = null;
+
+/** Start a fresh session over `engine`, killing any prior one. Returns the new
+ *  session so a caller can address it directly (e.g. an `onActivate` binding). */
+export function beginToolSession(engine: Engine): SessionEngine {
+    current?.kill();
+    return (current = new SessionEngine(engine));
+}
+
+/** Kill the live session, if any, and leave none. */
+export function killToolSession(): void {
+    current?.kill();
+    current = null;
+}
+
+/** The live session's engine, or `null` when no tool session is active. */
+export function toolEngine(): SessionEngine | null {
+    return current;
+}
+
+/** Run an async hook, swallowing {@link ToolSessionCancelled} (and only that —
+ *  real errors still propagate). Applied by the dispatcher at each hook call
+ *  site: a hook whose op was cancelled mid-flight settles cleanly instead of
+ *  surfacing a rejection. Accepts sync hooks too (they wrap trivially). */
+export function runHook(result: unknown): Promise<void> {
+    return Promise.resolve(result).then(
+        () => {},
+        (e) => {
+            if (!(e instanceof ToolSessionCancelled)) throw e;
+        },
+    );
+}

--- a/frontend/src/tools/transform.svelte.ts
+++ b/frontend/src/tools/transform.svelte.ts
@@ -19,6 +19,7 @@
  */
 import type { Tool, ToolContext } from './registry';
 import { app } from '../state/app.svelte';
+import { toolEngine, runHook } from './tool_session';
 import { TransformGizmo } from './transform_gizmo';
 import { floatingTransformBinding, voidTransformBinding } from './transform_bindings';
 
@@ -54,19 +55,28 @@ function applyEntryMode(): void {
     if (entryMode !== 0) gizmo?.setMode(entryMode);
 }
 
-/** Resolve the selected layer's capability and attach the matching binding. */
+/** Resolve the selected layer's capability and attach the matching binding.
+ *
+ *  Engine access is routed through the tool session, and `layerId` is captured
+ *  *before* the first await: reaching any line past an await proves the session
+ *  survived — same layer, same tool, same tab — so the captured id is still the
+ *  one being transformed. A layer/tool/tab change mid-sequence kills the session,
+ *  and the next `send` rejects with `ToolSessionCancelled` (swallowed upstream),
+ *  so we never attach a binding to a layer that's no longer active. */
 async function activate(): Promise<void> {
-    if (!gizmo || !app.engine || app.activeLayerId == null) return;
-    const { value: cap } = await app.engine.send<{ value: string }>('layer_transform_capability', {
-        id: app.activeLayerId,
+    const engine = toolEngine();
+    if (!gizmo || !engine || app.activeLayerId == null) return;
+    const layerId = app.activeLayerId;
+    const { value: cap } = await engine.send<{ value: string }>('layer_transform_capability', {
+        id: layerId,
     });
     if (cap === 'live') {
-        if (await gizmo.attach(voidTransformBinding(app.activeLayerId))) applyEntryMode();
+        if (await gizmo.attach(voidTransformBinding(layerId))) applyEntryMode();
     } else if (cap === 'destructive') {
         // Floating extract may resolve asynchronously (content-bounds readback);
         // if it isn't ready this frame, `onFrame` picks it up once it is.
-        if (!(await app.engine.send<{ value: boolean }>('has_floating')).value) {
-            await app.engine.send('begin_transform', { id: app.activeLayerId });
+        if (!(await engine.send<{ value: boolean }>('has_floating')).value) {
+            await engine.send('begin_transform', { id: layerId });
         }
         if (await gizmo.attach(floatingTransformBinding())) applyEntryMode();
     }
@@ -91,7 +101,10 @@ function createTransformTool(opts: {
         onActivate(ctx: ToolContext) {
             gizmo = new TransformGizmo(ctx.canvasEl);
             entryMode = opts.entry;
-            void activate();
+            // Fire-and-forget: if the session dies mid-activate (a rapid re-switch
+            // or layer change), activate() rejects with ToolSessionCancelled —
+            // swallow it here since onActivate can't await it.
+            void runHook(activate());
         },
 
         onDeactivate() {
@@ -148,12 +161,18 @@ function createTransformTool(opts: {
 
         async onFrame() {
             if (!gizmo) return;
+            const engine = toolEngine();
             // Pick up an async floating extract once its content-bounds readback
             // lands (begin_transform may defer a frame). Never auto-attaches
             // voids — those attach explicitly via activate(), so Enter/Escape
             // can end the session without it immediately reappearing.
-            if (!gizmo.active && app.engine) {
-                if ((await app.engine.send<{ value: boolean }>('has_floating')).value) {
+            //
+            // The engine read is session-routed: if a tool/layer/tab change ran
+            // `onDeactivate` (nulling `gizmo`) mid-await, the resumed `send`
+            // rejects and unwinds here — so the `gizmo` deref below can't hit
+            // null. No stopgap re-check needed.
+            if (!gizmo.active && engine) {
+                if ((await engine.send<{ value: boolean }>('has_floating')).value) {
                     if (await gizmo.attach(floatingTransformBinding())) applyEntryMode();
                 }
             }
@@ -162,20 +181,20 @@ function createTransformTool(opts: {
 
         async dismissOverlay() {
             if (!gizmo) return;
-            if (app.engine && (await app.engine.send<{ value: boolean }>('has_floating')).value) {
+            const engine = toolEngine();
+            if (engine && (await engine.send<{ value: boolean }>('has_floating')).value) {
                 // Activating the floating's own target layer (e.g.
                 // paste-as-floating creates a new layer and selects it) is part
                 // of the floating workflow, not a user-switched-away signal.
-                const { id } = await app.engine.send<{ id: number }>('floating_target_layer');
+                const { id } = await engine.send<{ id: number }>('floating_target_layer');
                 if (id >= 0 && id === app.activeLayerId) {
                     return;
                 }
             }
-            // The awaits above can outlive the gizmo: a tool switch or layer
-            // change may run onDeactivate (which already commits) and null it out
-            // before we resume. Re-check so we neither dereference null nor
-            // double-commit.
-            gizmo?.commit();
+            // Reaching here past the session-routed awaits proves the session
+            // (and thus `gizmo`) is still alive, so this commit is safe and
+            // single: a tool/layer change mid-await would have rejected above.
+            gizmo.commit();
         },
     };
 }

--- a/frontend/src/tools/transform_bindings.ts
+++ b/frontend/src/tools/transform_bindings.ts
@@ -11,7 +11,7 @@
  *   before `read()` returns non-null.
  * - `voidTransformBinding` — a void's live, persistent transform property.
  */
-import { app } from '../state/app.svelte';
+import { toolEngine } from './tool_session';
 import { affineToMat3, mat3ToAffine, type Mat3 } from './transform_projective';
 import type { TransformBinding } from './transform_gizmo';
 
@@ -36,7 +36,7 @@ export function floatingTransformBinding(): TransformBinding {
     return {
         live: false,
         async read() {
-            const raw = await app.engine?.send<
+            const raw = await toolEngine()?.send<
                 { ox: number; oy: number; w: number; h: number; mode: number; matrix: number[] } | null
             >('floating_info');
             if (!raw) return null;
@@ -49,16 +49,16 @@ export function floatingTransformBinding(): TransformBinding {
             };
         },
         update(matrix: Mat3, modeTag: number) {
-            app.engine?.post('update_floating_matrix', {
+            toolEngine()?.post('update_floating_matrix', {
                 mode_tag: modeTag,
                 payload: wirePayload(matrix, modeTag),
             });
         },
         commit() {
-            app.engine?.post('commit_floating');
+            toolEngine()?.post('commit_floating');
         },
         cancel() {
-            app.engine?.post('cancel_floating');
+            toolEngine()?.post('cancel_floating');
         },
     };
 }
@@ -75,7 +75,7 @@ export function voidTransformBinding(layerId: number): TransformBinding {
     return {
         live: true,
         async read() {
-            const raw = await app.engine?.send<
+            const raw = await toolEngine()?.send<
                 { ox: number; oy: number; w: number; h: number; mode: number; matrix: number[] } | null
             >('void_transform_info', { id: layerId });
             if (!raw) return null;
@@ -90,7 +90,7 @@ export function voidTransformBinding(layerId: number): TransformBinding {
             };
         },
         update(matrix: Mat3, modeTag: number) {
-            app.engine?.post('update_void_transform', {
+            toolEngine()?.post('update_void_transform', {
                 id: layerId,
                 mode_tag: modeTag,
                 payload: wirePayload(matrix, modeTag),
@@ -101,7 +101,7 @@ export function voidTransformBinding(layerId: number): TransformBinding {
         },
         cancel() {
             if (original) {
-                app.engine?.post('update_void_transform', {
+                toolEngine()?.post('update_void_transform', {
                     id: layerId,
                     mode_tag: original.mode,
                     payload: wirePayload(original.matrix, original.mode),

--- a/frontend/src/tools/transform_gizmo.ts
+++ b/frontend/src/tools/transform_gizmo.ts
@@ -13,6 +13,7 @@
  * live updates are fire-and-forget through the binding.
  */
 import { app } from '../state/app.svelte';
+import { toolEngine } from './tool_session';
 import { OverlayBuilder } from '../canvas/gpu_overlay';
 import { MAT3_IDENTITY, type Mat3 } from './transform_projective';
 import {
@@ -200,10 +201,11 @@ export class TransformGizmo {
     }
 
     private rebuildOverlay(): void {
-        if (!app.engine) return;
+        const engine = toolEngine();
+        if (!engine) return;
         const o = new OverlayBuilder(this.canvasEl);
         this.bbox = this.mode.buildOverlay(this.geo, o);
-        o.push(app.engine);
+        o.push(engine);
         this.overlay = o;
     }
 
@@ -212,7 +214,7 @@ export class TransformGizmo {
         this.drag = null;
         this.bbox = null;
         this.overlay = null;
-        app.engine?.post('clear_overlay');
+        toolEngine()?.post('clear_overlay');
         app.toolCursor = null;
     }
 }


### PR DESCRIPTION
Fixes a rare but annoying class of bug.

---

## Make "an async tool op resumes into a changed world" unrepresentable

Fixes a null-deref crash in `transform.svelte.ts` (`Cannot read properties of null (reading 'frame')`): `onFrame` checks the module-level `gizmo`, `await`s an engine round-trip, and during that yield a tool/layer change runs `onDeactivate` synchronously and nulls `gizmo`; on resume it dereferences null. That crash is one face of a class — a tool hook parked on an `await` resumes touching state (its gizmo, the active layer, the focused tab) that changed underneath it.

Rather than a "guard after every await" discipline, engine access is bound to the tool session so the `await` *is* the check.

### New primitive — `tools/tool_session.ts`
- `SessionEngine`: a thin wrapper over `Engine`. `send` resolves normally only if the session is still alive when the response lands, else rejects with `ToolSessionCancelled`; `post` drops on a dead session.
- `beginToolSession` / `killToolSession` / `toolEngine()` manage the single live session (matching today's module-global tool state).
- `runHook(p)`: swallows `ToolSessionCancelled` (and only that) — applied at the dispatcher's hook call sites.

### Lifecycle owned by the dispatcher (~3 sites)
- `CanvasView.svelte` tool-change `$effect`: deactivate through the outgoing (still-alive) session, then `beginToolSession` for the incoming tool. Reads `inst.engine` directly so the effect re-fires once async init sets it.
- `CanvasView.svelte` layer-change `$effect`: rebind the session (kills the old) before `dismissOverlay`, so a parked op rejects instead of resuming on the new layer.
- `state/app.svelte.ts` `setActiveInstance`: rebind the session to the newly-focused instance's engine — every tab's `<CanvasView>` stays mounted across a focus switch, so the tool/layer effects don't re-fire.
- Pointer hooks + per-frame `onFrame` dispatch wrapped in `runHook`.

### The rule that replaces the discipline
Tool code reaches the engine only through the session — `ctx.engine` (now a `SessionEngine`) or `toolEngine()`, never `app.engine`. Applied to `transform.svelte.ts` (active-layer id captured before the first await; the stopgap `gizmo?.` guards and "awaits can outlive the gizmo" comment blocks removed), `transform_gizmo.ts`, `transform_bindings.ts`, and the color-picker `restoreHover` path. `clipboard.ts`'s manual transform re-activation and the brush's `hoverGen` idiom are reconciled with the new mechanism.

A shared `EngineRequests` interface (`engine/protocol.ts`) — `send` + `post` — lets both `Engine` and `SessionEngine` satisfy the request-only helpers (`startPick`, `pushHoverOverlay`, `OverlayBuilder.push`/`clear`).

### Tests
- `tool_session.test.ts`: `send` resolves while alive; an in-flight `send` rejects with `ToolSessionCancelled` after `kill()`; `post` drops after `kill()`; registry + `runHook` behavior.
- `transform_session_race.test.ts`: the `onFrame` crash regression (parked read + torn-down gizmo + killed session ⇒ rejects instead of dereferencing null), and wrong-layer (active layer flips mid-`activate()` ⇒ no `begin_transform`/attach for the stale layer).
- Existing transform tests updated to establish a tool session over their fake engine.

Frontend-only; no Rust touched. `tsc --noEmit`, `vite build`, and `vitest` (311 tests) all pass.
