### PR TITLE
Desaturate

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ For a feature to count, it must be:
     - [x] Levels
     - [x] Curves
     - [x] Invert colors
-    - [ ] Desaturate
+    - [x] Desaturate
 - [ ] Clipping mask
 - [x] Feather + antialias
 - [x] Grow / Shrink / Border / Smooth

--- a/crates/darkly/presets/krita.yaml
+++ b/crates/darkly/presets/krita.yaml
@@ -67,6 +67,11 @@ hotkeys:
   # this is per-overlay, not a default. The action id is `filterInvert` —
   # the dynamically-registered id for the `invert` filter (`filter` + type).
   filterInvert: $mod+KeyI
+  # Krita binds Ctrl+Shift+U to Desaturate (`krita_filter_desaturate`, per
+  # docs/krita-default-hotkeys.md). Photoshop agrees (Shift+Ctrl+U → Image >
+  # Adjustments > Desaturate); GIMP has no default Desaturate shortcut, so
+  # this is per-overlay, not a default.
+  filterDesaturate: $mod+Shift+KeyU
 
 mouse_clicks:
   # Krita's default "Sample FG color from merged image" — Ctrl+drag on

--- a/crates/darkly/presets/photoshop.yaml
+++ b/crates/darkly/presets/photoshop.yaml
@@ -58,6 +58,11 @@ hotkeys:
   # so this is per-overlay, not a default. The action id is `filterInvert` —
   # the dynamically-registered id for the `invert` filter (`filter` + type).
   filterInvert: $mod+KeyI
+  # Photoshop binds Shift+Ctrl+U to Image > Adjustments > Desaturate (per
+  # docs/photoshop-default-hotkeys.md, "Keys for the Image ▸ Adjustments
+  # menu"). Krita agrees (Ctrl+Shift+U → `krita_filter_desaturate`); GIMP has
+  # no default Desaturate shortcut, so this is per-overlay, not a default.
+  filterDesaturate: $mod+Shift+KeyU
 
 mouse_clicks:
   # Photoshop's eyedropper modifier is Alt+drag (not Ctrl+drag).

--- a/crates/darkly/shaders/filters/desaturate.wgsl
+++ b/crates/darkly/shaders/filters/desaturate.wgsl
@@ -1,0 +1,74 @@
+// Desaturate — RGB → gray by one of six formulas, matching Krita's
+// desaturate adjustment (`krita/plugins/color/colorspaceextensions/
+// kis_desaturate_adjustment.cpp`), which follows Tanner Helland's grayscale
+// algorithm survey (https://www.tannerhelland.com/3643/grayscale-image-algorithm-vb6/).
+// The Rust side (`gpu/filters/desaturate.rs`) packs the mode selector into the
+// uniform. Alpha passes through; no output clamp — the unorm render target
+// clamps on store.
+
+@group(0) @binding(0) var t_src: texture_2d<f32>;
+
+struct Params {
+    mode: u32, // 0 lightness, 1 BT.709, 2 BT.601, 3 average, 4 min, 5 max
+    _pad0: u32,
+    _pad1: u32,
+    _pad2: u32,
+    _pad3: u32,
+    _pad4: u32,
+    _pad5: u32,
+    _pad6: u32,
+};
+@group(0) @binding(1) var<uniform> params: Params;
+
+struct VsOut { @builtin(position) pos: vec4f };
+
+@vertex
+fn vs_main(@builtin(vertex_index) idx: u32) -> VsOut {
+    // Fullscreen triangle.
+    let uv = vec2f(f32((idx << 1u) & 2u), f32(idx & 2u));
+    var out: VsOut;
+    out.pos = vec4f(uv * 2.0 - 1.0, 0.0, 1.0);
+    return out;
+}
+
+fn desaturate_gray(rgb: vec3f) -> f32 {
+    let lo = min(rgb.r, min(rgb.g, rgb.b));
+    let hi = max(rgb.r, max(rgb.g, rgb.b));
+    switch (params.mode) {
+        case 0u: { return (hi + lo) / 2.0; } // lightness
+        // The two luminosity modes use the standard BT.709 / BT.601 luma
+        // coefficients — the same constants as `lib/colorspace.wgsl` (HCY_R/G/B)
+        // and `composite.wgsl` (pd_lum); inlined rather than prepending the
+        // colorspace lib for two constants. Intentional sharing, not drift.
+        case 1u: { return dot(rgb, vec3f(0.2126, 0.7152, 0.0722)); } // BT.709
+        case 2u: { return dot(rgb, vec3f(0.299, 0.587, 0.114)); } // BT.601
+        case 3u: { return (rgb.r + rgb.g + rgb.b) / 3.0; } // average
+        case 4u: { return lo; } // min
+        default: { return hi; } // max
+    }
+}
+
+fn desaturate_transform(rgb: vec3f) -> vec3f {
+    return vec3f(desaturate_gray(rgb));
+}
+
+@fragment
+fn fs_desaturate(in: VsOut) -> @location(0) vec4f {
+    let p = vec2i(floor(in.pos.xy));
+    let c = textureLoad(t_src, p, 0);
+    return vec4f(desaturate_transform(c.rgb), c.a);
+}
+
+// Destructive selection-clipped variant: transform where the R8 mask is
+// selected (>0.5), pass the original through elsewhere (mirrors
+// `fs_invert_masked`).
+@group(0) @binding(2) var t_mask: texture_2d<f32>;
+
+@fragment
+fn fs_desaturate_masked(in: VsOut) -> @location(0) vec4f {
+    let p = vec2i(floor(in.pos.xy));
+    let orig = textureLoad(t_src, p, 0);
+    let filtered = vec4f(desaturate_transform(orig.rgb), orig.a);
+    let selected = textureLoad(t_mask, p, 0).r > 0.5;
+    return select(orig, filtered, selected);
+}

--- a/crates/darkly/src/gpu/filters/desaturate.rs
+++ b/crates/darkly/src/gpu/filters/desaturate.rs
@@ -1,0 +1,111 @@
+//! Desaturate filter — one-step RGB → gray conversion, modeled on Krita's
+//! desaturate adjustment
+//! (`plugins/color/colorspaceextensions/kis_desaturate_adjustment.cpp`), which
+//! follows Tanner Helland's grayscale algorithm survey
+//! (<https://www.tannerhelland.com/3643/grayscale-image-algorithm-vb6/>).
+//!
+//! Six modes over one shader, selected by a single enum param (Krita's order,
+//! default Lightness): lightness `(max+min)/2`, luminosity BT.709 / BT.601,
+//! average `(r+g+b)/3`, min, max. Distinct from Hue/Saturation, whose
+//! saturation −100 reaches only one gray mapping per color model.
+//!
+//! Like HSV this is the no-aux [`ParamFilter`] specialization
+//! (`[src, uniform]`) — the transform lives in
+//! [`desaturate.wgsl`](../../../shaders/filters/desaturate.wgsl); this module
+//! declares the param schema and packs the mode into the shader's uniform.
+
+use std::sync::Arc;
+
+use crate::gpu::effect::EffectCache;
+use crate::gpu::filter::{FilterEffect, FilterPipelineRegistration};
+use crate::gpu::param_filter::ParamFilter;
+use crate::gpu::params::{ParamDef, ParamValue};
+
+pub const PARAMS: &[ParamDef] = &[ParamDef::Enum {
+    name: "mode",
+    options: &[
+        "Lightness",
+        "Luminosity (BT.709)",
+        "Luminosity (BT.601)",
+        "Average",
+        "Min",
+        "Max",
+    ],
+    default: 0,
+}];
+
+/// Pack the mode enum into the shader's `Params` uniform layout (32 bytes):
+/// `[mode: u32, pad×7]`.
+fn pack_uniform(params: &[ParamValue]) -> [u32; 8] {
+    let mode = match params.first() {
+        Some(ParamValue::Int(m)) => (*m).max(0) as u32,
+        _ => 0,
+    };
+    [mode, 0, 0, 0, 0, 0, 0, 0]
+}
+
+/// Allocate (once) and refresh the params uniform — the [`ParamFilter`]
+/// `prepare` half for the no-aux desaturate filter.
+fn desaturate_prepare(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    params: &[ParamValue],
+    cache: &mut EffectCache,
+) {
+    if cache.uniform_bufs.is_empty() {
+        cache
+            .uniform_bufs
+            .push(device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("filter-desaturate-uniform"),
+                size: 32,
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            }));
+    }
+    queue.write_buffer(
+        &cache.uniform_bufs[0],
+        0,
+        bytemuck::cast_slice(&pack_uniform(params)),
+    );
+}
+
+fn create_pipeline(device: &wgpu::Device) -> Arc<dyn FilterEffect> {
+    Arc::new(ParamFilter::new(
+        device,
+        "filter-desaturate",
+        include_str!("../../../shaders/filters/desaturate.wgsl"),
+        "fs_desaturate",
+        "fs_desaturate_masked",
+        false, // no aux texture — packed uniform only
+        desaturate_prepare,
+    ))
+}
+
+pub fn register() -> FilterPipelineRegistration {
+    FilterPipelineRegistration {
+        type_id: "desaturate",
+        display_name: "Desaturate",
+        params: PARAMS,
+        create_pipeline,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Default params → mode 0 (Lightness, Krita's default).
+    #[test]
+    fn defaults_pack_to_lightness() {
+        let params: Vec<ParamValue> = PARAMS.iter().map(|d| d.default_value()).collect();
+        let u = pack_uniform(&params);
+        assert_eq!(u[0], 0, "default mode is Lightness");
+    }
+
+    /// An explicit mode passes straight through as u32.
+    #[test]
+    fn explicit_mode_passes_through() {
+        let u = pack_uniform(&[ParamValue::Int(5)]);
+        assert_eq!(u[0], 5, "mode Max");
+    }
+}

--- a/crates/darkly/src/gpu/filters/mod.rs
+++ b/crates/darkly/src/gpu/filters/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod brightness_contrast;
 pub mod curves;
+pub mod desaturate;
 pub mod hsv;
 pub mod invert;
 pub mod levels;
@@ -15,6 +16,7 @@ pub fn registrations() -> Vec<FilterPipelineRegistration> {
     vec![
         brightness_contrast::register(),
         curves::register(),
+        desaturate::register(),
         hsv::register(),
         invert::register(),
         levels::register(),

--- a/crates/darkly/tests/filters.rs
+++ b/crates/darkly/tests/filters.rs
@@ -905,6 +905,12 @@ fn destructive_brightness_contrast_with_selection_only_touches_selection() {
     assert_destructive_selection("brightness_contrast", bc_params(50.0, 0.0));
 }
 
+#[test]
+fn destructive_desaturate_with_selection_only_touches_selection() {
+    // Luminosity BT.709 — visibly grays the [200,100,50] fixture.
+    assert_destructive_selection("desaturate", vec![ParamValue::Int(1)]);
+}
+
 // ---- Live preview session (the non-dimming modal) --------------------------
 //
 // The modal previews a destructive filter non-destructively (`preview_filter`)
@@ -1206,6 +1212,38 @@ fn curves_lightness_curve_darkens_neutral() {
         "lightness on L* must keep the gray neutral, got {p:?}"
     );
     assert_eq!(p[3], 255, "alpha untouched by the lightness curve");
+}
+
+// ---- Desaturate GPU correctness ---------------------------------------------
+//
+// Pin the six gray mappings against Krita's desaturate adjustment
+// (`kis_desaturate_adjustment.cpp`): each mode produces a neutral gray
+// (R == G == B) at the value its formula predicts for the [200,100,50] fixture.
+
+#[test]
+fn desaturate_modes_produce_expected_grays() {
+    // (mode, expected gray) for opaque [200,100,50]: lightness (200+50)/2,
+    // BT.709 dot ≈ 117.7, BT.601 dot ≈ 124.2, average 350/3, min 50, max 200.
+    let expected: [(i32, u8); 6] = [(0, 125), (1, 118), (2, 124), (3, 117), (4, 50), (5, 200)];
+    for (mode, gray) in expected {
+        let (w, h) = (4u32, 4u32);
+        let mut e = test_engine(w, h);
+        let layer = e.paste_image(w, h, &solid_rgba(w, h, [200, 100, 50, 255]), 0, 0, None);
+        assert!(
+            e.apply_filter_typed(layer, "desaturate", vec![ParamValue::Int(mode)]),
+            "desaturate mode {mode} must apply"
+        );
+        let p = px(&e.test_readback_layer(layer), w, 1, 1);
+        assert!(
+            p[0] == p[1] && p[1] == p[2],
+            "mode {mode}: result must be neutral gray (R==G==B), got {p:?}"
+        );
+        assert!(
+            (p[0] as i32 - gray as i32).abs() <= 1,
+            "mode {mode}: expected gray ~{gray} (±1 unorm rounding), got {p:?}"
+        );
+        assert_eq!(p[3], 255, "mode {mode}: alpha untouched");
+    }
 }
 
 // ---- Brightness/Contrast GPU correctness ------------------------------------

--- a/docs/photoshop-default-hotkeys.md
+++ b/docs/photoshop-default-hotkeys.md
@@ -40,6 +40,7 @@ A comprehensive reference of the default keyboard shortcuts shipped with Adobe P
   - [Keys for Vanishing Point](#keys-for-vanishing-point)
   - [Keys for Extract and Pattern Maker (optional plug-ins)](#keys-for-extract-and-pattern-maker-optional-plug-ins)
 - **Camera Raw & Adjustments**
+  - [Keys for the Image ▸ Adjustments menu](#keys-for-the-image--adjustments-menu)
   - [Keys for the Camera Raw dialog box](#keys-for-the-camera-raw-dialog-box)
   - [Keys for the Black-and-White dialog box](#keys-for-the-black-and-white-dialog-box)
   - [Keys for Curves](#keys-for-curves)
@@ -510,6 +511,25 @@ A comprehensive reference of the default keyboard shortcuts shipped with Adobe P
 | Increase selection nudging when viewing the original | Shift + Right Arrow, Left Arrow, Up Arrow, or Down Arrow | Shift + Right Arrow, Left Arrow, Up Arrow, or Down Arrow |
 
 ## Camera Raw & Adjustments
+
+### Keys for the Image ▸ Adjustments menu
+
+The menu-command bindings themselves — absent from the HelpX page (whose tables cover dialogs and workspaces, not menus), recovered from [NYIM's Photoshop CS6 shortcut sheet](https://training-nyc.com/legacy/photoshop_cs6_all_keyboard_shortcuts_sheet.pdf); these bindings are unchanged in current Photoshop.
+
+| Result | Windows | macOS |
+| --- | --- | --- |
+| Levels | Ctrl + L | Command + L |
+| Curves | Ctrl + M | Command + M |
+| Hue/Saturation | Ctrl + U | Command + U |
+| Color Balance | Ctrl + B | Command + B |
+| Black & White | Alt + Shift + Ctrl + B | Option + Shift + Command + B |
+| Invert | Ctrl + I | Command + I |
+| Desaturate | Shift + Ctrl + U | Shift + Command + U |
+| Auto Tone | Shift + Ctrl + L | Shift + Command + L |
+| Auto Contrast | Alt + Shift + Ctrl + L | Option + Shift + Command + L |
+| Auto Color | Shift + Ctrl + B | Shift + Command + B |
+| Image Size | Alt + Ctrl + I | Option + Command + I |
+| Canvas Size | Alt + Ctrl + C | Option + Command + C |
 
 ### Keys for the Camera Raw dialog box
 

--- a/frontend/src/ui/Modal.svelte
+++ b/frontend/src/ui/Modal.svelte
@@ -154,6 +154,13 @@
         cursor: grab;
         touch-action: none;
         user-select: none;
+        /* Extend the hit area over the header's own padding so the whole
+         * title bar drags, not just the title text. The negative margins
+         * cancel the padding exactly, so layout is unchanged; the close
+         * button (to the right) stays outside the handle. */
+        margin: calc(-1 * var(--header-pad-y)) 0 calc(-1 * var(--header-pad-y))
+            calc(-1 * var(--header-pad-x));
+        padding: var(--header-pad-y) 0 var(--header-pad-y) var(--header-pad-x);
     }
     .drag-handle:active {
         cursor: grabbing;
@@ -164,10 +171,12 @@
     dialog.modal.size-lg { width: min(92vw, 960px); height: min(82vh, 720px); }
 
     header {
+        --header-pad-y: 14px;
+        --header-pad-x: 18px;
         display: flex;
         align-items: center;
         justify-content: space-between;
-        padding: 14px 18px;
+        padding: var(--header-pad-y) var(--header-pad-x);
         border-bottom: 1px solid var(--bg-hover);
         flex-shrink: 0;
     }

--- a/frontend/src/ui/brush_builder/PortWidget.svelte
+++ b/frontend/src/ui/brush_builder/PortWidget.svelte
@@ -346,9 +346,6 @@
     .port-right .port-dot {
         right: -5px;
     }
-    .port-dot.connected {
-        /* filled by inline style */
-    }
     .port-dot:hover {
         transform: translateY(-50%) scale(1.3);
     }

--- a/frontend/src/ui/layers/LayerFooter.svelte
+++ b/frontend/src/ui/layers/LayerFooter.svelte
@@ -252,10 +252,4 @@
     .split-main + .split-chevron {
         margin-left: 0;
     }
-
-    .mask-glyph {
-        width: 18px;
-        height: 11px;
-        display: block;
-    }
 </style>

--- a/frontend/src/ui/workspace/Subdivision.svelte
+++ b/frontend/src/ui/workspace/Subdivision.svelte
@@ -19,7 +19,7 @@
     // Axis is implicit from depth (Graphite's trick): even depth = row.
     let horizontal = $derived(depth % 2 === 0);
 
-    let containerEl: HTMLDivElement | undefined;
+    let containerEl: HTMLDivElement | undefined = $state();
     // Snapshot of the two adjacent slots' sizes captured at gutter-drag start,
     // so movement deltas apply against a stable baseline.
     let dragStartSizes: [number, number] | null = null;

--- a/frontend/src/ui/workspace/Workspace.svelte
+++ b/frontend/src/ui/workspace/Workspace.svelte
@@ -6,7 +6,7 @@
 
     let { workspaceId }: { workspaceId: number } = $props();
 
-    const isMain = workspaceId === 0;
+    let isMain = $derived(workspaceId === 0);
     let rootEl: HTMLDivElement | undefined;
 
     let ws = $derived(workspaces.getWorkspace(workspaceId));


### PR DESCRIPTION
<img width="822" height="579" alt="image" src="https://github.com/user-attachments/assets/ff8a3bd4-c730-4c1e-a92a-059f03d39066" />

---

Adds the **Desaturate** filter — the last unshipped entry in the README's filter-layer roadmap. Desaturate is a one-step RGB → gray conversion whose only parameter is which formula maps color to gray, matching Krita's six modes (`kis_desaturate_adjustment.cpp`, per Tanner Helland's grayscale algorithm survey): **Lightness** `(max+min)/2` (default), **Luminosity BT.709**, **Luminosity BT.601**, **Average**, **Min**, **Max**. Alpha passes through.

The filter system is fully registry-driven, so the whole feature lands with **zero frontend code changes**: the Svelte UI picks up the new registration for the destructive Colors-menu action (`filterDesaturate`, opens the params modal with live preview), the filter-layer picker, the enum-dropdown params editor, and undo.

### Engine
- `shaders/filters/desaturate.wgsl` — new fragment shader with the six formulas selected by a uniform `mode: u32`; `fs_desaturate` plus a selection-clipped `fs_desaturate_masked` (R8 mask, `select(orig, filtered, mask > 0.5)`). The BT.709/BT.601 luma coefficients are inlined with a comment marking them as the same standard constants used by `lib/colorspace.wgsl` (`HCY_*`) and `composite.wgsl` (`pd_lum`) — intentional sharing, not drift.
- `src/gpu/filters/desaturate.rs` — new registration: single `Enum` param `mode` (Krita's order, default Lightness), 32-byte uniform packing, no-aux `ParamFilter` specialization (`[src, uniform]`, same shape as HSV/Brightness-Contrast). `gpu/filters/mod.rs` regenerated by `build.rs`.

### Hotkeys
- Krita and Photoshop presets both bind `filterDesaturate: $mod+Shift+KeyU` — Krita's default (`Ctrl+Shift+U` → `krita_filter_desaturate`) and Photoshop's (Shift+Ctrl+U → Image ▸ Adjustments ▸ Desaturate) agree; GIMP has no default Desaturate shortcut, so its preset gets none.
- `docs/photoshop-default-hotkeys.md` gains the previously missing "Keys for the Image ▸ Adjustments menu" table (the HelpX source only covers dialogs/workspaces), sourced from NYIM's CS6 shortcut sheet, including the Desaturate row.

### Tests
- Uniform-packing unit tests (default → Lightness; explicit mode passes through).
- GPU integration tests in `tests/filters.rs`: destructive apply over a rect selection touches only the selection with undo restoring the layer, and a mode-correctness test pinning all six formulas on a solid `[200,100,50]` fixture (expected grays 125 / 118 / 124 / 117 / 50 / 200, ±1 unorm rounding, R==G==B, alpha untouched).

### Docs
- README roadmap: `- [x] Desaturate`.

All commit-time gates pass (fmt, clippy native + wasm, full workspace test suite single-threaded, wasm-pack, Vitest incl. the preset-id scan, vite build). `tsc`/`svelte-check` carry one pre-existing failure in `dialogFocusRing.test.ts` (`node:fs` types) that predates this branch.