### PR TITLE
Styling improvements

### DIFF
--- a/crates/darkly/src/engine/brush_graph.rs
+++ b/crates/darkly/src/engine/brush_graph.rs
@@ -530,40 +530,13 @@ impl DarklyEngine {
             return cached.unwrap_or_default();
         }
 
-        let fg = self.preview_theme_fg;
-        let bg = self.preview_theme_bg;
-
-        // Neutralize ports flagged `preview_value` (paint.size,
-        // watercolor.size, …) on a clone so the stroke preview matches the
-        // brush picker's tile-shape thumbnail: size-invariant, fits
-        // the fixed render canvas regardless of the user's working
-        // scrubs. Same generalization the dab path relies on via
-        // `reset_exposed_scrubs`; both previews show brush identity,
-        // not momentary parameter state. Per-node knowledge about
-        // what to neutralize lives on the port registrations — this
-        // pipeline doesn't introspect node types.
-        let mut graph = self.active_brush_graph();
-        graph.apply_preview_overrides();
-        let (rw, rh) = super::brush_library::BRUSH_STROKE_RENDER_SIZE;
-        let path = crate::brush::preview_renderer::synthesize_stroke_path(
-            rw as f32,
-            rh as f32,
-            30,
-            super::brush_library::BRUSH_STROKE_PATH_INSET,
-        );
-        self.render_preview_and_request_readback(
-            &graph,
-            &path,
-            rw,
-            rh,
-            fg,
-            bg,
+        self.request_stroke_preview_readback(self.active_brush_graph(), |width, height| {
             ReadbackContext::BrushStrokePreview {
-                width: rw,
-                height: rh,
+                width,
+                height,
                 graph_version: current_graph_version,
-            },
-        );
+            }
+        });
         self.last_rendered_stroke_preview_version = current_graph_version;
 
         cached.unwrap_or_default()
@@ -631,27 +604,11 @@ impl DarklyEngine {
             return cached.unwrap_or_default();
         }
 
-        let fg = self.preview_theme_fg;
-        let bg = self.preview_theme_bg;
-        // Reset every exposed scrub (size, opacity, hardness, …) to its
-        // registration default before rendering. The dab thumbnail
-        // represents the brush's identity (shape, texture, dynamics);
-        // user-facing scrubs belong in the brush bar, not the icon.
-        let mut graph = self.active_brush_graph();
-        crate::brush::reset_exposed_scrubs(&mut graph);
-        let (rw, rh) = super::brush_library::BRUSH_DAB_RENDER_SIZE;
-        let path = crate::brush::preview_renderer::synthesize_dab_path(rw as f32, rh as f32);
-        self.render_preview_and_request_readback(
-            &graph,
-            &path,
-            rw,
-            rh,
-            fg,
-            bg,
+        self.request_dab_preview_readback(self.active_brush_graph(), |_width, _height| {
             ReadbackContext::ActiveBrushDab {
                 topology_version: current_topology,
-            },
-        );
+            }
+        });
         self.last_rendered_dab_topology_version = current_topology;
 
         cached.unwrap_or_default()
@@ -726,6 +683,73 @@ impl DarklyEngine {
         );
         self.gpu.queue.submit([encoder.finish()]);
         self.readbacks.submit(request, context);
+    }
+
+    /// Neutralize the given graph's `preview_value` ports, lay the synthetic
+    /// S-curve at the proportional inset, and kick off a stroke-preview render
+    /// + readback tagged with the context built from the render dims.
+    ///
+    /// Shared by the live editor preview and both library thumbnail bakes —
+    /// the only things that differ across those three are which graph feeds in
+    /// and which [`ReadbackContext`] variant tags the result, which is why the
+    /// context is produced by the caller from the render dimensions.
+    ///
+    /// `apply_preview_overrides` makes every stroke preview size-invariant:
+    /// the tile-shape thumbnail, the save bake, and the editor preview all
+    /// show brush *identity*, not the momentary scrub value the user happened
+    /// to have. Per-node knowledge of what to neutralize lives on the port
+    /// registrations — this pipeline never introspects node types.
+    pub(crate) fn request_stroke_preview_readback(
+        &mut self,
+        mut graph: Graph<BrushWireType>,
+        make_context: impl FnOnce(u32, u32) -> ReadbackContext,
+    ) {
+        graph.apply_preview_overrides();
+        let (rw, rh) = super::brush_library::BRUSH_STROKE_RENDER_SIZE;
+        let inset =
+            rw.min(rh) as f32 * super::brush_library::BRUSH_STROKE_PATH_INSET_FRACTION;
+        let path =
+            crate::brush::preview_renderer::synthesize_stroke_path(rw as f32, rh as f32, 30, inset);
+        let fg = self.preview_theme_fg;
+        let bg = self.preview_theme_bg;
+        self.render_preview_and_request_readback(
+            &graph,
+            &path,
+            rw,
+            rh,
+            fg,
+            bg,
+            make_context(rw, rh),
+        );
+    }
+
+    /// Reset the given graph's exposed scrubs to their registration defaults,
+    /// synthesize a centered single dab, and kick off a dab-preview render +
+    /// readback tagged with the context built from the render dims.
+    ///
+    /// Shared by the baked dab thumbnail and the active-dab preview — they
+    /// differ only in the graph and the [`ReadbackContext`] variant. The dab
+    /// thumbnail represents brush identity (shape, texture, dynamics), so
+    /// user-facing scrubs that vary across instances shouldn't bias it.
+    pub(crate) fn request_dab_preview_readback(
+        &mut self,
+        mut graph: Graph<BrushWireType>,
+        make_context: impl FnOnce(u32, u32) -> ReadbackContext,
+    ) {
+        crate::brush::reset_exposed_scrubs(&mut graph);
+        let (rw, rh) = super::brush_library::BRUSH_DAB_RENDER_SIZE;
+        let path = crate::brush::preview_renderer::synthesize_dab_path(rw as f32, rh as f32);
+        let fg = self.preview_theme_fg;
+        let bg = self.preview_theme_bg;
+        self.render_preview_and_request_readback(
+            &graph,
+            &path,
+            rw,
+            rh,
+            fg,
+            bg,
+            make_context(rw, rh),
+        );
     }
 
     /// Serialize the active graph as JSON.

--- a/crates/darkly/src/engine/brush_graph.rs
+++ b/crates/darkly/src/engine/brush_graph.rs
@@ -706,8 +706,7 @@ impl DarklyEngine {
     ) {
         graph.apply_preview_overrides();
         let (rw, rh) = super::brush_library::BRUSH_STROKE_RENDER_SIZE;
-        let inset =
-            rw.min(rh) as f32 * super::brush_library::BRUSH_STROKE_PATH_INSET_FRACTION;
+        let inset = rw.min(rh) as f32 * super::brush_library::BRUSH_STROKE_PATH_INSET_FRACTION;
         let path =
             crate::brush::preview_renderer::synthesize_stroke_path(rw as f32, rh as f32, 30, inset);
         let fg = self.preview_theme_fg;

--- a/crates/darkly/src/engine/brush_library.rs
+++ b/crates/darkly/src/engine/brush_library.rs
@@ -10,26 +10,31 @@ use crate::brush::library::BrushInfo;
 /// preview so brushes look identical in the picker grid.
 pub(crate) const BRUSH_THUMBNAIL_SIZE: (u32, u32) = (320, 120);
 
-/// Render canvas for stroke previews. Sized once, statically, with
-/// enough headroom around `BRUSH_THUMBNAIL_SIZE` to fit endpoint dabs
-/// at the largest preview-time radius any port's `preview_value` allows
-/// (currently `paint.size` ≤ 0.1 → ≤ 26 px radius). The pipeline never
-/// inspects the brush graph to size this canvas — `apply_preview_overrides`
-/// has already neutralized any port that would otherwise blow it out.
-pub(crate) const BRUSH_STROKE_RENDER_SIZE: (u32, u32) = (384, 192);
+/// Render canvas for stroke previews. Generously oversized — not derived
+/// from any per-brush geometry. `apply_preview_overrides` neutralizes the
+/// preview-time size to a known cap (round base radius ≤ ~26 px), but a
+/// broad-nib tip can stretch that footprint ~10× via anisotropy (see
+/// `shape::extent`), so the canvas simply reserves enough clearance on every
+/// edge (≳ 300 px, see `BRUSH_STROKE_PATH_INSET_FRACTION`) that the
+/// neutralized preview stroke can never reach the border. The pipeline does
+/// not inspect the graph to size this; the changed-pixel crop in
+/// `frame_stroke_thumbnail` frames the actual inked region afterward.
+pub(crate) const BRUSH_STROKE_RENDER_SIZE: (u32, u32) = (1024, 768);
 
-/// Inset reserved on every edge of the stroke render canvas so endpoint
-/// dabs at the preview-time cap radius fit fully inside without
-/// touching the canvas border. Half the gap between the render canvas
-/// and the cache:  (384-320)/2 = 32  ≥  ceil(0.1 * 256) + safety.
-pub(crate) const BRUSH_STROKE_PATH_INSET: f32 = 32.0;
+/// Fraction of the smaller render-canvas edge reserved as a margin on every
+/// side when laying the synthetic S-curve. Proportional (not a hardcoded
+/// pixel count) so the clearance scales with the canvas — at
+/// `BRUSH_STROKE_RENDER_SIZE` this yields ≳ 300 px, enough for a worst-case
+/// anisotropic nib at the preview-time radius cap to stay clear of the
+/// border. The changed-pixel crop, not this value, decides the framed size.
+pub(crate) const BRUSH_STROKE_PATH_INSET_FRACTION: f32 = 0.4;
 
-/// Render canvas for dab previews. Square and oversized relative to
-/// what we cache — the readback handler bbox-crops the rendered dab and
-/// downscales to a stable cache size, so brushes with small `size`
-/// ports or with `scatter` displacement still produce a recognizable
-/// thumbnail (no truncation, auto-centered).
-pub(crate) const BRUSH_DAB_RENDER_SIZE: (u32, u32) = (256, 256);
+/// Render canvas for dab previews. Square and generously oversized for the
+/// same reason as `BRUSH_STROKE_RENDER_SIZE`: the readback handler
+/// bbox-crops the rendered dab and downscales to a stable cache size, so the
+/// canvas only needs enough headroom that no neutralized-size tip (including
+/// a broad calligraphy nib or a `scatter`-displaced dab) touches the border.
+pub(crate) const BRUSH_DAB_RENDER_SIZE: (u32, u32) = (768, 768);
 
 #[handlers]
 impl DarklyEngine {
@@ -74,35 +79,18 @@ impl DarklyEngine {
         self.snapshot_brush_defaults();
 
         // Kick off the thumbnail bake. Uses theme colors (not the active
-        // fg) so the picker grid looks consistent across brushes. Apply
-        // preview overrides so the saved brush thumbnails are size-
-        // invariant — the picker grid should show brush identity, not a
-        // snapshot of whatever scrub value the user happened to have
-        // when saving.
-        let fg = self.preview_theme_fg;
-        let bg = self.preview_theme_bg;
-        let mut graph = self.active_brush_graph();
-        graph.apply_preview_overrides();
-        let (rw, rh) = BRUSH_STROKE_RENDER_SIZE;
-        let path = crate::brush::preview_renderer::synthesize_stroke_path(
-            rw as f32,
-            rh as f32,
-            30,
-            BRUSH_STROKE_PATH_INSET,
-        );
-        self.render_preview_and_request_readback(
-            &graph,
-            &path,
-            rw,
-            rh,
-            fg,
-            bg,
+        // fg) so the picker grid looks consistent across brushes. The shared
+        // helper applies preview overrides so the saved brush thumbnails are
+        // size-invariant — the picker grid should show brush identity, not a
+        // snapshot of whatever scrub value the user happened to have when
+        // saving.
+        self.request_stroke_preview_readback(self.active_brush_graph(), |width, height| {
             ReadbackContext::BrushThumbnailForSave {
                 name: name.to_string(),
-                width: rw,
-                height: rh,
-            },
-        );
+                width,
+                height,
+            }
+        });
         Ok(())
     }
 
@@ -131,30 +119,13 @@ impl DarklyEngine {
         let Some(brush) = self.brush_library.get(name).cloned() else {
             return Vec::new();
         };
-        let fg = self.preview_theme_fg;
-        let bg = self.preview_theme_bg;
-        let mut graph = brush.metadata.graph.clone();
-        graph.apply_preview_overrides();
-        let (rw, rh) = BRUSH_STROKE_RENDER_SIZE;
-        let path = crate::brush::preview_renderer::synthesize_stroke_path(
-            rw as f32,
-            rh as f32,
-            30,
-            BRUSH_STROKE_PATH_INSET,
-        );
-        self.render_preview_and_request_readback(
-            &graph,
-            &path,
-            rw,
-            rh,
-            fg,
-            bg,
+        self.request_stroke_preview_readback(brush.metadata.graph.clone(), |width, height| {
             ReadbackContext::BrushThumbnailForSave {
                 name: name.to_string(),
-                width: rw,
-                height: rh,
-            },
-        );
+                width,
+                height,
+            }
+        });
         Vec::new()
     }
 
@@ -177,34 +148,19 @@ impl DarklyEngine {
         let Some(brush) = self.brush_library.get(name).cloned() else {
             return Vec::new();
         };
-        let (w, h) = BRUSH_DAB_RENDER_SIZE;
-        let fg = self.preview_theme_fg;
-        let bg = self.preview_theme_bg;
-        // Reset every exposed scrub (size, opacity, hardness, …) to its
-        // registration default before rendering — same treatment the
-        // active-dab preview applies. The dab thumbnail represents the
-        // brush's identity (shape, texture, dynamics), so user-facing
-        // scrubs that vary across instances of the same brush type
-        // shouldn't bias the picker icon. Keeping the two paths
-        // identical here also means `brush_dab_thumbnail(active_name)`
-        // and `brush_active_dab_preview()` produce byte-identical PNGs,
-        // so the picker tile and the BrushBar trigger always agree.
-        let mut graph = brush.metadata.graph.clone();
-        crate::brush::reset_exposed_scrubs(&mut graph);
-        let path = crate::brush::preview_renderer::synthesize_dab_path(w as f32, h as f32);
-        self.render_preview_and_request_readback(
-            &graph,
-            &path,
-            w,
-            h,
-            fg,
-            bg,
+        // The shared helper resets every exposed scrub (size, opacity,
+        // hardness, …) to its registration default before rendering — same
+        // treatment the active-dab preview applies. Keeping the two paths on
+        // one helper means `brush_dab_thumbnail(active_name)` and
+        // `brush_active_dab_preview()` produce byte-identical PNGs, so the
+        // picker tile and the BrushBar trigger always agree.
+        self.request_dab_preview_readback(brush.metadata.graph.clone(), |width, height| {
             ReadbackContext::BrushDabThumbnail {
                 name: name.to_string(),
-                width: w,
-                height: h,
-            },
-        );
+                width,
+                height,
+            }
+        });
         Vec::new()
     }
 

--- a/crates/darkly/src/engine/mod.rs
+++ b/crates/darkly/src/engine/mod.rs
@@ -1070,6 +1070,75 @@ impl DarklyEngine {
         self.brush_perf.dabs_placed as u64
     }
 
+    /// Blocking readback of the raw stroke-preview **render canvas** for the
+    /// active brush — the buffer *before* `frame_stroke_thumbnail` crops it.
+    /// Returns `(pixels, width, height)`. For test assertions only: lets a
+    /// test confirm the neutralized preview stroke stays clear of the render
+    /// border, i.e. no ink was clipped away before the changed-pixel crop
+    /// ever ran. Renders through the same neutralization + proportional-inset
+    /// path the async `request_stroke_preview_readback` uses.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn test_render_stroke_preview_canvas(&mut self) -> (Vec<u8>, u32, u32) {
+        let mut graph = self.active_brush_graph();
+        graph.apply_preview_overrides();
+        let (rw, rh) = brush_library::BRUSH_STROKE_RENDER_SIZE;
+        let inset = rw.min(rh) as f32 * brush_library::BRUSH_STROKE_PATH_INSET_FRACTION;
+        let path =
+            crate::brush::preview_renderer::synthesize_stroke_path(rw as f32, rh as f32, 30, inset);
+        self.test_render_preview_canvas(&graph, &path, rw, rh)
+    }
+
+    /// Blocking readback of the raw dab-preview **render canvas** for the
+    /// active brush — the buffer *before* `frame_dab_thumbnail` crops it.
+    /// Returns `(pixels, width, height)`. Same purpose and path as
+    /// [`Self::test_render_stroke_preview_canvas`], for the single-dab preview.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn test_render_dab_preview_canvas(&mut self) -> (Vec<u8>, u32, u32) {
+        let mut graph = self.active_brush_graph();
+        crate::brush::reset_exposed_scrubs(&mut graph);
+        let (rw, rh) = brush_library::BRUSH_DAB_RENDER_SIZE;
+        let path = crate::brush::preview_renderer::synthesize_dab_path(rw as f32, rh as f32);
+        self.test_render_preview_canvas(&graph, &path, rw, rh)
+    }
+
+    /// Shared body of the two preview-canvas test accessors: render the given
+    /// path with the theme colors into the preview renderer and block-read the
+    /// full render target back as unpadded RGBA8.
+    #[cfg(any(test, feature = "testing"))]
+    fn test_render_preview_canvas(
+        &mut self,
+        graph: &crate::nodegraph::Graph<BrushWireType>,
+        path: &[crate::brush::paint_info::PaintInformation],
+        rw: u32,
+        rh: u32,
+    ) -> (Vec<u8>, u32, u32) {
+        let fg = self.preview_theme_fg;
+        let bg = self.preview_theme_bg;
+        let texture = self
+            .brush_stroke_preview_renderer
+            .render_stroke(
+                &self.gpu.device,
+                &self.gpu.queue,
+                &self.brush_pipelines,
+                graph,
+                path,
+                fg,
+                bg,
+                rw,
+                rh,
+            )
+            .expect("preview render should return a texture");
+        let pixels = crate::gpu::test_utils::readback_texture(
+            &self.gpu.device,
+            &self.gpu.queue,
+            texture,
+            wgpu::TextureFormat::Rgba8Unorm,
+            rw,
+            rh,
+        );
+        (pixels, rw, rh)
+    }
+
     // -----------------------------------------------------------------
     // BrushState accessors — keep call sites compact.
     // -----------------------------------------------------------------

--- a/crates/darkly/src/engine/rendering.rs
+++ b/crates/darkly/src/engine/rendering.rs
@@ -1159,6 +1159,54 @@ const CURSOR_PREVIEW_TARGET_COVERAGE: f32 = 130.0 / 255.0;
 /// scale that amplifies noise.
 const CURSOR_PREVIEW_MAX_BOOST: f32 = 8.0;
 
+/// Tight bounding box of the pixels a caller deems "interesting", scanning
+/// an unpadded RGBA8 buffer of `width × height`. Returns `[min_x, min_y,
+/// max_x, max_y]` (inclusive) or `None` when no pixel qualifies.
+///
+/// This is the single CPU implementation of "bounding box of the changed
+/// pixels" — the same min/max reduction the GPU [`BboxReduction`] runs, on
+/// the CPU side of an already-read-back buffer. The two thumbnail framers
+/// pass a "differs from the theme bg" predicate; the cursor-preview coverage
+/// scan passes an alpha-threshold predicate. Keeping the scan in one place
+/// means a border/empty-region convention can't drift between the callers.
+///
+/// [`BboxReduction`]: crate::gpu::bbox::BboxReduction
+pub(crate) fn changed_pixels_bbox(
+    pixels: &[u8],
+    width: u32,
+    height: u32,
+    interesting: impl Fn([u8; 4]) -> bool,
+) -> Option<[u32; 4]> {
+    let mut min_x = width;
+    let mut min_y = height;
+    let mut max_x = 0u32;
+    let mut max_y = 0u32;
+    let mut found = false;
+    for y in 0..height {
+        for x in 0..width {
+            let i = ((y * width + x) * 4) as usize;
+            if interesting([pixels[i], pixels[i + 1], pixels[i + 2], pixels[i + 3]]) {
+                min_x = min_x.min(x);
+                min_y = min_y.min(y);
+                max_x = max_x.max(x);
+                max_y = max_y.max(y);
+                found = true;
+            }
+        }
+    }
+    found.then_some([min_x, min_y, max_x, max_y])
+}
+
+/// Predicate for [`changed_pixels_bbox`]: does an RGBA8 pixel differ from the
+/// solid `bg` on any RGB channel by more than `tol`? The tolerance
+/// accommodates the GPU's premultiplied-alpha rounding and any
+/// color-management drift while still catching a pale stroke against the bg.
+fn differs_from_bg(px: [u8; 4], bg: [u8; 3], tol: i32) -> bool {
+    (px[0] as i32 - bg[0] as i32).abs() > tol
+        || (px[1] as i32 - bg[1] as i32).abs() > tol
+        || (px[2] as i32 - bg[2] as i32).abs() > tol
+}
+
 /// Frame a rendered dab into a centered, content-fitted PNG.
 ///
 /// Generic across every brush — no per-brush logic. The procedure:
@@ -1189,45 +1237,16 @@ pub fn frame_dab_thumbnail(pixels: &[u8], width: u32, height: u32, bg: [f32; 4])
         (bg[1].clamp(0.0, 1.0) * 255.0).round() as u8,
         (bg[2].clamp(0.0, 1.0) * 255.0).round() as u8,
     ];
-    // Tolerance accommodates the GPU's premultiplied-alpha rounding
-    // and any color-management drift; tight enough to still pick up a
-    // pale stroke against the bg.
     const TOLERANCE: i32 = 12;
-
-    let mut min_x = width;
-    let mut min_y = height;
-    let mut max_x = 0u32;
-    let mut max_y = 0u32;
-    let mut found = false;
-    for y in 0..height {
-        for x in 0..width {
-            let i = ((y * width + x) * 4) as usize;
-            let dr = (pixels[i] as i32 - bg_u8[0] as i32).abs();
-            let dg = (pixels[i + 1] as i32 - bg_u8[1] as i32).abs();
-            let db = (pixels[i + 2] as i32 - bg_u8[2] as i32).abs();
-            if dr > TOLERANCE || dg > TOLERANCE || db > TOLERANCE {
-                if x < min_x {
-                    min_x = x;
-                }
-                if y < min_y {
-                    min_y = y;
-                }
-                if x > max_x {
-                    max_x = x;
-                }
-                if y > max_y {
-                    max_y = y;
-                }
-                found = true;
-            }
-        }
-    }
+    let bbox = changed_pixels_bbox(pixels, width, height, |px| {
+        differs_from_bg(px, bg_u8, TOLERANCE)
+    });
 
     let Some(src) = image::RgbaImage::from_raw(width, height, pixels.to_vec()) else {
         return Vec::new();
     };
 
-    let cropped = if found {
+    let cropped = if let Some([min_x, min_y, max_x, max_y]) = bbox {
         let bbox_w = max_x - min_x + 1;
         let bbox_h = max_y - min_y + 1;
         let raw_side = bbox_w.max(bbox_h);
@@ -1294,34 +1313,11 @@ pub(crate) fn cursor_preview_scale_from_mask(pixels: &[u8], width: u32, height: 
     // uses (matched against the bake's clear-to-zero, which makes the
     // "no content" pixel value 0 exactly).
     const TOLERANCE: u8 = 12;
-    let mut min_x = width;
-    let mut min_y = height;
-    let mut max_x = 0u32;
-    let mut max_y = 0u32;
-    let mut found = false;
-    for y in 0..height {
-        for x in 0..width {
-            let alpha = pixels[((y * width + x) * 4 + 3) as usize];
-            if alpha > TOLERANCE {
-                if x < min_x {
-                    min_x = x;
-                }
-                if y < min_y {
-                    min_y = y;
-                }
-                if x > max_x {
-                    max_x = x;
-                }
-                if y > max_y {
-                    max_y = y;
-                }
-                found = true;
-            }
-        }
-    }
-    if !found {
+    let Some([min_x, min_y, max_x, max_y]) =
+        changed_pixels_bbox(pixels, width, height, |px| px[3] > TOLERANCE)
+    else {
         return 1.0;
-    }
+    };
 
     let bbox_w = max_x - min_x + 1;
     let bbox_h = max_y - min_y + 1;
@@ -1389,41 +1385,15 @@ fn frame_stroke_thumbnail(
     // Same tolerance shape as frame_dab_thumbnail — accommodates
     // premultiplied-alpha rounding on the GPU side.
     const TOLERANCE: i32 = 12;
-
-    let mut min_x = src_w;
-    let mut min_y = src_h;
-    let mut max_x = 0u32;
-    let mut max_y = 0u32;
-    let mut found = false;
-    for y in 0..src_h {
-        for x in 0..src_w {
-            let i = ((y * src_w + x) * 4) as usize;
-            let dr = (pixels[i] as i32 - bg_u8[0] as i32).abs();
-            let dg = (pixels[i + 1] as i32 - bg_u8[1] as i32).abs();
-            let db = (pixels[i + 2] as i32 - bg_u8[2] as i32).abs();
-            if dr > TOLERANCE || dg > TOLERANCE || db > TOLERANCE {
-                if x < min_x {
-                    min_x = x;
-                }
-                if y < min_y {
-                    min_y = y;
-                }
-                if x > max_x {
-                    max_x = x;
-                }
-                if y > max_y {
-                    max_y = y;
-                }
-                found = true;
-            }
-        }
-    }
+    let bbox = changed_pixels_bbox(pixels, src_w, src_h, |px| {
+        differs_from_bg(px, bg_u8, TOLERANCE)
+    });
 
     let Some(src) = image::RgbaImage::from_raw(src_w, src_h, pixels.to_vec()) else {
         return Vec::new();
     };
 
-    let cropped = if found {
+    let cropped = if let Some([min_x, min_y, max_x, max_y]) = bbox {
         let bbox_w = max_x - min_x + 1;
         let bbox_h = max_y - min_y + 1;
         let target_aspect = dst_w as f32 / dst_h as f32;

--- a/crates/darkly/src/gpu/bbox.rs
+++ b/crates/darkly/src/gpu/bbox.rs
@@ -1,0 +1,143 @@
+//! Shared async "bounding box of interesting pixels" GPU reduction.
+//!
+//! A compute shader visits every texel, tests a caller-defined predicate, and
+//! folds the coordinates of any matching texel into a 16-byte atomic min/max
+//! buffer. After dispatch the buffer holds `[min_x, min_y, max_x, max_y]`; if
+//! `min_x > max_x` no texel matched. The result is read back asynchronously —
+//! no full-texture readback required.
+//!
+//! This module owns the machinery that every bbox caller shares: the atomic
+//! storage buffer + its `BOUNDS_INIT` seed, the staging buffer, the
+//! `div_ceil(16)` dispatch tiling, the `map_async` → poll → decode round-trip,
+//! and the "`min_x > max_x` ⇒ empty" convention. What stays per-caller is the
+//! *predicate* (a WGSL shader + bind-group layout) and the *post-processing*
+//! of the returned rect. [`DiffRectPass`](super::diff_rect::DiffRectPass) and
+//! [`ContentBoundsPass`](super::content_bounds::ContentBoundsPass) are thin
+//! wrappers over this primitive; the CPU-side twin lives in
+//! [`changed_pixels_bbox`](crate::engine::rendering::changed_pixels_bbox).
+
+/// Initial values for the atomic bounds buffer: min = MAX, max = 0.
+/// After dispatch, `min_x > max_x` means no texel matched the predicate.
+const BOUNDS_INIT: [u32; 4] = [u32::MAX, u32::MAX, 0, 0];
+
+/// Size of the atomic bounds / staging buffers: 4 × u32.
+const BOUNDS_BYTES: u64 = 16;
+
+/// The shared bbox-reduction machinery. Stateless — it only bundles the
+/// [`dispatch`](Self::dispatch) constructor for an in-flight [`PendingBbox`].
+pub struct BboxReduction;
+
+impl BboxReduction {
+    /// Seed the atomic storage buffer, let the caller build its bind group
+    /// over it (binding the caller's input textures + predicate params
+    /// alongside), dispatch `pipeline` over `width × height`, copy the result
+    /// into a staging buffer, and submit. Poll the returned handle with
+    /// [`PendingBbox::poll`].
+    ///
+    /// `make_bind_group` receives the freshly-created storage buffer so the
+    /// caller can bind it at whichever binding index its shader expects; the
+    /// caller owns everything else in the bind group (input textures, the
+    /// params uniform). The bind group retains its resources, so any params
+    /// buffer the closure creates may be dropped once it returns.
+    pub fn dispatch(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        pipeline: &wgpu::ComputePipeline,
+        make_bind_group: impl FnOnce(&wgpu::Buffer) -> wgpu::BindGroup,
+        width: u32,
+        height: u32,
+    ) -> PendingBbox {
+        let storage = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("bbox-storage"),
+            size: BOUNDS_BYTES,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: true,
+        });
+        {
+            let mut mapping = storage.slice(..).get_mapped_range_mut();
+            mapping.copy_from_slice(bytemuck::bytes_of(&BOUNDS_INIT));
+        }
+        storage.unmap();
+
+        let staging = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("bbox-staging"),
+            size: BOUNDS_BYTES,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let bind_group = make_bind_group(&storage);
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("bbox-reduction"),
+        });
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("bbox-reduction"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(pipeline);
+            pass.set_bind_group(0, Some(&bind_group), &[]);
+            pass.dispatch_workgroups(width.div_ceil(16), height.div_ceil(16), 1);
+        }
+        encoder.copy_buffer_to_buffer(&storage, 0, &staging, 0, BOUNDS_BYTES);
+        queue.submit([encoder.finish()]);
+
+        PendingBbox { staging, rx: None }
+    }
+}
+
+/// An in-flight bbox reduction awaiting its async buffer mapping.
+pub struct PendingBbox {
+    staging: wgpu::Buffer,
+    rx: Option<std::sync::mpsc::Receiver<Result<(), wgpu::BufferAsyncError>>>,
+}
+
+impl PendingBbox {
+    /// Poll for the reduced bbox.
+    ///
+    /// - `None` — still pending; call again next frame.
+    /// - `Some(None)` — no texel matched the predicate (empty result).
+    /// - `Some(Some([x, y, w, h]))` — the tight bounding box, converted from
+    ///   the shader's inclusive `[min, max]` to origin + size (`w = max - min
+    ///   + 1`). Coordinates are texel-local; callers translate as needed.
+    ///
+    /// Begins the async mapping on the first call, then nudges native backends
+    /// with a non-blocking `device.poll(Poll)` — never a blocking wait, so this
+    /// is safe on WebGPU/WASM.
+    pub fn poll(&mut self, device: &wgpu::Device) -> Option<Option<[u32; 4]>> {
+        if self.rx.is_none() {
+            let slice = self.staging.slice(..);
+            let (tx, rx) = std::sync::mpsc::sync_channel(1);
+            slice.map_async(wgpu::MapMode::Read, move |result| {
+                let _ = tx.send(result);
+            });
+            self.rx = Some(rx);
+        }
+
+        let _ = device.poll(wgpu::PollType::Poll);
+
+        match self.rx.as_ref().unwrap().try_recv().ok() {
+            Some(Ok(())) => {
+                let slice = self.staging.slice(..);
+                let mapped = slice.get_mapped_range();
+                let raw: [u32; 4] = *bytemuck::from_bytes(&mapped[..BOUNDS_BYTES as usize]);
+                drop(mapped);
+                self.staging.unmap();
+
+                let [min_x, min_y, max_x, max_y] = raw;
+                Some(if min_x <= max_x && min_y <= max_y {
+                    // +1 because max is an inclusive pixel coordinate.
+                    Some([min_x, min_y, max_x - min_x + 1, max_y - min_y + 1])
+                } else {
+                    None
+                })
+            }
+            Some(Err(e)) => {
+                log::error!("bbox reduction buffer mapping failed: {e}");
+                Some(None)
+            }
+            None => None,
+        }
+    }
+}

--- a/crates/darkly/src/gpu/content_bounds.rs
+++ b/crates/darkly/src/gpu/content_bounds.rs
@@ -8,12 +8,9 @@
 //! bounds. Bounds are invalidated on [`mark_dirty`](super::compositor::Compositor::mark_dirty)
 //! and recomputed lazily when a consumer requests them.
 
+use super::bbox::{BboxReduction, PendingBbox};
 use crate::layer::LayerId;
 use std::collections::HashMap;
-
-/// Initial values for the atomic bounds buffer: min = MAX, max = 0.
-/// If min_x > max_x after dispatch, the texture is fully transparent.
-const BOUNDS_INIT: [u32; 4] = [u32::MAX, u32::MAX, 0, 0];
 
 /// GPU compute pipeline + per-layer cache for content bounds.
 pub struct ContentBoundsPass {
@@ -34,8 +31,7 @@ pub struct ContentBoundsPass {
 struct PendingBounds {
     layer_id: LayerId,
     gen: u64,
-    staging: wgpu::Buffer,
-    rx: Option<std::sync::mpsc::Receiver<Result<(), wgpu::BufferAsyncError>>>,
+    bbox: PendingBbox,
 }
 
 /// Uniform buffer layout matching the shader's `Params` struct.
@@ -188,28 +184,6 @@ impl ContentBoundsPass {
             return;
         }
 
-        // Storage buffer for atomic results (16 bytes).
-        let storage_buf = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("content-bounds-storage"),
-            size: 16,
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
-            mapped_at_creation: true,
-        });
-        // Initialize: min = MAX, max = 0.
-        {
-            let mut mapping = storage_buf.slice(..).get_mapped_range_mut();
-            mapping.copy_from_slice(bytemuck::bytes_of(&BOUNDS_INIT));
-        }
-        storage_buf.unmap();
-
-        // Staging buffer for CPU readback (16 bytes).
-        let staging_buf = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("content-bounds-staging"),
-            size: 16,
-            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-
         // Params uniform.
         let params = Params {
             width,
@@ -229,50 +203,38 @@ impl ContentBoundsPass {
         }
         param_buf.unmap();
 
-        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("content-bounds-bg"),
-            layout: &self.bind_group_layout,
-            entries: &[
-                wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: wgpu::BindingResource::TextureView(texture_view),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 1,
-                    resource: storage_buf.as_entire_binding(),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 2,
-                    resource: param_buf.as_entire_binding(),
-                },
-            ],
-        });
-
-        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("content-bounds-compute"),
-        });
-
-        {
-            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
-                label: Some("content-bounds"),
-                timestamp_writes: None,
-            });
-            pass.set_pipeline(&self.pipeline);
-            pass.set_bind_group(0, Some(&bind_group), &[]);
-            let wg_x = width.div_ceil(16);
-            let wg_y = height.div_ceil(16);
-            pass.dispatch_workgroups(wg_x, wg_y, 1);
-        }
-
-        // Copy storage → staging for CPU readback.
-        encoder.copy_buffer_to_buffer(&storage_buf, 0, &staging_buf, 0, 16);
-        queue.submit([encoder.finish()]);
+        let bbox = BboxReduction::dispatch(
+            device,
+            queue,
+            &self.pipeline,
+            |storage| {
+                device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: Some("content-bounds-bg"),
+                    layout: &self.bind_group_layout,
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: wgpu::BindingResource::TextureView(texture_view),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: storage.as_entire_binding(),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 2,
+                            resource: param_buf.as_entire_binding(),
+                        },
+                    ],
+                })
+            },
+            width,
+            height,
+        );
 
         self.pending.push(PendingBounds {
             layer_id,
             gen,
-            staging: staging_buf,
-            rx: None,
+            bbox,
         });
     }
 
@@ -280,59 +242,23 @@ impl ContentBoundsPass {
     ///
     /// Returns the list of layer IDs whose bounds just became available.
     pub fn poll(&mut self, device: &wgpu::Device) -> Vec<LayerId> {
-        // Begin mapping for newly submitted requests.
-        for p in &mut self.pending {
-            if p.rx.is_none() {
-                let slice = p.staging.slice(..);
-                let (tx, rx) = std::sync::mpsc::sync_channel(1);
-                slice.map_async(wgpu::MapMode::Read, move |result| {
-                    let _ = tx.send(result);
-                });
-                p.rx = Some(rx);
-            }
-        }
-
-        if !self.pending.is_empty() {
-            let _ = device.poll(wgpu::PollType::Poll);
-        }
-
         let mut completed = Vec::new();
         let mut i = 0;
         while i < self.pending.len() {
-            let ready = self.pending[i]
-                .rx
-                .as_ref()
-                .and_then(|rx| rx.try_recv().ok());
-
-            match ready {
-                Some(Ok(())) => {
+            match self.pending[i].bbox.poll(device) {
+                Some(result) => {
                     let p = self.pending.swap_remove(i);
                     let current_gen = self.generation.get(&p.layer_id).copied().unwrap_or(0);
-
                     if p.gen == current_gen {
-                        // Read the 4× u32 result.
-                        let slice = p.staging.slice(..);
-                        let mapped = slice.get_mapped_range();
-                        let raw: [u32; 4] = *bytemuck::from_bytes(&mapped[..16]);
-                        drop(mapped);
-                        p.staging.unmap();
-
-                        let [min_x, min_y, max_x, max_y] = raw;
-                        if min_x <= max_x && min_y <= max_y {
-                            let bounds = [min_x, min_y, max_x - min_x + 1, max_y - min_y + 1];
+                        // `result` is already origin + size, or `None` when the
+                        // texture is fully transparent (no cached entry).
+                        if let Some(bounds) = result {
                             self.cached.insert(p.layer_id, bounds);
                         }
-                        // If min_x > max_x: fully transparent — no cached entry.
-
                         completed.push(p.layer_id);
-                    } else {
-                        // Stale result — generation changed since dispatch.
-                        p.staging.unmap();
                     }
-                }
-                Some(Err(e)) => {
-                    log::error!("content bounds buffer mapping failed: {e}");
-                    self.pending.swap_remove(i);
+                    // Stale result (generation changed since dispatch) → drop it.
+                    // Don't increment i — swap_remove moved the last element here.
                 }
                 None => {
                     i += 1;

--- a/crates/darkly/src/gpu/diff_rect.rs
+++ b/crates/darkly/src/gpu/diff_rect.rs
@@ -4,10 +4,12 @@
 //! canvas) and produces the tight bounding rect of all differing pixels using
 //! atomic min/max. Used at stroke end to determine the exact undo region
 //! without hand-tracking dab positions.
+//!
+//! The "differs from texture B" predicate + its two-texture bind group are all
+//! that's specific here; the atomic min/max machinery and async readback live
+//! in [`BboxReduction`](super::bbox::BboxReduction).
 
-/// Initial values for the atomic bounds buffer: min = MAX, max = 0.
-/// If min_x > max_x after dispatch, the textures are identical.
-const BOUNDS_INIT: [u32; 4] = [u32::MAX, u32::MAX, 0, 0];
+use super::bbox::{BboxReduction, PendingBbox};
 
 pub struct DiffRectPass {
     pipeline: wgpu::ComputePipeline,
@@ -16,8 +18,7 @@ pub struct DiffRectPass {
 }
 
 struct PendingDiff {
-    staging: wgpu::Buffer,
-    rx: Option<std::sync::mpsc::Receiver<Result<(), wgpu::BufferAsyncError>>>,
+    bbox: PendingBbox,
     /// Canvas-space extent of the layer at the time of `request`. Used to
     /// translate the shader's layer-local bounding rect back to canvas
     /// coords on `poll` — must be captured at request time so the result
@@ -131,28 +132,7 @@ impl DiffRectPass {
     ) {
         let width = layer_canvas_extent.width;
         let height = layer_canvas_extent.height;
-        // Storage buffer for atomic results (16 bytes).
-        let storage_buf = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("diff-rect-storage"),
-            size: 16,
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
-            mapped_at_creation: true,
-        });
-        {
-            let mut mapping = storage_buf.slice(..).get_mapped_range_mut();
-            mapping.copy_from_slice(bytemuck::bytes_of(&BOUNDS_INIT));
-        }
-        storage_buf.unmap();
 
-        // Staging buffer for CPU readback (16 bytes).
-        let staging_buf = device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("diff-rect-staging"),
-            size: 16,
-            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
-        });
-
-        // Params uniform.
         let params = Params { width, height };
         let param_buf = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("diff-rect-params"),
@@ -166,52 +146,40 @@ impl DiffRectPass {
         }
         param_buf.unmap();
 
-        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("diff-rect-bg"),
-            layout: &self.bind_group_layout,
-            entries: &[
-                wgpu::BindGroupEntry {
-                    binding: 0,
-                    resource: wgpu::BindingResource::TextureView(scratch_view),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 1,
-                    resource: wgpu::BindingResource::TextureView(current_view),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 2,
-                    resource: storage_buf.as_entire_binding(),
-                },
-                wgpu::BindGroupEntry {
-                    binding: 3,
-                    resource: param_buf.as_entire_binding(),
-                },
-            ],
-        });
-
-        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("diff-rect-compute"),
-        });
-
-        {
-            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
-                label: Some("diff-rect"),
-                timestamp_writes: None,
-            });
-            pass.set_pipeline(&self.pipeline);
-            pass.set_bind_group(0, Some(&bind_group), &[]);
-            let wg_x = width.div_ceil(16);
-            let wg_y = height.div_ceil(16);
-            pass.dispatch_workgroups(wg_x, wg_y, 1);
-        }
-
-        // Copy storage -> staging for CPU readback.
-        encoder.copy_buffer_to_buffer(&storage_buf, 0, &staging_buf, 0, 16);
-        queue.submit([encoder.finish()]);
+        let bbox = BboxReduction::dispatch(
+            device,
+            queue,
+            &self.pipeline,
+            |storage| {
+                device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: Some("diff-rect-bg"),
+                    layout: &self.bind_group_layout,
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: wgpu::BindingResource::TextureView(scratch_view),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: wgpu::BindingResource::TextureView(current_view),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 2,
+                            resource: storage.as_entire_binding(),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 3,
+                            resource: param_buf.as_entire_binding(),
+                        },
+                    ],
+                })
+            },
+            width,
+            height,
+        );
 
         self.pending = Some(PendingDiff {
-            staging: staging_buf,
-            rx: None,
+            bbox,
             layer_canvas_extent,
         });
     }
@@ -229,54 +197,15 @@ impl DiffRectPass {
     /// extent captured at [`request`](Self::request) time. The result
     /// therefore remains valid through layer growth between request and poll.
     pub fn poll(&mut self, device: &wgpu::Device) -> Option<Option<crate::coord::CanvasRect>> {
-        let pending = self.pending.as_mut()?;
-
-        // Begin mapping if not started.
-        if pending.rx.is_none() {
-            let slice = pending.staging.slice(..);
-            let (tx, rx) = std::sync::mpsc::sync_channel(1);
-            slice.map_async(wgpu::MapMode::Read, move |result| {
-                let _ = tx.send(result);
-            });
-            pending.rx = Some(rx);
-        }
-
-        let _ = device.poll(wgpu::PollType::Poll);
-
-        let ready = pending.rx.as_ref().unwrap().try_recv().ok();
-        match ready {
-            Some(Ok(())) => {
-                let p = self.pending.take().unwrap();
-                let slice = p.staging.slice(..);
-                let mapped = slice.get_mapped_range();
-                let raw: [u32; 4] = *bytemuck::from_bytes(&mapped[..16]);
-                drop(mapped);
-                p.staging.unmap();
-
-                let [min_x, min_y, max_x, max_y] = raw;
-                if min_x <= max_x && min_y <= max_y {
-                    // +1 because max is inclusive pixel coordinate.
-                    // Translate layer-local bounds to canvas coords using the
-                    // extent captured at request time.
-                    let canvas_x = p.layer_canvas_extent.origin.x + min_x as i32;
-                    let canvas_y = p.layer_canvas_extent.origin.y + min_y as i32;
-                    Some(Some(crate::coord::CanvasRect::from_xywh(
-                        canvas_x,
-                        canvas_y,
-                        max_x - min_x + 1,
-                        max_y - min_y + 1,
-                    )))
-                } else {
-                    // Textures are identical — no diff.
-                    Some(None)
-                }
-            }
-            Some(Err(e)) => {
-                log::error!("diff rect buffer mapping failed: {e}");
-                self.pending = None;
-                Some(None)
-            }
-            None => None,
-        }
+        // Still pending (no request, or the reduction hasn't landed) → None.
+        let ready = self.pending.as_mut()?.bbox.poll(device)?;
+        // The reduction landed — consume the request and map its texel-local
+        // rect into canvas coords via the extent captured at request time.
+        let pending = self.pending.take().unwrap();
+        Some(ready.map(|[x, y, w, h]| {
+            let canvas_x = pending.layer_canvas_extent.origin.x + x as i32;
+            let canvas_y = pending.layer_canvas_extent.origin.y + y as i32;
+            crate::coord::CanvasRect::from_xywh(canvas_x, canvas_y, w, h)
+        }))
     }
 }

--- a/crates/darkly/src/gpu/mod.rs
+++ b/crates/darkly/src/gpu/mod.rs
@@ -94,6 +94,7 @@ pub fn blit_region(
 
 pub mod apply_mask;
 pub mod atlas;
+pub mod bbox;
 pub mod blend;
 pub mod blend_mode;
 pub mod blend_modes;

--- a/crates/darkly/tests/brush_editor_preview.rs
+++ b/crates/darkly/tests/brush_editor_preview.rs
@@ -567,7 +567,9 @@ fn calligraphy_stroke_preview_not_clipped_against_render_border() {
 
     // Pin a black bg / white stroke so border ink is unambiguous.
     engine.set_preview_theme([1.0, 1.0, 1.0, 1.0], [0.0, 0.0, 0.0, 1.0]);
-    engine.brush_load("Calligraphy").expect("Calligraphy built-in");
+    engine
+        .brush_load("Calligraphy")
+        .expect("Calligraphy built-in");
     squash_active_brush_to_extreme_nib(&mut engine);
 
     let (pixels, w, h) = engine.test_render_stroke_preview_canvas();
@@ -589,7 +591,9 @@ fn calligraphy_dab_preview_not_clipped_against_render_border() {
     let mut engine = DarklyEngine::new(gpu, 1024, 768);
 
     engine.set_preview_theme([1.0, 1.0, 1.0, 1.0], [0.0, 0.0, 0.0, 1.0]);
-    engine.brush_load("Calligraphy").expect("Calligraphy built-in");
+    engine
+        .brush_load("Calligraphy")
+        .expect("Calligraphy built-in");
     squash_active_brush_to_extreme_nib(&mut engine);
 
     let (pixels, w, h) = engine.test_render_dab_preview_canvas();

--- a/crates/darkly/tests/brush_editor_preview.rs
+++ b/crates/darkly/tests/brush_editor_preview.rs
@@ -493,6 +493,109 @@ fn size_scrub_does_not_bump_editor_preview_version() {
     );
 }
 
+/// Assert no pixel on the outermost border row/column carries ink — i.e. the
+/// rendered content stayed clear of the render-canvas edge and nothing was
+/// clipped away before the framer's changed-pixel crop ran. `bg` is assumed
+/// near-black (the tests pin a black theme bg), so any bright border pixel is
+/// clipped stroke.
+fn assert_no_ink_on_render_border(pixels: &[u8], w: u32, h: u32, label: &str) {
+    assert_eq!(pixels.len(), (w * h * 4) as usize);
+    const TOLERANCE: u8 = 16;
+    let is_ink = |x: u32, y: u32| -> bool {
+        let i = ((y * w + x) * 4) as usize;
+        pixels[i] > TOLERANCE || pixels[i + 1] > TOLERANCE || pixels[i + 2] > TOLERANCE
+    };
+    for x in 0..w {
+        for y in [0, h - 1] {
+            assert!(
+                !is_ink(x, y),
+                "{label}: ink clipped against render border at ({x}, {y}) rgba={:?}",
+                {
+                    let i = ((y * w + x) * 4) as usize;
+                    [pixels[i], pixels[i + 1], pixels[i + 2], pixels[i + 3]]
+                }
+            );
+        }
+    }
+    for y in 0..h {
+        for x in [0, w - 1] {
+            assert!(
+                !is_ink(x, y),
+                "{label}: ink clipped against render border at ({x}, {y}) rgba={:?}",
+                {
+                    let i = ((y * w + x) * 4) as usize;
+                    [pixels[i], pixels[i + 1], pixels[i + 2], pixels[i + 3]]
+                }
+            );
+        }
+    }
+}
+
+/// Squash the active brush's tip to the extreme calligraphy nib (aspect
+/// 10% → ~10× anisotropy, the worst case the preview canvas is sized for)
+/// by scrubbing its exposed `aspect` port. Returns nothing; mutates the
+/// active graph in place.
+fn squash_active_brush_to_extreme_nib(engine: &mut darkly::engine::DarklyEngine) {
+    let aspect = engine
+        .brush_exposed_ports()
+        .into_iter()
+        .find(|p| p.port_name == "aspect")
+        .expect("Calligraphy exposes an `aspect` port");
+    // Percent unit: display 10 → port 0.1 (the port's minimum, ~10× stretch).
+    engine
+        .brush_set_exposed_port(aspect.node_id, "aspect", 10.0)
+        .expect("scrub aspect to 10%");
+}
+
+/// Regression: a broad-nib calligraphy tip must not be clipped against the
+/// stroke-preview render canvas. The tip's anisotropy stretches the dab
+/// footprint up to ~10×, so a fixed small canvas + absolute inset clipped the
+/// endpoints (and even mid-stroke edges) before the changed-pixel crop ever
+/// saw them — the user-reported "calligraphy stroke is cut off" bug.
+///
+/// The invariant is size-agnostic: whatever canvas the preview pipeline picks,
+/// the neutralized preview stroke must stay clear of its border. We assert
+/// directly on the raw render canvas (pre-crop) via the test accessor.
+#[test]
+fn calligraphy_stroke_preview_not_clipped_against_render_border() {
+    use darkly::engine::DarklyEngine;
+    use darkly::gpu::context::GpuContext;
+
+    let (device, queue) = test_device();
+    let gpu = GpuContext::new_headless(device, queue);
+    let mut engine = DarklyEngine::new(gpu, 1024, 768);
+
+    // Pin a black bg / white stroke so border ink is unambiguous.
+    engine.set_preview_theme([1.0, 1.0, 1.0, 1.0], [0.0, 0.0, 0.0, 1.0]);
+    engine.brush_load("Calligraphy").expect("Calligraphy built-in");
+    squash_active_brush_to_extreme_nib(&mut engine);
+
+    let (pixels, w, h) = engine.test_render_stroke_preview_canvas();
+    assert_no_ink_on_render_border(&pixels, w, h, "calligraphy stroke preview");
+}
+
+/// Regression: the same broad-nib calligraphy tip must not be clipped against
+/// the single-dab preview render canvas either. `aspect` is
+/// `persist_in_thumbnail` and not a default-exposed scrub, so it survives the
+/// dab path's `reset_exposed_scrubs` — the nib the picker tile shows is the
+/// full ellipse, not a truncated one.
+#[test]
+fn calligraphy_dab_preview_not_clipped_against_render_border() {
+    use darkly::engine::DarklyEngine;
+    use darkly::gpu::context::GpuContext;
+
+    let (device, queue) = test_device();
+    let gpu = GpuContext::new_headless(device, queue);
+    let mut engine = DarklyEngine::new(gpu, 1024, 768);
+
+    engine.set_preview_theme([1.0, 1.0, 1.0, 1.0], [0.0, 0.0, 0.0, 1.0]);
+    engine.brush_load("Calligraphy").expect("Calligraphy built-in");
+    squash_active_brush_to_extreme_nib(&mut engine);
+
+    let (pixels, w, h) = engine.test_render_dab_preview_canvas();
+    assert_no_ink_on_render_border(&pixels, w, h, "calligraphy dab preview");
+}
+
 #[test]
 fn empty_path_returns_none() {
     let (device, queue) = test_device();

--- a/crates/darkly/tests/stroke.rs
+++ b/crates/darkly/tests/stroke.rs
@@ -961,6 +961,122 @@ fn diff_rect_undo_restores_offset_paint() {
     }
 }
 
+/// Build an `w × h` RGBA8 buffer, transparent everywhere except a solid
+/// `color` rectangle at `(rx, ry)` of size `(rw, rh)`. Used by the bbox
+/// exactness tests to plant a precisely-known changed region.
+fn rgba_with_rect(w: u32, h: u32, rx: u32, ry: u32, rw: u32, rh: u32, color: [u8; 4]) -> Vec<u8> {
+    let mut buf = vec![0u8; (w * h * 4) as usize];
+    for y in ry..ry + rh {
+        for x in rx..rx + rw {
+            let i = ((y * w + x) * 4) as usize;
+            buf[i..i + 4].copy_from_slice(&color);
+        }
+    }
+    buf
+}
+
+/// Blocking-poll a `DiffRectPass` to completion (native/test only).
+fn poll_diff_blocking(diff: &mut DiffRectPass, device: &wgpu::Device) -> Option<CanvasRect> {
+    loop {
+        if let Some(result) = diff.poll(device) {
+            return result;
+        }
+        let _ = device.poll(wgpu::PollType::Wait {
+            submission_index: None,
+            timeout: None,
+        });
+    }
+}
+
+/// Parity regression for the shared `BboxReduction` extraction: the diff
+/// predicate must report the *exact* changed rect (not merely a superset), and
+/// identical textures must report no diff. Guards against the reduction/decode
+/// or the empty-convention drifting when the machinery moved out of
+/// `DiffRectPass` into `gpu::bbox`.
+#[test]
+fn diff_rect_returns_exact_changed_rect() {
+    let (device, queue) = test_device();
+    let (w, h) = (64u32, 64u32);
+    let blank = vec![0u8; (w * h * 4) as usize];
+    let (_a_tex, a_view) = create_test_texture(&device, &queue, w, h, &blank);
+
+    // B differs from A in exactly x∈[10,15), y∈[20,27).
+    let b = rgba_with_rect(w, h, 10, 20, 5, 7, [255, 0, 0, 255]);
+    let (_b_tex, b_view) = create_test_texture(&device, &queue, w, h, &b);
+
+    let mut diff = DiffRectPass::new(&device);
+    diff.request(&device, &queue, &a_view, &b_view, cr(0, 0, w, h));
+    let rect = poll_diff_blocking(&mut diff, &device).expect("should find the changed rect");
+    assert_eq!(
+        (rect.x0(), rect.y0(), rect.width, rect.height),
+        (10, 20, 5, 7),
+        "diff rect must be exact, not a superset"
+    );
+
+    // Identical textures → no diff.
+    let mut diff_same = DiffRectPass::new(&device);
+    diff_same.request(&device, &queue, &a_view, &a_view, cr(0, 0, w, h));
+    assert!(
+        poll_diff_blocking(&mut diff_same, &device).is_none(),
+        "identical textures must report no diff (empty convention)"
+    );
+}
+
+/// Parity regression for the shared `BboxReduction` extraction, content-bounds
+/// predicate: the alpha-threshold scan must report the *exact* non-transparent
+/// rect, and a fully-transparent texture must yield no cached bounds.
+#[test]
+fn content_bounds_returns_exact_content_rect() {
+    use darkly::gpu::content_bounds::ContentBoundsPass;
+    use darkly::layer::LayerId;
+
+    let (device, queue) = test_device();
+    let (w, h) = (64u32, 64u32);
+
+    // Non-transparent content in exactly x∈[8,14), y∈[12,21).
+    let buf = rgba_with_rect(w, h, 8, 12, 6, 9, [10, 20, 30, 255]);
+    let (_tex, view) = create_test_texture(&device, &queue, w, h, &buf);
+
+    let mut pass = ContentBoundsPass::new(&device);
+    let lid = LayerId::from_ffi(1);
+    pass.request(&device, &queue, &view, w, h, false, lid);
+    loop {
+        if pass.poll(&device).contains(&lid) {
+            break;
+        }
+        let _ = device.poll(wgpu::PollType::Wait {
+            submission_index: None,
+            timeout: None,
+        });
+    }
+    assert_eq!(
+        pass.get(lid),
+        Some([8, 12, 6, 9]),
+        "content bounds must be the exact non-transparent rect"
+    );
+
+    // Fully-transparent texture → completes with no cached bounds.
+    let blank = vec![0u8; (w * h * 4) as usize];
+    let (_t2, v2) = create_test_texture(&device, &queue, w, h, &blank);
+    let mut pass_empty = ContentBoundsPass::new(&device);
+    let lid2 = LayerId::from_ffi(2);
+    pass_empty.request(&device, &queue, &v2, w, h, false, lid2);
+    loop {
+        if pass_empty.poll(&device).contains(&lid2) {
+            break;
+        }
+        let _ = device.poll(wgpu::PollType::Wait {
+            submission_index: None,
+            timeout: None,
+        });
+    }
+    assert_eq!(
+        pass_empty.get(lid2),
+        None,
+        "a fully-transparent texture must yield no cached bounds (empty convention)"
+    );
+}
+
 /// Regression for canvas-coord snapshot storage: a `Snapshot` saved on a
 /// 256×256 layer at canvas (0, 0) survives a negative-direction grow that
 /// shifts the layer's local-coord origin by (256, 256). Commit at canvas

--- a/frontend/src/canvas/CanvasView.svelte
+++ b/frontend/src/canvas/CanvasView.svelte
@@ -506,4 +506,11 @@
         object-fit: contain;
         touch-action: none;
     }
+
+    /* The canvas holds keyboard focus (tabindex via `bindingSite`) so tool
+       keys route to it, but it must never show the UA focus ring. */
+    canvas:focus,
+    canvas:focus-visible {
+        outline: none;
+    }
 </style>

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -53,6 +53,40 @@ input[type="range"]::-moz-range-thumb {
     cursor: pointer;
 }
 
+/* Tool-options bar control — the black rounded button shared by the scrubs
+   (Scrub.svelte) and the brush picker (BrushOptions.svelte), and available to
+   any tool that embeds a custom control in its options bar. Consumers layer on
+   their own behavior (cursor, active/selected state, value formatting). */
+.bar-control {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: var(--radius-md);
+    background: var(--bg);
+    transition: background var(--transition-fast);
+}
+.bar-control:hover {
+    background: var(--bg-hover);
+}
+/* Two-line label/value stack: a small uppercase caption over the value. */
+.bar-control-text {
+    display: flex;
+    flex-direction: column;
+}
+.bar-control-label {
+    font-size: 9px;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    line-height: 1;
+}
+.bar-control-value {
+    font-size: 12px;
+    color: var(--text);
+    line-height: 1.3;
+}
+
 /* Context menu / dropdown surface */
 .dropdown-surface {
     background: var(--bg-active);

--- a/frontend/src/ui/BrushOptions.svelte
+++ b/frontend/src/ui/BrushOptions.svelte
@@ -78,23 +78,29 @@
 </script>
 
 <ToolBarLayout>
-    {#snippet left()}
+    {#snippet center()}
+        <!-- The brush picker is the leading control in the same wrapping row
+             as the scrubs — a black rounded button that wraps alongside them.
+             Its dropdown menu anchors to this button. -->
         <div class="brush-picker-section">
             <button
-                class="brush-picker-button"
+                class="brush-picker-button bar-control"
                 data-keep-open="brush-picker"
                 onclick={() => { ensureInit(); brushPickerOpen = !brushPickerOpen; }}
                 title="Select brush"
             >
                 <!-- Live preview of the active graph — same component the
-                     picker's active strip uses, so preset and custom states
-                     render identically. The label below is the only thing
-                     that switches between the preset name and "Custom". -->
+                     picker's tiles use, so preset and custom states render
+                     identically. The value switches between the preset name
+                     and "Custom". The preview stands in for a scrub's icon. -->
                 <span class="trigger-preview">
-                    <LiveBrushPreviewStrip width={80} />
+                    <LiveBrushPreviewStrip width={64} />
                 </span>
-                <span class="brush-name">{brushGraph.activeBrush ?? 'Custom'}</span>
-                <svg class="chevron" width="10" height="6" viewBox="0 0 10 6">
+                <span class="bar-control-text">
+                    <span class="bar-control-label">Brush</span>
+                    <span class="bar-control-value name">{brushGraph.activeBrush ?? 'Custom'}</span>
+                </span>
+                <svg class="chevron" class:flipped={brushPickerOpen} width="10" height="6" viewBox="0 0 10 6">
                     <path d="M1 1l4 4 4-4" stroke="currentColor" stroke-width="1.5" fill="none"/>
                 </svg>
             </button>
@@ -103,9 +109,7 @@
                 <BrushPicker onSelect={selectBrush} onClose={() => (brushPickerOpen = false)} />
             {/if}
         </div>
-    {/snippet}
 
-    {#snippet center()}
         {#each brushGraph.exposedPorts as port}
             {#if port.data.kind === 'scalar'}
                 {@const d = port.data}
@@ -170,47 +174,31 @@
 </ToolBarLayout>
 
 <style>
+    /* Anchor for the dropdown menu; the button itself sizes to content so it
+     * wraps in the scrub row like any other control. */
     .brush-picker-section {
         position: relative;
         flex-shrink: 0;
     }
 
     /* Width-bound wrapper for the embedded preview strip — the strip
-     * is `width: 100%; aspect-ratio: 11/3`, so the wrapper width
-     * picks the trigger preview's height. 80px → ~22px tall. */
+     * is `width: 100%; aspect-ratio: 11/3`, so the wrapper width picks the
+     * trigger preview's height. 64px → ~17px tall, matching the scrubs. */
     .trigger-preview {
         display: block;
-        width: 80px;
+        width: 64px;
         flex-shrink: 0;
     }
 
+    /* Shared `.bar-control` supplies the look (fill, radius, padding, gap,
+     * label/value metrics) so this matches the scrubs; only the button reset
+     * and the name's truncation are picker-specific. */
     .brush-picker-button {
-        display: flex;
-        align-items: center;
-        gap: 4px;
-        /* Gradient lives on the border, not the fill — two-layer
-         * background with `padding-box`/`border-box` clips so the
-         * border-radius is preserved (border-image flattens corners). */
-        background:
-            linear-gradient(var(--bg), var(--bg)) padding-box,
-            linear-gradient(to right, var(--thumb-bg), var(--bg)) border-box;
-        border: 3px solid transparent;
-        border-radius: 6px;
-        color: var(--text);
+        border: none;
         cursor: pointer;
-        font-size: 13px;
-        font-weight: 600;
-        padding: 2px 6px;
-        min-width: 100px;
-        transition: filter 0.1s;
     }
-    .brush-picker-button:hover {
-        filter: brightness(1.15);
-    }
-
-    .brush-name {
-        flex: 1;
-        text-align: left;
+    .brush-picker-button .name {
+        max-width: 120px;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -219,6 +207,10 @@
     .chevron {
         flex-shrink: 0;
         color: var(--text-muted);
+        transition: transform 0.2s ease-out;
+    }
+    .chevron.flipped {
+        transform: rotate(180deg);
     }
 
     .error-badge {

--- a/frontend/src/ui/BrushOptions.svelte
+++ b/frontend/src/ui/BrushOptions.svelte
@@ -12,6 +12,7 @@
     import { watchDismiss } from '../lib/dismiss';
 
     let brushPickerOpen = $state(false);
+    let brushPickerTrigger: HTMLButtonElement | undefined = $state();
 
     function ensureInit() {
         if (!brushGraph.graph && app.engine) brushGraph.init();
@@ -84,6 +85,7 @@
              Its dropdown menu anchors to this button. -->
         <div class="brush-picker-section">
             <button
+                bind:this={brushPickerTrigger}
                 class="brush-picker-button bar-control"
                 data-keep-open="brush-picker"
                 onclick={() => { ensureInit(); brushPickerOpen = !brushPickerOpen; }}
@@ -106,7 +108,7 @@
             </button>
 
             {#if brushPickerOpen}
-                <BrushPicker onSelect={selectBrush} onClose={() => (brushPickerOpen = false)} />
+                <BrushPicker anchor={brushPickerTrigger} onSelect={selectBrush} onClose={() => (brushPickerOpen = false)} />
             {/if}
         </div>
 

--- a/frontend/src/ui/Scrub.svelte
+++ b/frontend/src/ui/Scrub.svelte
@@ -69,16 +69,16 @@
 
 {#snippet body()}
     <Icon name={props.icon ?? DEFAULT_ICON} class="scrub-icon" />
-    <div class="scrub-text">
-        <span class="scrub-label">{props.label}</span>
-        <span class="scrub-value">{valueText}</span>
+    <div class="bar-control-text">
+        <span class="bar-control-label">{props.label}</span>
+        <span class="bar-control-value">{valueText}</span>
     </div>
 {/snippet}
 
 {#if props.mode === 'drag'}
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
-        class="scrub"
+        class="scrub bar-control"
         class:dragging
         title={props.title}
         onpointerdown={startDrag}
@@ -89,7 +89,7 @@
 {:else}
     <button
         type="button"
-        class="scrub toggle"
+        class="scrub bar-control toggle"
         class:on={props.active}
         title={props.title}
         onclick={props.onToggle}
@@ -99,20 +99,12 @@
 {/if}
 
 <style>
+    /* Base look comes from the shared `.bar-control`; the rules here are
+       scrub-specific behavior: drag cursor, the accent active/dragging
+       state, tabular value digits, and the button reset. */
     .scrub {
         flex-shrink: 0;
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        padding: 4px 10px;
-        border-radius: 6px;
         cursor: col-resize;
-        background: var(--bg-hover);
-        transition: background 0.1s;
-    }
-
-    .scrub:hover {
-        background: var(--bg-active);
     }
 
     .scrub.dragging,
@@ -121,11 +113,11 @@
     }
 
     .scrub.dragging :global(.scrub-icon),
-    .scrub.dragging .scrub-label,
-    .scrub.dragging .scrub-value,
+    .scrub.dragging .bar-control-label,
+    .scrub.dragging .bar-control-value,
     .scrub.on :global(.scrub-icon),
-    .scrub.on .scrub-label,
-    .scrub.on .scrub-value {
+    .scrub.on .bar-control-label,
+    .scrub.on .bar-control-value {
         color: #ffffff;
     }
 
@@ -140,23 +132,8 @@
         color: var(--text-muted);
     }
 
-    .scrub-text {
-        display: flex;
-        flex-direction: column;
-    }
-
-    .scrub-label {
-        font-size: 9px;
-        color: var(--text-muted);
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
-        line-height: 1;
-    }
-
-    .scrub-value {
-        font-size: 12px;
-        color: var(--text);
+    /* Values are numeric — keep digits from shifting width while scrubbing. */
+    .scrub .bar-control-value {
         font-variant-numeric: tabular-nums;
-        line-height: 1.3;
     }
 </style>

--- a/frontend/src/ui/ToolBarLayout.svelte
+++ b/frontend/src/ui/ToolBarLayout.svelte
@@ -29,18 +29,18 @@
         min-width: 0;
     }
 
-    /* Center is the only scrollable region. `min-width: 0` is required
-     * for a flex child to be allowed to shrink below its content size —
-     * without it the parent grows and the bar overflows its column
-     * instead of letting this region scroll. */
+    /* When the bar is too narrow to hold every control on one line, the
+     * controls wrap onto additional lines (growing the bar's height)
+     * rather than falling back to a horizontal scrollbar. `min-width: 0`
+     * lets this flex child shrink below its content width so the wrap
+     * point tracks the available space. */
     .center {
         flex: 1;
         min-width: 0;
         display: flex;
         align-items: center;
+        justify-content: flex-start;
+        flex-wrap: wrap;
         gap: 4px;
-        overflow-x: auto;
-        overflow-y: hidden;
-        scrollbar-width: thin;
     }
 </style>

--- a/frontend/src/ui/ToolOptionsBar.svelte
+++ b/frontend/src/ui/ToolOptionsBar.svelte
@@ -49,26 +49,24 @@
         justify-content: center;
         gap: 4px;
         padding: 4px 8px;
-        background: var(--bg);
+        background: var(--canvas-bg);
         flex-shrink: 0;
-        /* Fixed height (not min-height) so the bar stays the same size
-         * across tool switches and the canvas above doesn't shift when
-         * the user swaps tools. Sized to fit the tallest tool's content
-         * — currently the brush picker (preview strip + name + chevron),
-         * which is ~32px tall; 40px total leaves a 4px breather around
-         * it. Shorter content (scrubs, dropdowns) centers within the
-         * extra space. `box-sizing: border-box` is set globally, so this
-         * height is inclusive of padding. */
-        height: 40px;
+        /* Minimum (not fixed) height: the bar is 40px at rest — sized to
+         * fit the tallest control (~32px) with a 4px breather — but grows
+         * taller when controls wrap onto extra lines in a narrow window
+         * (see ToolBarLayout `.center`). */
+        min-height: 40px;
     }
 
     .tool-name {
+        display: flex;
+        align-items: center;
         font-size: 11px;
         font-weight: 600;
         color: var(--text-muted);
         text-transform: uppercase;
         letter-spacing: 0.5px;
-        padding: 0 4px;
+        padding: 0 12px;
     }
 
     .spacer {

--- a/frontend/src/ui/brush_picker/BrushPicker.svelte
+++ b/frontend/src/ui/brush_picker/BrushPicker.svelte
@@ -7,8 +7,39 @@
     interface Props {
         onSelect: (brush: BrushInfo) => void;
         onClose: () => void;
+        /** Trigger element the dropdown anchors to. The picker is
+         *  `position: fixed` so it escapes the panel tiles' `overflow: hidden`
+         *  clipping and paints above the docked side panels; that means it can't
+         *  ride the trigger via CSS flow, so it measures the anchor instead. */
+        anchor: HTMLElement | undefined;
     }
-    let { onSelect, onClose }: Props = $props();
+    let { onSelect, onClose, anchor }: Props = $props();
+
+    let pickerEl: HTMLElement | undefined = $state();
+    let left = $state(0);
+    let bottom = $state(0);
+
+    // Anchor the fixed dropdown above the trigger, left-aligned and clamped
+    // into the viewport. Recomputed on scroll/resize because the tool-options
+    // bar reflows (controls wrap) as the window changes.
+    function reposition() {
+        if (!anchor) return;
+        const r = anchor.getBoundingClientRect();
+        const gap = 6;
+        const width = pickerEl?.offsetWidth ?? 480;
+        left = Math.max(8, Math.min(r.left, window.innerWidth - width - 8));
+        bottom = window.innerHeight - r.top + gap;
+    }
+
+    $effect(() => {
+        reposition();
+        window.addEventListener('resize', reposition);
+        window.addEventListener('scroll', reposition, true);
+        return () => {
+            window.removeEventListener('resize', reposition);
+            window.removeEventListener('scroll', reposition, true);
+        };
+    });
 
     let query = $state('');
     let searchInput: HTMLInputElement | undefined = $state();
@@ -99,7 +130,14 @@
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="brush-picker" data-keep-open="brush-picker" onkeydown={handleKey}>
+<div
+    class="brush-picker"
+    bind:this={pickerEl}
+    data-keep-open="brush-picker"
+    onkeydown={handleKey}
+    style:left="{left}px"
+    style:bottom="{bottom}px"
+>
     <!-- Non-scrolling header: the search box stays put while the grid
          below scrolls. The active brush lives on the trigger foot. -->
     <div class="picker-header">
@@ -150,16 +188,17 @@
     /* A black rounded dropdown anchored to the trigger button and popping
      * upward. No border, no shadow: it reads against the raised bar and the
      * canvas by fill contrast, and its lighter tile wells give it body.
-     * `max-width` keeps it from pushing past the viewport edge. */
+     * `max-width` keeps it from pushing past the viewport edge.
+     *
+     * `position: fixed` (with `left`/`bottom` set from the trigger's rect in
+     * script) lifts it out of the panel tiles' `overflow: hidden` so it paints
+     * over the docked side panels; the overlay z-index matches ContextMenu. */
     .brush-picker {
-        position: absolute;
-        bottom: 100%;
-        left: 0;
-        margin-bottom: 6px;
+        position: fixed;
         width: 480px;
         max-width: calc(100vw - 32px);
         max-height: 60vh;
-        z-index: 100;
+        z-index: 1000;
         background: var(--bg);
         border-radius: var(--radius-md);
         /* Non-scrolling flex column so the header stays put while only

--- a/frontend/src/ui/brush_picker/BrushPicker.svelte
+++ b/frontend/src/ui/brush_picker/BrushPicker.svelte
@@ -2,7 +2,6 @@
     import { tick } from 'svelte';
     import { brushGraph } from '../../state/brush_graph.svelte';
     import type { BrushInfo } from '../../state/brush_graph.svelte';
-    import LiveBrushPreviewStrip from './LiveBrushPreviewStrip.svelte';
     import BrushTile from './BrushTile.svelte';
 
     interface Props {
@@ -30,10 +29,6 @@
         const tokens = q.toLowerCase().trim().split(/\s+/).filter(t => t.length > 0);
         return tokens.every(t => haystack.includes(t));
     }
-
-    const activeBrush = $derived(
-        brushGraph.brushes.find(b => b.name === brushGraph.activeBrush) ?? null
-    );
 
     const filtered = $derived(
         brushGraph.brushes.filter(b => matches(b, query))
@@ -104,9 +99,9 @@
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="brush-picker dropdown-surface" data-keep-open="brush-picker" onkeydown={handleKey}>
-    <!-- Non-scrolling header: search + active brush stay visible while
-         the user scans the grid below. -->
+<div class="brush-picker" data-keep-open="brush-picker" onkeydown={handleKey}>
+    <!-- Non-scrolling header: the search box stays put while the grid
+         below scrolls. The active brush lives on the trigger foot. -->
     <div class="picker-header">
         <input
             bind:this={searchInput}
@@ -115,23 +110,6 @@
             class="search"
             placeholder="Search brushes…"
         />
-
-        <div class="active-strip">
-            <span class="active-preview">
-                <!-- One preview path for both preset and custom states.
-                     The live engine preview is keyed on the graph itself,
-                     so a loaded preset renders identically to its baked
-                     thumbnail and a modified graph stays in sync. -->
-                <LiveBrushPreviewStrip width={176} />
-            </span>
-            <div class="active-meta">
-                <span class="active-label">Active</span>
-                <span class="active-name">{activeBrush?.name ?? 'Custom'}</span>
-                {#if activeBrush?.category}
-                    <span class="active-category">{activeBrush.category}</span>
-                {/if}
-            </div>
-        </div>
     </div>
 
     <div class="picker-body">
@@ -146,7 +124,6 @@
                     <section class="group">
                         <div class="group-header">
                             <span class="group-label">{group.category}</span>
-                            <span class="group-fence" aria-hidden="true"></span>
                         </div>
                         <div class="grid">
                             {#each group.brushes as brush, bi (brush.name)}
@@ -170,32 +147,33 @@
 </div>
 
 <style>
+    /* A black rounded dropdown anchored to the trigger button and popping
+     * upward. No border, no shadow: it reads against the raised bar and the
+     * canvas by fill contrast, and its lighter tile wells give it body.
+     * `max-width` keeps it from pushing past the viewport edge. */
     .brush-picker {
         position: absolute;
         bottom: 100%;
         left: 0;
-        margin-bottom: 4px;
-        /* Bounded so the absolute panel can't push past the viewport
-         * edge (which would surface a horizontal scrollbar on body). */
+        margin-bottom: 6px;
         width: 480px;
         max-width: calc(100vw - 32px);
         max-height: 60vh;
         z-index: 100;
-        /* Outer panel is a non-scrolling flex column so the header
-         * stays put while only `.picker-body` scrolls. */
+        background: var(--bg);
+        border-radius: var(--radius-md);
+        /* Non-scrolling flex column so the header stays put while only
+         * `.picker-body` scrolls. */
         display: flex;
         flex-direction: column;
         overflow: hidden;
     }
-    /* Pinned header: search + active strip. Padding lives here so the
-     * scroll content underneath doesn't bleed through under the
-     * header — `.picker-body` provides its own padding. */
+    /* Pinned header: the search box. Padding lives here so the scroll
+     * content underneath doesn't bleed through — `.picker-body` provides
+     * its own padding. */
     .picker-header {
         flex-shrink: 0;
-        padding: 10px 10px 0;
-        display: flex;
-        flex-direction: column;
-        gap: 10px;
+        padding: 12px;
     }
     .picker-body {
         /* flex-basis stays `auto`, not the `flex: 1` shorthand's `0%`: the
@@ -206,66 +184,31 @@
         flex: 1 1 auto;
         min-height: 0;
         overflow-y: auto;
-        padding: 10px;
+        /* Let a pen/stylus pan the grid vertically — without this an
+         * ancestor's `touch-action: none` (canvas gesture guard) leaves the
+         * list unscrollable with anything but a mouse wheel. */
+        touch-action: pan-y;
+        padding: 0 12px 12px;
     }
+    /* Raised well on the black slab — lighter fill, no border. */
     .search {
         width: 100%;
-        padding: 6px 10px;
+        padding: 8px 10px;
         font-size: 12px;
         background: var(--bg-hover);
         color: var(--text);
-        border: 1px solid var(--bg-active);
-        border-radius: 6px;
+        border: none;
+        border-radius: var(--radius-md);
         outline: none;
+        transition: background var(--transition-fast);
     }
     .search:focus {
-        border-color: var(--accent);
-    }
-    /* Width-bound wrapper for the strip — strip is `width: 100%;
-     * aspect-ratio: 11/3`, so 176px wide → 48px tall, matching the
-     * previous BrushDabView size in this slot. */
-    .active-preview {
-        display: block;
-        width: 176px;
-        flex-shrink: 0;
-    }
-    .active-strip {
-        display: flex;
-        align-items: center;
-        gap: 10px;
-        padding: 8px;
-        background: var(--bg-hover);
-        border-radius: 6px;
-    }
-    .active-meta {
-        display: flex;
-        flex-direction: column;
-        gap: 2px;
-        min-width: 0;
-    }
-    .active-label {
-        font-size: 9px;
-        color: var(--text-muted);
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
-    }
-    .active-name {
-        font-size: 13px;
-        color: var(--text);
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-    }
-    .active-category {
-        font-size: 9px;
-        color: var(--text-muted);
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
+        background: var(--bg-active);
     }
     .groups {
         display: flex;
         flex-direction: column;
-        gap: 12px;
+        gap: 16px;
     }
     .group {
         display: flex;
@@ -275,24 +218,13 @@
     .group-header {
         display: flex;
         align-items: center;
-        gap: 8px;
     }
     .group-label {
-        font-size: 12px;
+        font-size: 11px;
         font-weight: 600;
-        color: var(--text);
-        letter-spacing: 0.2px;
-        flex-shrink: 0;
-    }
-    /* Gentle fence: a thin hairline that fades from the label outward. */
-    .group-fence {
-        flex: 1;
-        height: 1px;
-        background: linear-gradient(
-            to right,
-            var(--bg-active) 0%,
-            transparent 100%
-        );
+        color: var(--text-muted);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
     }
     .grid {
         display: grid;
@@ -302,11 +234,11 @@
         grid-template-columns: repeat(2, minmax(0, 1fr));
         gap: 8px;
     }
-    /* Outline rather than swap colors so it stacks cleanly with `.active`
-     * on the same tile (highlight = current keyboard cursor; active =
-     * currently loaded brush). */
+    /* Keyboard cursor: reuse the hover fill (a lighter well). `.active`
+     * (loaded brush) uses a lighter slab still, so the two remain
+     * distinguishable when they land on the same tile. */
     .grid-cell.highlight :global(.brush-tile) {
-        border-color: var(--accent);
+        background: var(--bg-active);
     }
     .empty {
         font-size: 11px;

--- a/frontend/src/ui/brush_picker/BrushTile.svelte
+++ b/frontend/src/ui/brush_picker/BrushTile.svelte
@@ -21,33 +21,33 @@
 </button>
 
 <style>
-    /* Card-style container so each brush reads as one unit even when
-     * the picker is dense. Stronger border + slightly inset bg gives
-     * each tile clear visual edges against the picker surface. */
+    /* Raised well on the black picker slab — separation is fill contrast,
+     * not a border. Hover/selected lighten the fill; no outlines, no
+     * shadows. */
     .brush-tile {
         display: flex;
         flex-direction: column;
         gap: 6px;
         padding: 8px;
-        background: var(--bg);
-        border: 1px solid var(--bg-active);
-        border-radius: 6px;
-        color: var(--text);
+        background: var(--bg-hover);
+        border: none;
+        border-radius: var(--radius-md);
+        color: var(--text-muted);
         cursor: pointer;
         text-align: left;
-        transition: background 0.1s, border-color 0.1s;
+        transition: background 0.1s, color 0.1s;
         /* Backstop for the grid `minmax(0, 1fr)` columns — children
          * (especially imgs) can't blow the tile out horizontally. */
         min-width: 0;
     }
     .brush-tile:hover {
-        background: var(--bg-hover);
-        border-color: var(--text-muted);
+        background: var(--bg-active);
+        color: var(--text);
     }
+    /* Loaded brush: a clearly lighter slab, not an outline. */
     .brush-tile.active {
-        border-color: var(--accent);
-        background: color-mix(in srgb, var(--accent) 12%, var(--bg));
-        box-shadow: 0 0 0 1px var(--accent) inset;
+        background: var(--thumb-bg);
+        color: var(--text);
     }
     .name {
         font-size: 11px;


### PR DESCRIPTION
<img width="865" height="214" alt="image" src="https://github.com/user-attachments/assets/a38e3493-3628-4577-8bbe-897f03da5d7f" />

---

## Fix cut-off calligraphy stroke/dab previews; unify the changed-pixel bbox

### Problem

The brush editor's stroke preview and the picker's baked thumbnails clipped
broad-nib brushes (calligraphy): the ends/edges of the sample stroke were cut
off. Root cause was a **dab-size assumption** baked into the preview pipeline —
it rendered into a hardcoded `384×192` (stroke) / `256×256` (dab) canvas and
laid the sample stroke at a hardcoded `32 px` absolute inset. That reserved
enough headroom only for *round* dabs; a calligraphy tip squashes via the Shape
node's `aspect` port up to ~10×, so its footprint (~260 px) overran both the
inset and the canvas. The GPU render target hard-clips anything outside
`[0,W]×[0,H]` **before** the framer's changed-pixel crop ever runs, so the
clipped ink was gone by the time the (already-correct) crop measured it.

### Approach — measure, don't predict

The framer's changed-pixel crop is the authority on output size; it already
tracks inked pixels by construction. So the preview pipeline is kept dumb: give
the render pass generous, fixed headroom so the size-neutralized preview stroke
can never touch the border, and let the crop do 100% of the framing. No
per-brush extent math, no compile-to-read-footprint.

- **Oversized fixed canvases + proportional inset.** `BRUSH_STROKE_RENDER_SIZE`
  → `1024×768`, `BRUSH_DAB_RENDER_SIZE` → `768×768`. The absolute
  `BRUSH_STROKE_PATH_INSET = 32.0` is replaced by
  `BRUSH_STROKE_PATH_INSET_FRACTION = 0.4` (fraction of the smaller edge →
  ≳ 300 px clearance, which covers the worst-case ~10× anisotropic nib). The
  synthetic S-curve is laid at `min(w,h) * fraction` instead of a pixel
  constant. Constant docs rewritten to describe "generous headroom + the crop
  frames the result", not a per-dab radius prediction.
- **Collapsed the 3× stroke-preview duplication** (live editor preview, save
  bake, thumbnail bake) into one helper `request_stroke_preview_readback`, and
  the 2× dab-preview duplication into `request_dab_preview_readback`. Each
  takes the graph + a closure that builds the `ReadbackContext` from the render
  dims, so the neutralization + inset + sizing live in exactly one place.

### DRY: unify the changed-pixel bounding box (was four copies)

"Bounding box of the pixels that changed from a baseline" existed **four**
times. This collapses them to **one GPU implementation + one CPU implementation**
(the two can't share an execution model — the GPU passes are async compute over
VRAM; the framers scan an already-read-back buffer — so unifying further would
be a forced abstraction over the texture-oriented readback scheduler; the plan
sanctioned this split as the escape hatch).

- **New `gpu::bbox::BboxReduction` / `PendingBbox`** owns the shared async
  min/max machinery: the `[MAX,MAX,0,0]` seed, the 16-byte storage + staging
  buffers, the `div_ceil(16)` dispatch tiling, the `map_async` → non-blocking
  `poll` → `[u32;4]` decode, and the "`min_x > max_x` ⇒ empty" convention,
  decoded to origin+size. Callers supply only their pipeline, bind group
  (predicate + input textures), and post-processing.
- **`DiffRectPass` and `ContentBoundsPass` are now thin wrappers** over it,
  keeping only what's genuinely theirs — their two-texture / one-texture bind
  groups + predicate shaders, and their coordinate translation / per-layer
  generation cache respectively.
- **New CPU `changed_pixels_bbox` helper** (rendering.rs) with a `differs_from_bg`
  predicate replaces the three hand-rolled scans in `frame_stroke_thumbnail`,
  `frame_dab_thumbnail`, and `cursor_preview_scale_from_mask`.

### Tests

- **Regression (bug):** `calligraphy_stroke_preview_not_clipped_against_render_border`
  and `calligraphy_dab_preview_not_clipped_against_render_border` load the
  built-in Calligraphy brush, scrub `aspect` to its 10% extreme, and assert **no
  ink touches any border** of the raw render canvas (via new test-only
  accessors `test_render_stroke_preview_canvas` / `test_render_dab_preview_canvas`).
  Confirmed to **fail** against the old `384×192 / 32 px` sizing and pass after.
- **Parity (refactor):** `diff_rect_returns_exact_changed_rect` and
  `content_bounds_returns_exact_content_rect` assert both predicates return the
  *exact* rect (not a superset) and honor the empty→`None` convention. Existing
  `diff_rect_*` tests remain the regression net proving the extraction preserved
  semantics.

### Files touched

- `engine/brush_library.rs` — oversized-canvas + proportional-inset constants; call sites on the shared helpers.
- `engine/brush_graph.rs` — `request_stroke_preview_readback` / `request_dab_preview_readback` helpers; both call sites.
- `engine/mod.rs` — test-only render-canvas accessors.
- `engine/rendering.rs` — `changed_pixels_bbox` + `differs_from_bg`; three CPU scans routed through them.
- `gpu/bbox.rs` (new), `gpu/mod.rs` — the shared `BboxReduction` primitive.
- `gpu/diff_rect.rs`, `gpu/content_bounds.rs` — reduced to thin wrappers.
- `tests/brush_editor_preview.rs`, `tests/stroke.rs` — regression + parity tests.

No format/wire changes; frontend Svelte previews untouched (they scale a PNG via CSS).
