### PR TITLE
Node comments

### DIFF
--- a/crates/darkly/src/brush/portable.rs
+++ b/crates/darkly/src/brush/portable.rs
@@ -82,6 +82,10 @@ pub struct PortableBrush {
 pub struct PortableNode {
     #[serde(rename = "type")]
     pub type_id: String,
+    /// Free-form author annotation on this node. Empty is elided so
+    /// un-annotated nodes stay a bare `type`/`inputs` entry.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub comment: String,
     /// Input values that differ from the node registration's defaults, keyed
     /// by input name. One unified map — every input kind (scalar default,
     /// enum index, texture name, curve points, …) rides the same
@@ -208,6 +212,7 @@ impl PortableBrush {
                 id.0.clone(),
                 PortableNode {
                     type_id: node.type_id.clone(),
+                    comment: node.comment.clone(),
                     inputs,
                 },
             );
@@ -306,6 +311,11 @@ impl PortableBrush {
             }
 
             let new_id = graph.add_node(pn.type_id.clone(), ports);
+            if !pn.comment.is_empty() {
+                graph
+                    .set_node_comment(&new_id, pn.comment.clone())
+                    .expect("node just added by add_node must exist");
+            }
             id_map.insert(yaml_id.clone(), new_id);
         }
 
@@ -627,6 +637,48 @@ nodes: {}
             serde_yaml_ng::to_string(&PortableBrush::from_graph_only(&restored, registry).unwrap())
                 .unwrap();
         assert_eq!(yaml, reyaml);
+    }
+
+    /// A node comment survives the full YAML round trip (including multi-line
+    /// text, which YAML emits as a block scalar), is emitted only for the
+    /// node that has one, and re-lands on the correct id after same-kind
+    /// normalization.
+    #[test]
+    fn node_comment_round_trips() {
+        let registry = registry();
+        let mut graph = Graph::<BrushWireType>::new();
+        let a = graph.add_node("random", registry.get("random").unwrap().ports.clone());
+        let _b = graph.add_node("random", registry.get("random").unwrap().ports.clone());
+        graph
+            .set_node_comment(&a, "roughness source\nkeep frequency low".into())
+            .unwrap();
+
+        let yaml =
+            serde_yaml_ng::to_string(&PortableBrush::from_graph_only(&graph, registry).unwrap())
+                .unwrap();
+        // Only the annotated node emits `comment:`.
+        assert_eq!(yaml.matches("comment:").count(), 1);
+
+        let restored = serde_yaml_ng::from_str::<PortableBrush>(&yaml)
+            .unwrap()
+            .into_graph(registry)
+            .unwrap();
+        assert_eq!(
+            restored
+                .nodes()
+                .get(&NodeId("random".into()))
+                .unwrap()
+                .comment,
+            "roughness source\nkeep frequency low"
+        );
+        assert_eq!(
+            restored
+                .nodes()
+                .get(&NodeId("random_2".into()))
+                .unwrap()
+                .comment,
+            ""
+        );
     }
 
     /// A hand-authored file whose same-kind keys don't follow the `_N`

--- a/crates/darkly/src/engine/brush_graph.rs
+++ b/crates/darkly/src/engine/brush_graph.rs
@@ -1106,6 +1106,27 @@ impl DarklyEngine {
         Ok(self.active_graph_json())
     }
 
+    /// Set (or clear, with an empty string) a node's author comment.
+    /// Deliberately bumps no version: a comment is inert w.r.t. render
+    /// output and preset identity, so it must not clear the active preset
+    /// name or invalidate the dab-thumbnail cache. `applyResult` refreshes
+    /// the frontend graph from the returned JSON regardless.
+    #[handler(returns = graph)]
+    pub fn brush_graph_set_node_comment(
+        &mut self,
+        node_id: &str,
+        comment: String,
+    ) -> Result<String, String> {
+        self.tool_session
+            .write()
+            .get_mut::<BrushState>()
+            .expect(NO_BRUSH_STATE)
+            .graph
+            .set_node_comment(&NodeId(node_id.to_string()), comment)
+            .map_err(|e| format!("{e}"))?;
+        Ok(self.active_graph_json())
+    }
+
     /// Remove a brush-bar entry. Idempotent (missing entries aren't an
     /// error). Bumps the topology version so the frontend clears the
     /// active preset name.

--- a/crates/darkly/src/nodegraph/graph.rs
+++ b/crates/darkly/src/nodegraph/graph.rs
@@ -501,6 +501,12 @@ pub struct NodeInstance<W: WireKind> {
     /// node's single, unified input/output list — the per-instance authored
     /// value of every input lives on its [`PortDef::value`].
     pub ports: Vec<PortDef<W>>,
+    /// Free-form author annotation on this node instance. Empty means none.
+    /// Inert w.r.t. compilation and render output; carried purely so a brush
+    /// author can leave explanatory notes on a node. Serializable graph state
+    /// (survives save/load through both the portable YAML and the bundle).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub comment: String,
 }
 
 // ── Errors ───────────────────────────────────────────────────────────
@@ -712,6 +718,7 @@ impl<W: WireKind> Graph<W> {
                 id: id.clone(),
                 type_id,
                 ports,
+                comment: String::new(),
             },
         );
         id
@@ -978,6 +985,16 @@ impl<W: WireKind> Graph<W> {
                 port: port_name.to_string(),
             })?;
         port.value = value;
+        Ok(())
+    }
+
+    /// Set (or clear, with an empty string) a node's author comment.
+    pub fn set_node_comment(&mut self, id: &NodeId, comment: String) -> Result<(), GraphError> {
+        let node = self
+            .nodes
+            .get_mut(id)
+            .ok_or_else(|| GraphError::NodeNotFound(id.clone()))?;
+        node.comment = comment;
         Ok(())
     }
 
@@ -1400,6 +1417,45 @@ mod tests {
         let g2: Graph<TestWireKind> = serde_json::from_str(&json).unwrap();
         assert_eq!(g2.nodes.len(), 2);
         assert_eq!(g2.connections.len(), 1);
+    }
+
+    #[test]
+    fn set_node_comment_sets_and_clears() {
+        let mut g = Graph::<TestWireKind>::new();
+        let a = g.add_node("source", vec![scalar_out("out")]);
+        assert_eq!(g.nodes[&a].comment, "");
+
+        g.set_node_comment(&a, "explanatory wisdom".into()).unwrap();
+        assert_eq!(g.nodes[&a].comment, "explanatory wisdom");
+
+        g.set_node_comment(&a, String::new()).unwrap();
+        assert_eq!(g.nodes[&a].comment, "");
+    }
+
+    #[test]
+    fn set_node_comment_unknown_node_errors() {
+        let mut g = Graph::<TestWireKind>::new();
+        let err = g
+            .set_node_comment(&NodeId("ghost".into()), "hi".into())
+            .unwrap_err();
+        assert_eq!(err, GraphError::NodeNotFound(NodeId("ghost".into())));
+    }
+
+    /// A comment is inert but must survive the raw-`Graph` serde that backs
+    /// the `.darkly-brush` bundle. Empty comments are elided from the JSON.
+    #[test]
+    fn comment_survives_serde_and_elides_when_empty() {
+        let mut g = Graph::<TestWireKind>::new();
+        let a = g.add_node("source", vec![scalar_out("out")]);
+        let b = g.add_node("sink", vec![scalar_in("in")]);
+        g.set_node_comment(&a, "keep me".into()).unwrap();
+
+        let json = serde_json::to_string(&g).unwrap();
+        assert_eq!(json.matches("\"comment\"").count(), 1);
+
+        let g2: Graph<TestWireKind> = serde_json::from_str(&json).unwrap();
+        assert_eq!(g2.nodes[&a].comment, "keep me");
+        assert_eq!(g2.nodes[&b].comment, "");
     }
 
     // ── UnitType tests ──────────────────────────────────────────────

--- a/crates/darkly/tests/brush_picker_backend.rs
+++ b/crates/darkly/tests/brush_picker_backend.rs
@@ -354,6 +354,38 @@ fn size_scrub_does_not_change_active_dab_pixels() {
     );
 }
 
+#[test]
+fn set_node_comment_does_not_advance_topology_version() {
+    // A node comment is inert w.r.t. render output and preset identity, so
+    // setting one must NOT advance `brush_topology_version` — otherwise the
+    // brush bar would flip the active preset name to "Custom" the moment a
+    // user annotated a node. The comment must still land on the graph.
+    let mut engine = fresh_engine();
+
+    let target = engine
+        .brush_exposed_ports()
+        .into_iter()
+        .next()
+        .expect("default brush exposes at least one port");
+
+    let topo_before = engine.brush_topology_version();
+    engine
+        .brush_graph_set_node_comment(&target.node_id, "words of explanatory wisdom".to_string())
+        .expect("set comment");
+    assert_eq!(
+        engine.brush_topology_version(),
+        topo_before,
+        "setting a node comment must not advance the topology version"
+    );
+
+    let graph = engine.active_brush_graph();
+    let node = graph
+        .nodes()
+        .get(&darkly::nodegraph::NodeId(target.node_id.clone()))
+        .expect("target node exists in the active graph");
+    assert_eq!(node.comment, "words of explanatory wisdom");
+}
+
 /// The active-brush capabilities drive two frontend behaviours: the
 /// erase toggle in the brush-tool options bar (`supports_erase`) and
 /// the live preview strips' iconify fallback (`preview_fallback_icon`,

--- a/frontend/src/engine/protocol_gen.ts
+++ b/frontend/src/engine/protocol_gen.ts
@@ -153,6 +153,8 @@ export type BrushGraphSetExposedPortMetaReq = { key: string, label: string, desc
 
 export type BrushGraphSetInputReq = { node_id: string, input_name: string, kind: string, value: JsonValue, };
 
+export type BrushGraphSetNodeCommentReq = { node_id: string, comment: string, };
+
 export type BrushGraphUnexposePortReq = { node_id: string, port_name: string, };
 
 export type BrushInfo = { name: string, category: string, author: string, description: string, tags: Array<string>, 
@@ -168,11 +170,11 @@ export type BrushLoadReq = { name: string, };
 
 export type BrushNodePreviewReq = { node_id: string, };
 
+export type BrushWireType = "Scalar" | "Int" | "Bool" | "Vec2" | "Vec4" | "Enum" | "String" | "Curve";
+
 export type InputValue = boolean | number | number | string | Array<[number, number]> | [number, number] | [number, number, number, number];
 
 export type PortDir = "Input" | "Output";
-
-export type BrushWireType = "Scalar" | "Int" | "Bool" | "Vec2" | "Vec4" | "Enum" | "String" | "Curve";
 
 export type PortDef = { name: string, dir: PortDir, wire_type: BrushWireType, 
 /**
@@ -499,6 +501,17 @@ export type LayerKindTypeInfo = { type: string, displayName: string, };
 
 export type LayerTransformCapabilityReq = { id: number, };
 
+export type ModifierInfo = { id: number, kind: string, name: string, visible: boolean, locked: boolean, 
+/**
+ * Whether this modifier participates in transforms with its host.
+ */
+linkedToHost: boolean, 
+/**
+ * See [`LayerInfo::Raster::editable`] — a modifier is editable when
+ * neither it nor its host (nor any ancestor of the host) is locked.
+ */
+editable: boolean, };
+
 export type LayerInfo = { "type": "raster", id: number, name: string, visible: boolean, locked: boolean, 
 /**
  * Effective editability — `false` when this node *or any ancestor*
@@ -550,17 +563,6 @@ pipeline: string,
  * uses.
  */
 params: Array<ParamInfo>, } | { "type": "vector", id: number, name: string, visible: boolean, locked: boolean, editable: boolean, canHaveMask: boolean, canRename: boolean, hasThumbnail: boolean, icon: string, kindName: string, opacity: number, blendMode: string, modifiers: Array<ModifierInfo>, } | { "type": "group", id: number, name: string, visible: boolean, locked: boolean, editable: boolean, canHaveMask: boolean, canRename: boolean, hasThumbnail: boolean, icon: string, kindName: string, collapsed: boolean, passthrough: boolean, opacity: number, blendMode: string, modifiers: Array<ModifierInfo>, children: Array<LayerInfo>, };
-
-export type ModifierInfo = { id: number, kind: string, name: string, visible: boolean, locked: boolean, 
-/**
- * Whether this modifier participates in transforms with its host.
- */
-linkedToHost: boolean, 
-/**
- * See [`LayerInfo::Raster::editable`] — a modifier is editable when
- * neither it nor its host (nor any ancestor of the host) is locked.
- */
-editable: boolean, };
 
 export type MaskToSelectionReq = { id: number, };
 
@@ -783,6 +785,7 @@ export type RequestKind =
     | 'brush_graph_reset'
     | 'brush_graph_set_exposed_port_meta'
     | 'brush_graph_set_input'
+    | 'brush_graph_set_node_comment'
     | 'brush_graph_unexpose_port'
     | 'brush_graph_validate'
     | 'brush_import'
@@ -975,6 +978,7 @@ export const REQUEST_KINDS: readonly RequestKind[] = [
     'brush_graph_reset',
     'brush_graph_set_exposed_port_meta',
     'brush_graph_set_input',
+    'brush_graph_set_node_comment',
     'brush_graph_unexpose_port',
     'brush_graph_validate',
     'brush_import',
@@ -1175,6 +1179,7 @@ export interface EngineApi {
     brushGraphReset(): void;
     brushGraphSetExposedPortMeta(req: BrushGraphSetExposedPortMetaReq): Promise<{ graph: JsonValue } | { error: string }>;
     brushGraphSetInput(req: BrushGraphSetInputReq): Promise<{ graph: JsonValue } | { error: string }>;
+    brushGraphSetNodeComment(req: BrushGraphSetNodeCommentReq): Promise<{ graph: JsonValue } | { error: string }>;
     brushGraphUnexposePort(req: BrushGraphUnexposePortReq): Promise<{ graph: JsonValue } | { error: string }>;
     brushGraphValidate(req: BrushGraphJsonReq): Promise<null | { error: string }>;
     brushImport(bytes: Uint8Array): Promise<string>;
@@ -1369,6 +1374,7 @@ export function makeApi(t: Transport): EngineApi {
         brushGraphReset: () => t.postFF('brush_graph_reset'),
         brushGraphSetExposedPortMeta: (req) => t.request('brush_graph_set_exposed_port_meta', req),
         brushGraphSetInput: (req) => t.request('brush_graph_set_input', req),
+        brushGraphSetNodeComment: (req) => t.request('brush_graph_set_node_comment', req),
         brushGraphUnexposePort: (req) => t.request('brush_graph_unexpose_port', req),
         brushGraphValidate: (req) => t.request('brush_graph_validate', req),
         brushImport: (bytes) => t.request('brush_import', {}, bytes),

--- a/frontend/src/state/__tests__/brush_graph_comment.test.ts
+++ b/frontend/src/state/__tests__/brush_graph_comment.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Per-node author comments are ordinary graph state. `setNodeCommentLocal` is
+// the pure, engine-free local-feedback path the node editor calls while the
+// user types; the engine commit is exercised end-to-end by the Rust
+// round-trip test. These class-level tests need no DOM and no real engine.
+
+vi.mock('../app.svelte', () => ({ app: { engine: null } }));
+
+import { BrushGraphState, type BrushGraph, type NodeInstance } from '../brush_graph.svelte';
+
+function node(id: string): NodeInstance {
+    return { id, type_id: 'test', ports: [] };
+}
+
+function graphWith(...ids: string[]): BrushGraph {
+    const nodes: Record<string, NodeInstance> = {};
+    for (const id of ids) nodes[id] = node(id);
+    return { nodes, connections: [] };
+}
+
+let state: BrushGraphState;
+beforeEach(() => {
+    state = new BrushGraphState();
+});
+
+describe('setNodeCommentLocal', () => {
+    it('updates the target node comment', () => {
+        state.graph = graphWith('shape', 'stamp');
+        state.setNodeCommentLocal('shape', 'words of wisdom');
+        expect(state.graph.nodes['shape'].comment).toBe('words of wisdom');
+        // Siblings are untouched.
+        expect(state.graph.nodes['stamp'].comment).toBeUndefined();
+    });
+
+    it('clears the comment with an empty string', () => {
+        state.graph = graphWith('shape');
+        state.setNodeCommentLocal('shape', 'note');
+        state.setNodeCommentLocal('shape', '');
+        expect(state.graph.nodes['shape'].comment).toBe('');
+    });
+
+    it('is a no-op for an unknown node or missing graph', () => {
+        expect(() => state.setNodeCommentLocal('ghost', 'x')).not.toThrow();
+        state.graph = graphWith('shape');
+        state.setNodeCommentLocal('ghost', 'x');
+        expect(state.graph.nodes['shape'].comment).toBeUndefined();
+    });
+});

--- a/frontend/src/state/brush_graph.svelte.ts
+++ b/frontend/src/state/brush_graph.svelte.ts
@@ -67,6 +67,9 @@ export interface NodeInstance {
     id: string;
     type_id: string;
     ports: PortDef[];   // the node's single, unified input/output list
+    /** Free-form author annotation. Optional: Rust elides it when empty, so
+     *  the JSON snapshot omits it for un-annotated nodes. */
+    comment?: string;
 }
 
 export interface Connection {
@@ -600,6 +603,20 @@ export class BrushGraphState {
     async setInput(nodeId: string, inputName: string, kind: string, value: InputValue) {
         if (!app.engine) return;
         await this.applyResult(await app.engine.api.brushGraphSetInput({ node_id: nodeId, input_name: inputName, kind, value }));
+    }
+
+    /** Update a node's author comment locally (for responsive typing). */
+    setNodeCommentLocal(nodeId: string, comment: string) {
+        if (!this.graph) return;
+        const node = this.graph.nodes[nodeId];
+        if (node) node.comment = comment;
+    }
+
+    /** Commit a node's author comment via Rust. Bumps no version — a comment
+     *  is inert w.r.t. render output and preset identity. */
+    async setNodeComment(nodeId: string, comment: string) {
+        if (!app.engine) return;
+        await this.applyResult(await app.engine.api.brushGraphSetNodeComment({ node_id: nodeId, comment }));
     }
 
     /** Get a flat array of all node instances. */

--- a/frontend/src/ui/brush_builder/NodeWidget.svelte
+++ b/frontend/src/ui/brush_builder/NodeWidget.svelte
@@ -54,10 +54,42 @@
     let nodeEl: HTMLDivElement;
 
     /** Returns true if the event target is an interactive child that should
-     *  handle its own pointer events (port dots, sliders, buttons). */
+     *  handle its own pointer events (port dots, sliders, buttons, the
+     *  comment editor). */
     function isInteractiveTarget(e: PointerEvent): boolean {
         const t = e.target as HTMLElement;
-        return !!t.closest('.port-dot, .port-slider, .curve-editor, input, button, select');
+        return !!t.closest('.port-dot, .port-slider, .curve-editor, input, button, select, textarea');
+    }
+
+    // --- Author comment (inline note beneath the header) ---
+    let editingComment = $state(false);
+    let commentDraft = $state('');
+    let commentOriginal = '';
+
+    function startEditComment(e: MouseEvent) {
+        e.stopPropagation();
+        commentOriginal = node.comment ?? '';
+        commentDraft = commentOriginal;
+        editingComment = true;
+    }
+
+    /** Live local feedback while typing — no engine round-trip per keystroke. */
+    function onCommentInput() {
+        brushGraph.setNodeCommentLocal(node.id, commentDraft);
+    }
+
+    /** Commit on blur. Trims, reflects locally, and only hits the engine when
+     *  the value actually changed since editing began. */
+    function commitComment() {
+        editingComment = false;
+        const next = commentDraft.trim();
+        brushGraph.setNodeCommentLocal(node.id, next);
+        if (next !== commentOriginal) brushGraph.setNodeComment(node.id, next);
+    }
+
+    /** Focus the textarea as soon as it mounts (avoids the autofocus lint). */
+    function focusOnMount(el: HTMLTextAreaElement) {
+        el.focus();
     }
 
     function onNodeDown(e: PointerEvent) {
@@ -134,6 +166,23 @@
             <NodePreview nodeId={node.id} width={96} height={96} />
         {/if}
     </div>
+
+    {#if editingComment}
+        <textarea
+            class="node-comment-edit"
+            bind:value={commentDraft}
+            oninput={onCommentInput}
+            onblur={commitComment}
+            use:focusOnMount
+            placeholder="Note…"
+            maxlength={500}
+            rows={2}
+        ></textarea>
+    {:else if node.comment}
+        <button class="node-comment" onclick={startEditComment} title="Edit note">{node.comment}</button>
+    {:else}
+        <button class="add-note-btn" onclick={startEditComment} title="Add a note">+ note</button>
+    {/if}
 </div>
 
 <style>
@@ -181,6 +230,61 @@
     .remove-btn:hover {
         color: var(--danger);
     }
+    /* Inline author note, pinned to the bottom of the card. A top separator
+       divides it from the ports above; it inherits the card's rounded
+       bottom corners. */
+    .node-comment,
+    .add-note-btn,
+    .node-comment-edit {
+        display: block;
+        box-sizing: border-box;
+        width: 100%;
+        font-size: 10px;
+        text-align: left;
+        border-top: 1px solid color-mix(in srgb, var(--text) 10%, transparent);
+        border-radius: 0 0 5px 5px;
+    }
+    .node-comment {
+        background: none;
+        border-left: none;
+        border-right: none;
+        border-bottom: none;
+        padding: 4px 6px;
+        color: color-mix(in srgb, var(--text) 70%, transparent);
+        font-style: italic;
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+        cursor: text;
+        line-height: 1.3;
+    }
+    .add-note-btn {
+        background: none;
+        border-left: none;
+        border-right: none;
+        border-bottom: none;
+        padding: 3px 6px;
+        color: color-mix(in srgb, var(--text) 35%, transparent);
+        cursor: pointer;
+        opacity: 0;
+        transition: opacity 0.1s;
+    }
+    .node-widget:hover .add-note-btn,
+    .node-widget.selected .add-note-btn {
+        opacity: 1;
+    }
+    .add-note-btn:hover {
+        color: var(--accent);
+    }
+    .node-comment-edit {
+        padding: 4px 6px;
+        background: var(--bg);
+        color: var(--text);
+        border: 1px solid var(--accent);
+        font-family: inherit;
+        line-height: 1.3;
+        resize: vertical;
+    }
+
     .node-body {
         padding: 4px 0;
     }

--- a/frontend/src/ui/brush_builder/PortWidget.svelte
+++ b/frontend/src/ui/brush_builder/PortWidget.svelte
@@ -27,15 +27,17 @@
     let color = $derived(WIRE_COLORS[port.wire_type] ?? '#888');
     let connected = $derived(brushGraph.isPortConnected(nodeId, port.name, port.dir));
 
-    /** The port label to display, or '' when it merely repeats the node's
-     *  title — redundant text the node header already conveys (e.g. the Curve
-     *  node's sole "Curve" input). Meaningful labels like "Pressure Curve"
-     *  survive. */
-    let labelText = $derived.by(() => {
-        const raw = regPort?.label || port.name;
+    let label = $derived(regPort?.label || port.name);
+
+    /** A block widget (curve) gets its own standalone header row. When that
+     *  lone label merely repeats the node's title it's pure redundancy — the
+     *  node header already says it — so we suppress it and drop the empty row.
+     *  Inline labels (sliders/enums) are NOT suppressed even when they match
+     *  the title: there they disambiguate one control among sibling ports. */
+    let blockLabelRedundant = $derived.by(() => {
         const node = brushGraph.graph?.nodes[nodeId];
         const title = node ? (brushGraph.getNodeType(node.type_id)?.display_name ?? node.type_id) : '';
-        return raw.toLowerCase() === title.toLowerCase() ? '' : raw;
+        return label.toLowerCase() === title.toLowerCase();
     });
 
     /** Numeric view of the input's value for the slider path (Scalar/Int/Bool).
@@ -399,12 +401,12 @@
                     class="port-slider-fill"
                     style="width: {sliderPercent}%; background: {color};"
                 ></div>
-                <span class="port-slider-label">{labelText}</span>
+                <span class="port-slider-label">{label}</span>
                 <span class="port-slider-value">{displayValue}</span>
             </div>
         {/if}
     {:else if showEnum}
-        {#if labelText}<span class="port-label">{labelText}</span>{/if}
+        <span class="port-label">{label}</span>
         <select
             class="port-select"
             value={Number(port.value)}
@@ -416,7 +418,7 @@
             {/each}
         </select>
     {:else if showString}
-        {#if labelText}<span class="port-label">{labelText}</span>{/if}
+        <span class="port-label">{label}</span>
         <input
             class="port-text-input"
             type="text"
@@ -431,9 +433,9 @@
              inside the fixed-height inline row the scalar widgets use. The row
              is dropped entirely when it would hold nothing (a redundant label
              and no expose toggle, as on the Curve node). -->
-        {#if labelText || canExpose}
+        {#if !blockLabelRedundant || canExpose}
             <div class="port-block-head">
-                {#if labelText}<span class="port-label">{labelText}</span>{/if}
+                {#if !blockLabelRedundant}<span class="port-label">{label}</span>{/if}
                 {#if canExpose}{@render exposeBtn()}{/if}
             </div>
         {/if}
@@ -443,7 +445,7 @@
             onchange={(pts) => brushGraph.setInput(nodeId, port.name, 'curve', JSON.stringify(pts))}
         />
     {:else}
-        {#if labelText}<span class="port-label">{labelText}</span>{/if}
+        <span class="port-label">{label}</span>
     {/if}
     {#if canExpose && !showCurve}{@render exposeBtn()}{/if}
     {#if showSourceHandle}

--- a/frontend/src/ui/brush_builder/PortWidget.svelte
+++ b/frontend/src/ui/brush_builder/PortWidget.svelte
@@ -27,6 +27,17 @@
     let color = $derived(WIRE_COLORS[port.wire_type] ?? '#888');
     let connected = $derived(brushGraph.isPortConnected(nodeId, port.name, port.dir));
 
+    /** The port label to display, or '' when it merely repeats the node's
+     *  title — redundant text the node header already conveys (e.g. the Curve
+     *  node's sole "Curve" input). Meaningful labels like "Pressure Curve"
+     *  survive. */
+    let labelText = $derived.by(() => {
+        const raw = regPort?.label || port.name;
+        const node = brushGraph.graph?.nodes[nodeId];
+        const title = node ? (brushGraph.getNodeType(node.type_id)?.display_name ?? node.type_id) : '';
+        return raw.toLowerCase() === title.toLowerCase() ? '' : raw;
+    });
+
     /** Numeric view of the input's value for the slider path (Scalar/Int/Bool).
      *  A bool value may arrive as a real boolean or a number. */
     let numValue = $derived(
@@ -388,12 +399,12 @@
                     class="port-slider-fill"
                     style="width: {sliderPercent}%; background: {color};"
                 ></div>
-                <span class="port-slider-label">{regPort?.label || port.name}</span>
+                <span class="port-slider-label">{labelText}</span>
                 <span class="port-slider-value">{displayValue}</span>
             </div>
         {/if}
     {:else if showEnum}
-        <span class="port-label">{regPort?.label || port.name}</span>
+        {#if labelText}<span class="port-label">{labelText}</span>{/if}
         <select
             class="port-select"
             value={Number(port.value)}
@@ -405,7 +416,7 @@
             {/each}
         </select>
     {:else if showString}
-        <span class="port-label">{regPort?.label || port.name}</span>
+        {#if labelText}<span class="port-label">{labelText}</span>{/if}
         <input
             class="port-text-input"
             type="text"
@@ -417,18 +428,22 @@
     {:else if showCurve}
         <!-- A curve is a full-height block widget, so it gets its own header
              row (label + expose) with the editor stacked below — it can't sit
-             inside the fixed-height inline row the scalar widgets use. -->
-        <div class="port-block-head">
-            <span class="port-label">{regPort?.label || port.name}</span>
-            {#if canExpose}{@render exposeBtn()}{/if}
-        </div>
+             inside the fixed-height inline row the scalar widgets use. The row
+             is dropped entirely when it would hold nothing (a redundant label
+             and no expose toggle, as on the Curve node). -->
+        {#if labelText || canExpose}
+            <div class="port-block-head">
+                {#if labelText}<span class="port-label">{labelText}</span>{/if}
+                {#if canExpose}{@render exposeBtn()}{/if}
+            </div>
+        {/if}
         <CurveEditor
             points={port.value as Array<[number, number]>}
             oninput={(pts) => brushGraph.setInputLocal(nodeId, port.name, pts)}
             onchange={(pts) => brushGraph.setInput(nodeId, port.name, 'curve', JSON.stringify(pts))}
         />
     {:else}
-        <span class="port-label">{regPort?.label || port.name}</span>
+        {#if labelText}<span class="port-label">{labelText}</span>{/if}
     {/if}
     {#if canExpose && !showCurve}{@render exposeBtn()}{/if}
     {#if showSourceHandle}


### PR DESCRIPTION
<img width="291" height="414" alt="image" src="https://github.com/user-attachments/assets/40894483-42f0-4bc5-ba73-1bf2b48ecfc9" />

---

## Per-node comments for brush graphs

Adds an optional free-form **comment** to any node in a brush graph — a note a brush author can attach to a node to explain what it does. Comments persist in the portable YAML and the `.darkly-brush` bundle, round-trip cleanly through save/load, and are edited inline in the brush builder.

### Model
- `NodeInstance` gains `comment: String` (serde-elided when empty), with a `Graph::set_node_comment` mutator. The comment lives **on the node** rather than in a graph-level side map (contrast `ExposedPortMeta`, which is graph-level only because the brush bar is a single ordered display surface). This makes it serialize for free through both the YAML and the raw-`Graph` bundle path, and makes desync structurally impossible.
- `PortableNode` gains a matching optional `comment` key, exported in `from_graph_only` and re-applied to the freshly-assigned `NodeId` on import (so it survives same-kind id normalization).

### Engine
- New `brush_graph_set_node_comment` handler. It deliberately bumps **no** version counter: a comment is inert w.r.t. render output and preset identity, so — unlike port exposure — it must not invalidate the dab-thumbnail cache or clear the active preset name.

### Frontend
- `NodeInstance` gains optional `comment?: string` (matching Rust's empty-elision) plus `setNodeCommentLocal` (live typing feedback) and `setNodeComment` (engine commit).
- `NodeWidget` renders the note inline beneath the header: existing notes show as muted italic text; empty nodes show a hover-revealed "+ note" affordance; clicking opens an inline textarea that commits on blur. The textarea is added to the node's pointer drag-guard.

### Tests
- Rust: graph set/clear + unknown-node error; raw-`Graph` serde survival + empty elision; full portable YAML round-trip including a multi-line comment (block scalar); an engine contract test asserting a comment does not advance `brush_topology_version`.
- Frontend: Vitest coverage for `setNodeCommentLocal` (set, clear, no-op on unknown node / missing graph).

No migration: pre-release, the format break is made directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
